### PR TITLE
fix(server-go): bump golang-jwt/jwt/v5 a v5.3.1 (CVE-2025-30204)

### DIFF
--- a/server-go/go.mod
+++ b/server-go/go.mod
@@ -16,7 +16,7 @@ replace github.com/gnacho/netpulse/agent => ../agent
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect

--- a/server-go/go.sum
+++ b/server-go/go.sum
@@ -2,8 +2,9 @@ github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
 github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=


### PR DESCRIPTION
Cierra la alerta dependabot #4 (HIGH, CVE-2025-30204): jwt-go permite asignación excesiva de memoria durante el parseo del header (strings.Split sin límite en ParseUnverified).

- Bump `github.com/golang-jwt/jwt/v5` v5.2.1 → v5.3.1 (dependencia indirecta vía webpush-go).
- Verificado local: `go vet` limpio, `go test ./...` 11/11 paquetes OK, build CGO_ENABLED=0 completo OK.

Las otras 3 alertas dependabot (react-router RSC, hono legacy x2) se han cerrado como not_used (no aplican a SPA sin RSC / backend Node archivado).

Closes #4