### PR TITLE
fix(auth): requerir rol admin en rutas de agentes, rearme y gestión de routers

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.4.0",
+  "version": "2.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src/components/routers/AgentRearmButton.tsx
+++ b/app/src/components/routers/AgentRearmButton.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Loader2 } from 'lucide-react'
 import { useNetPulse } from '@/data/DataProvider'
+import { useAuth } from '@/data/AuthContext'
 import type { AgentInfo } from '@/data/types'
 import { cn } from '@/lib/utils'
 
@@ -13,9 +14,10 @@ interface AgentRearmButtonProps {
 type RearmState = 'idle' | 'busy' | 'ok' | 'pending' | 'fail'
 
 /**
- * Botón «Rearmar» (Fase 6.1, Plan B): solo aparece con un agente registrado
- * y NO fresh (caído). Reinicia el servicio procd en el router vía
- * POST /api/agents/{slug}/rearm y refleja el resultado real:
+ * Botón «Rearmar» (Fase 6.1, Plan B): solo aparece con un agente registrado,
+ * NO fresh (caído) y sesión con rol admin (la API exige admin en el rearme;
+ * auditoría v2.4.0 §2, issue #7). Reinicia el servicio procd en el router
+ * vía POST /api/agents/{slug}/rearm y refleja el resultado real:
  *   ok      → el agente volvió a empujar (recuperado)
  *   pending → reiniciado pero sin push en 30 s
  *   fail    → petición fallida (SSH, cooldown, sin servidor…)
@@ -24,9 +26,11 @@ type RearmState = 'idle' | 'busy' | 'ok' | 'pending' | 'fail'
 export function AgentRearmButton({ agent, className }: AgentRearmButtonProps) {
   const { t } = useTranslation()
   const { rearmAgent } = useNetPulse()
+  const auth = useAuth()
   const [state, setState] = useState<RearmState>('idle')
 
   if (!agent || agent.fresh) return null
+  if (auth?.role !== 'admin') return null
 
   const label =
     state === 'busy' ? t('routers.agent.rearming')

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -2076,8 +2076,9 @@ export default function Settings() {
           <PushNotificationsCard reduce={reduce} onSaved={notify} />
         </div>
 
-        {/* Gestión de routers — solo con backend (modo live) */}
-        {!isDemo && (
+        {/* Gestión de routers — solo admin y con backend (modo live); la API
+            exige rol admin en las mutaciones (auditoría v2.4.0 §2, #7) */}
+        {!isDemo && auth?.role === 'admin' && (
           <div className="lg:col-span-12">
             <RoutersManager reduce={reduce} onSaved={notify} />
           </div>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,8 +1,8 @@
 # NetPulse — Hoja de ruta
 
-> Actualizada: 2026-08-03 (v2.3.0: Fase 6.1 resiliencia del agente — watchdog
-> cron con heartbeat + rearme desde el servidor). Orden por dependencias: lo
-> bloqueante primero.
+> Actualizada: 2026-08-04 (v2.4.1: endurecimiento de permisos — rutas de
+> agentes/rearme/gestión de routers exigen rol admin; auditoría §2, issue #7).
+> Orden por dependencias: lo bloqueante primero.
 > Referencias: `docs/AUDITORIA-FASE65.md` (riesgos R1-R8),
 > `docs/AGENTE-OPENWRT.md` (diseño del agente), ARCHITECTURE.md.
 
@@ -64,6 +64,15 @@ Cierre de los dos huecos de supervisión detectados en la auditoría del piloto:
    token registrado y push previo (nunca un slug que no ha empujado jamás);
    alerta de fallo si tras el reinicio no vuelve a empujar. Lógica de rearme
    compartida con el endpoint manual (paquete `rearmer`).
+4. **Endurecimiento de permisos (v2.4.1):** las rutas que mutan la
+   monitorización (`POST/DELETE /api/agents`, `POST /api/agents/{slug}/rearm`,
+   `POST/DELETE /api/config/routers`) o exponen credenciales/escaneo
+   (`GET /api/config/sshkey`, `GET /api/config/discover`) pasan de
+   `RequireAuth` a `RequireAdmin`. Un usuario con rol `user` recibe 403.
+   Las lecturas equivalentes (`GET /api/agents`, `GET /api/config/routers`)
+   siguen tras `RequireAuth`. Frontend: `RoutersManager` y el botón «Rearmar»
+   se ocultan a usuarios no admin. Cierra el punto §2 de la auditoría
+   (issue #7); el resto de la auditoría vive en el issue #6.
 
 ## Fase 6 — incremento 2: el agente de verdad (~1 semana)
 

--- a/server-go/internal/httpapi/admin_gate_test.go
+++ b/server-go/internal/httpapi/admin_gate_test.go
@@ -1,0 +1,92 @@
+// admin_gate_test.go — auditoría v2.4.0 §2 (issue #7): las rutas que mutan
+// la monitorización (crear/revocar agentes, rearme SSH, añadir/borrar
+// routers) o exponen credenciales/escaneo (sshkey, discover) exigen rol
+// admin; un usuario con rol 'user' recibe 403, y las lecturas equivalentes
+// siguen disponibles para cualquier sesión.
+package httpapi_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// createUserAndLogin: alta un usuario con el rol dado vía API (como admin) y
+// devuelve su cookie de sesión.
+func createUserAndLogin(t *testing.T, base, adminCookie, username, password, role string) string {
+	t.Helper()
+	req, _ := http.NewRequest("POST", base+"/api/users",
+		strings.NewReader(`{"username":"`+username+`","password":"`+password+`","role":"`+role+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Cookie", "session="+adminCookie)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("alta %s: %v", username, err)
+	}
+	res.Body.Close()
+	if res.StatusCode != 201 {
+		t.Fatalf("alta %s: got %d want 201", username, res.StatusCode)
+	}
+	status, cookie, _ := loginCookie(t, base, username, password)
+	if status != 204 || cookie == "" {
+		t.Fatalf("login %s: got %d", username, status)
+	}
+	return cookie
+}
+
+// do: petición con cookie de sesión.
+func do(t *testing.T, method, base, path, cookie string) *http.Response {
+	t.Helper()
+	req, _ := http.NewRequest(method, base+path, strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Cookie", "session="+cookie)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	res.Body.Close()
+	return res
+}
+
+func TestRutasAdminDevuelven403ParaRolUser(t *testing.T) {
+	ts := makeTestServer(t)
+	_, adminCookie, _ := loginCookie(t, ts.URL, "admin", "test1234")
+	userCookie := createUserAndLogin(t, ts.URL, adminCookie, "viewer", "clave1234", "user")
+
+	adminOnly := []struct{ method, path string }{
+		{"POST", "/api/agents"},
+		{"DELETE", "/api/agents/rt2"},
+		{"POST", "/api/agents/rt2/rearm"},
+		{"POST", "/api/config/routers"},
+		{"DELETE", "/api/config/routers/rt2"},
+		{"GET", "/api/config/sshkey"},
+		{"GET", "/api/config/discover"},
+	}
+	for _, rt := range adminOnly {
+		if got := do(t, rt.method, ts.URL, rt.path, userCookie).StatusCode; got != 403 {
+			t.Errorf("%s %s como user: got %d want 403", rt.method, rt.path, got)
+		}
+	}
+
+	// Las lecturas equivalentes siguen abiertas a cualquier sesión.
+	readable := []string{"/api/agents", "/api/config/routers", "/api/overview"}
+	for _, p := range readable {
+		if got := do(t, "GET", ts.URL, p, userCookie).StatusCode; got != 200 {
+			t.Errorf("GET %s como user: got %d want 200", p, got)
+		}
+	}
+
+	// Y el admin sí pasa el gate (el 201 de POST /api/agents confirma que
+	// RequireAdmin deja llegar al handler; el slug no necesita router).
+	req, _ := http.NewRequest("POST", ts.URL+"/api/agents", strings.NewReader(`{"slug":"rt-gate"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Cookie", "session="+adminCookie)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/agents admin: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != 201 {
+		t.Errorf("POST /api/agents como admin: got %d want 201", res.StatusCode)
+	}
+}

--- a/server-go/internal/httpapi/config.go
+++ b/server-go/internal/httpapi/config.go
@@ -20,12 +20,15 @@ import (
 var hostRe = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
 // registerConfigRoutes registra las rutas /api/config/* en el mux.
+// Las mutaciones (añadir/borrar routers) y las que exponen credenciales o
+// escanean la red (sshkey, discover) exigen rol admin (auditoría v2.4.0 §2,
+// issue #7); la lista de routers es de lectura y queda tras RequireAuth.
 func (s *server) registerConfigRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /api/config/sshkey", s.handleGetSSHKey)
-	mux.HandleFunc("GET /api/config/discover", s.handleDiscover)
+	mux.Handle("GET /api/config/sshkey", auth.RequireAdmin(http.HandlerFunc(s.handleGetSSHKey)))
+	mux.Handle("GET /api/config/discover", auth.RequireAdmin(http.HandlerFunc(s.handleDiscover)))
 	mux.HandleFunc("GET /api/config/routers", s.handleListConfigRouters)
-	mux.HandleFunc("POST /api/config/routers", s.handleAddConfigRouter)
-	mux.HandleFunc("DELETE /api/config/routers/{id}", s.handleDeleteConfigRouter)
+	mux.Handle("POST /api/config/routers", auth.RequireAdmin(http.HandlerFunc(s.handleAddConfigRouter)))
+	mux.Handle("DELETE /api/config/routers/{id}", auth.RequireAdmin(http.HandlerFunc(s.handleDeleteConfigRouter)))
 	mux.Handle("GET /api/config/adguard", auth.RequireAdmin(http.HandlerFunc(s.handleGetAdguardConfig)))
 	mux.Handle("PUT /api/config/adguard", auth.RequireAdmin(http.HandlerFunc(s.handlePutAdguardConfig)))
 }

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Version es la versión del backend (app.js:18).
-const Version = "2.4.0"
+const Version = "2.4.1"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {
@@ -142,12 +142,15 @@ func NewHandler(d Deps) http.Handler {
 	// --- Agentes nativos (Fase 6) ---
 	// Ingesta: SIN sesión (auth Bearer propia; exenta en RequireAuth).
 	mux.HandleFunc("POST /api/ingest/agent", s.handleIngestAgent)
-	// Gestión de tokens: tras sesión como el resto del API.
-	mux.HandleFunc("POST /api/agents", s.handleAgentsCreate)
+	// Gestión de tokens: tras sesión como el resto del API; las mutaciones
+	// (crear/revocar/rearmar) exigen rol admin — ejecutan acciones sobre los
+	// routers o exponen credenciales (auditoría v2.4.0 §2, issue #7). La
+	// lista es de lectura y se deja tras RequireAuth.
+	mux.Handle("POST /api/agents", auth.RequireAdmin(http.HandlerFunc(s.handleAgentsCreate)))
 	mux.HandleFunc("GET /api/agents", s.handleAgentsList)
-	mux.HandleFunc("DELETE /api/agents/{slug}", s.handleAgentsDelete)
+	mux.Handle("DELETE /api/agents/{slug}", auth.RequireAdmin(http.HandlerFunc(s.handleAgentsDelete)))
 	// Fase 6.1 (Plan B): rearme del servicio procd del agente vía SSH.
-	mux.HandleFunc("POST /api/agents/{slug}/rearm", s.handleAgentRearm)
+	mux.Handle("POST /api/agents/{slug}/rearm", auth.RequireAdmin(http.HandlerFunc(s.handleAgentRearm)))
 
 	// --- Web Push (Fase 6 Bloque C; tras sesión como el resto del API) ---
 	mux.HandleFunc("GET /api/push/vapid-key", s.handlePushVapidKey)


### PR DESCRIPTION
Cierra el punto §2 (permisos demasiado amplios) de la auditoría de seguridad v2.4.0.

**Problema:** crear/revocar agentes, rearmar agentes vía SSH, añadir/borrar routers, ver la clave SSH pública y escanear la LAN solo exigían sesión (RequireAuth), no rol admin. Un usuario de rol `user` podía modificar la monitorización o ejecutar acciones sobre los routers.

**Fix:**
- Backend: `POST/DELETE /api/agents`, `POST /api/agents/{slug}/rearm`, `POST/DELETE /api/config/routers`, `GET /api/config/sshkey`, `GET /api/config/discover` → `RequireAdmin` (403 para rol user). Lecturas equivalentes siguen tras `RequireAuth`.
- Frontend: `RoutersManager` y botón «Rearmar» solo visibles para admin.
- Tests: `admin_gate_test.go` (403 user / 200 lecturas / 201 admin). Suite completa verde + vet + tsc.
- Bump v2.4.1 + nota en ROADMAP.

Fixes #7. Relacionado con #6 (issue paraguas de la auditoría).