### PR TITLE
docs: SPEC Fase 9 on-box + reordenado de fases (Fase 8 = consolidación)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # NetPulse — Hoja de ruta
 
-> Actualizada: 2026-08-06 (v2.6.0, Fase 7 completada; Fase 10 = paquete LuCI). 
+> Actualizada: 2026-08-06 (v2.6.0, Fase 7 completada; Fase 10 = paquete LuCI; cola pre-Fase 8). 
 
 ## Estado actual (v2.6.0) ✅
 
@@ -318,6 +318,52 @@ ningún NOC multi-router; la webapp (Go + SSE) sigue siendo el visor de red.
   sin login adicional de la webapp.
 
 **Deploy**: paquete junto al agente en gateway y APs.
+
+---
+
+## Cola pre-Fase 8 — mejoras a atacar ANTES del paquete on-box (6-Ago-2026)
+
+Frente de trabajo anterior a la Fase 8 (el paquete del gateway no urge).
+Cada ítem es un PR independiente; ordenados por valor/esfuerzo.
+
+1. **Métricas operativas en `/api/health`** (barato, alto valor operativo):
+   - Añadir `agentsConnected`, `sseConnections`, `devicesTotal` al health.
+     Los datos ya existen (AgentRegistry, hub SSE, poller) — solo exponerlos.
+     Punto de mejora nº2 de la auditoría Fase 7.
+
+2. **Persistir el registry de agentes (R8)** (prerrequisito de pairing Fase 8):
+   - Hoy `AgentRegistry` es un `map` en RAM → `lastSeen`/payloads se pierden
+     al reiniciar el servidor. Deuda transversal ya anotada.
+   - Persistir último push por slug en SQLite (kv o tabla `agent_state`);
+     cargar al arrancar. Además: adoptar solo slugs conocidos (evitar huérfanos).
+
+3. **Integración del colector sidecar con server-go (propuesta 2)** (el gap
+   de histórico largo, deuda desde merge v2):
+   - **Frontera read-only**: `COLLECTOR_DB=/opt/netpulse-collector/data/metrics.db`;
+     server-go abre con `file:...?mode=ro` (1 escritor = el sidecar).
+   - El endpoint de histórico sirve corto plazo desde su tabla `metrics` (5s)
+     + largo plazo (días/meses) desde `buckets`/`daily` del sidecar (LTTB +
+     retención del skill sqlite-timeseries-daemon).
+   - **Ampliar el sidecar como historiador real**: además de latencia TCP,
+     disponibilidad (up/down) y contadores de tráfico por interfaz, todo en
+     la escalera raw→buckets→daily con NightlyJob. El server-go conserva la
+     instantánea SSE; el histórico largo se consume del sidecar.
+   - Bonus: del mismo árbol cae el **informe semanal de disponibilidad**
+     (deuda de la auditoría v2.1.0).
+   - Colateral: reinstalar el collector con release nueva (reporta `0.1.0`:
+     nunca se aplicó el fix goreleaser `-X main.Version`).
+
+4. **recharts v2 → v3** (deuda de mantenimiento):
+   - `app/package.json` usa `^2.15.4` (deprecated en npm). PR con verificación
+     visual de las gráficas (Playwright) — riesgo bajo pero a comprobar.
+
+5. **Limpieza de ramas** (trivial):
+   - `origin/feat/go-backend`, `origin/fix/issues-3-4-5` (y `fix/netpulse-jwt-cve`
+     si quedó tras el squash) — borrar las ya mergeadas.
+
+Quedan fuera de esta cola (a propósito): Web Push (requiere decisión de infra
+HTTPS en CT 226, no es micromejora), series del collector (cubierto por el
+punto 3) y paquete del gateway (Fase 8).
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -223,6 +223,10 @@ independiente; ordenados por valor/esfuerzo.
      sistemas externos envíen eventos a NetPulse sin agente (lista de
      orígenes permitida, anti-SSRF). Reutiliza el patrón HMAC de Fase 6
      (el único HMAC que existe hoy es el de la ingesta del agente).
+   - **⚠️ Skill para el entrante: NO existe** (verificado 6-Ago). `api-stack`
+     es solo Node (no aplica a backend Go); `email-webhook-notifications`
+     solo cubre saliente. Crear skill `api-ingest-go` (firma entrante +
+     orígenes + anti-SSRF) o ampliar la existente antes de implementar.
 
 Quedan fuera de esta fase (a propósito): Web Push (requiere decisión de infra
 HTTPS en CT 226, no es micromejora), series del collector (cubierto por el

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # NetPulse — Hoja de ruta
 
-> Actualizada: 2026-08-06 (v2.6.0, Fase 7 completada; Fase 10 = paquete LuCI; cola pre-Fase 8). 
+> Actualizada: 2026-08-06 (v2.6.0, Fase 7 completada; Fase 8 = consolidación de deudas; Fases 9-11 reordenadas). 
 
 ## Estado actual (v2.6.0) ✅
 
@@ -132,7 +132,7 @@ oficial de OpenWrt.
 
 3. **✅ 7.3 — Comunicación bidireccional SSE**: `GET /api/agents/{slug}/stream`
    + `POST /api/agents/{slug}/refresh`. Agente mantiene SSE abierta, recibe
-   comandos del servidor. Infraestructura lista para Fase 9 (escritura).
+   comandos del servidor. Infraestructura lista para Fase 10 (escritura).
    Verificado: `refresh → {"ok":true}` en gateway y APs.
 
 4. **✅ 7.4 — Empaquetado `.ipk`**: Makefile + procd init + UCI config +
@@ -162,7 +162,54 @@ oficial de OpenWrt.
 
 ---
 
-## Fase 8 — App embebida en routers (decisión de diseño primero)
+## Fase 8 — Consolidación de deudas y cierre de gaps (antes del on-box)
+
+Frente de trabajo previo al paquete del gateway (Fase 9). Cada ítem es un PR
+independiente; ordenados por valor/esfuerzo.
+
+1. **Métricas operativas en `/api/health`** (barato, alto valor operativo):
+   - Añadir `agentsConnected`, `sseConnections`, `devicesTotal` al health.
+     Los datos ya existen (AgentRegistry, hub SSE, poller) — solo exponerlos.
+     Punto de mejora nº2 de la auditoría Fase 7.
+
+2. **Persistir el registry de agentes (R8)** (prerrequisito de pairing de la
+   Fase 9):
+   - Hoy `AgentRegistry` es un `map` en RAM → `lastSeen`/payloads se pierden
+     al reiniciar el servidor. Deuda transversal ya anotada.
+   - Persistir último push por slug en SQLite (kv o tabla `agent_state`);
+     cargar al arrancar. Además: adoptar solo slugs conocidos (evitar huérfanos).
+
+3. **Integración del colector sidecar con server-go (propuesta 2)** (el gap
+   de histórico largo, deuda desde merge v2):
+   - **Frontera read-only**: `COLLECTOR_DB=/opt/netpulse-collector/data/metrics.db`;
+     server-go abre con `file:...?mode=ro` (1 escritor = el sidecar).
+   - El endpoint de histórico sirve corto plazo desde su tabla `metrics` (5s)
+     + largo plazo (días/meses) desde `buckets`/`daily` del sidecar (LTTB +
+     retención del skill sqlite-timeseries-daemon).
+   - **Ampliar el sidecar como historiador real**: además de latencia TCP,
+     disponibilidad (up/down) y contadores de tráfico por interfaz, todo en
+     la escalera raw→buckets→daily con NightlyJob. El server-go conserva la
+     instantánea SSE; el histórico largo se consume del sidecar.
+   - Bonus: del mismo árbol cae el **informe semanal de disponibilidad**
+     (deuda de la auditoría v2.1.0).
+   - Colateral: reinstalar el collector con release nueva (reporta `0.1.0`:
+     nunca se aplicó el fix goreleaser `-X main.Version`).
+
+4. **recharts v2 → v3** (deuda de mantenimiento):
+   - `app/package.json` usa `^2.15.4` (deprecated en npm). PR con verificación
+     visual de las gráficas (Playwright) — riesgo bajo pero a comprobar.
+
+5. **Limpieza de ramas** (trivial):
+   - `origin/feat/go-backend`, `origin/fix/issues-3-4-5` (y `fix/netpulse-jwt-cve`
+     si quedó tras el squash) — borrar las ya mergeadas.
+
+Quedan fuera de esta fase (a propósito): Web Push (requiere decisión de infra
+HTTPS en CT 226, no es micromejora) y series del collector (cubierto por el
+punto 3).
+
+---
+
+## Fase 9 — App embebida en routers (on-box; antes "Fase 8")
 
 Objetivo: NetPulse deja de ser un panel externo en un CT para convertirse en
 una app que vive en el propio router, alcanzable desde la IP del gateway sin
@@ -196,8 +243,8 @@ Contexto:
      LuCI o en un log accesible (`logread`).
    - El servidor on-box escanea/adopta agentes de la misma LAN con ese token.
    - No más `curl | sh` con token en argv.
-5. **`luci-app-netpulse`**: ver Fase 10 (paquete LuCI dedicado, se construye
-   después de la Fase 8; no reemplaza la PWA, permite diagnóstico local sin
+5. **`luci-app-netpulse`**: ver Fase 11 (paquete LuCI dedicado, se construye
+   después de la Fase 9; no reemplaza la PWA, permite diagnóstico local sin
    la app).
 6. **Presupuesto y roles**:
    - Gateway (Flint 2): server (~20 MB RSS) + agent.
@@ -210,19 +257,19 @@ Contexto:
   de datos (en USB/overlay).
 
 **Bloqueantes previos**: TLS resuelto en Fase 6 + agente bidireccional de
-Fase 7.
+Fase 7. Ver SPEC-FASE8.md (retos R1-R6 y criterios).
 
 **Deploy**: instalar server on-box en el gateway, agentes en APs.
 
 ---
 
-## Fase 9 — Escritura/orquestación (riesgo alto, reglas estrictas)
+## Fase 10 — Escritura/orquestación (riesgo alto, reglas estrictas; antes "Fase 9")
 
 Objetivo: pasar de leer la red a actuar sobre ella de forma declarativa,
 segura y reversible, con reglas que impidan quedarse sin wifi por un error.
 
 Contexto:
-- Hasta Fase 8 NetPulse es un panel de observación y alertas.
+- Hasta Fase 9 NetPulse es un panel de observación y alertas.
 - Cualquier cambio en routers (AdGuard, WireGuard, roaming) requiere LuCI/SSH.
 - Un error en un script puede dejar la red inaccesible.
 
@@ -284,7 +331,7 @@ Contexto:
 
 ---
 
-## Fase 10 — Paquete LuCI `luci-app-netpulse` (decisión de alcance 6-Ago-2026)
+## Fase 11 — Paquete LuCI `luci-app-netpulse` (antes "Fase 10")
 
 Objetivo: paquete `luci-app-netpulse` instalable junto al `.ipk`/`.apk` del
 agente. **NO repite la webapp**: verificado en los feeds oficiales
@@ -308,7 +355,7 @@ ningún NOC multi-router; la webapp (Go + SSE) sigue siendo el visor de red.
   en el agente (cero superficie/RAM).
 - Build vía SDK OpenWrt; empaquetar para opkg y apk (25.12). El `.apk` del
   agente sigue pendiente de construir (Fase 7).
-- Cobra pleno sentido tras la Fase 8 (server on-box en el gateway); para
+- Cobra pleno sentido tras la Fase 9 (server on-box en el gateway); para
   terceros con OpenWrt estándar, ya es útil sin ella.
 
 **Criterios de aceptación:**
@@ -318,52 +365,6 @@ ningún NOC multi-router; la webapp (Go + SSE) sigue siendo el visor de red.
   sin login adicional de la webapp.
 
 **Deploy**: paquete junto al agente en gateway y APs.
-
----
-
-## Cola pre-Fase 8 — mejoras a atacar ANTES del paquete on-box (6-Ago-2026)
-
-Frente de trabajo anterior a la Fase 8 (el paquete del gateway no urge).
-Cada ítem es un PR independiente; ordenados por valor/esfuerzo.
-
-1. **Métricas operativas en `/api/health`** (barato, alto valor operativo):
-   - Añadir `agentsConnected`, `sseConnections`, `devicesTotal` al health.
-     Los datos ya existen (AgentRegistry, hub SSE, poller) — solo exponerlos.
-     Punto de mejora nº2 de la auditoría Fase 7.
-
-2. **Persistir el registry de agentes (R8)** (prerrequisito de pairing Fase 8):
-   - Hoy `AgentRegistry` es un `map` en RAM → `lastSeen`/payloads se pierden
-     al reiniciar el servidor. Deuda transversal ya anotada.
-   - Persistir último push por slug en SQLite (kv o tabla `agent_state`);
-     cargar al arrancar. Además: adoptar solo slugs conocidos (evitar huérfanos).
-
-3. **Integración del colector sidecar con server-go (propuesta 2)** (el gap
-   de histórico largo, deuda desde merge v2):
-   - **Frontera read-only**: `COLLECTOR_DB=/opt/netpulse-collector/data/metrics.db`;
-     server-go abre con `file:...?mode=ro` (1 escritor = el sidecar).
-   - El endpoint de histórico sirve corto plazo desde su tabla `metrics` (5s)
-     + largo plazo (días/meses) desde `buckets`/`daily` del sidecar (LTTB +
-     retención del skill sqlite-timeseries-daemon).
-   - **Ampliar el sidecar como historiador real**: además de latencia TCP,
-     disponibilidad (up/down) y contadores de tráfico por interfaz, todo en
-     la escalera raw→buckets→daily con NightlyJob. El server-go conserva la
-     instantánea SSE; el histórico largo se consume del sidecar.
-   - Bonus: del mismo árbol cae el **informe semanal de disponibilidad**
-     (deuda de la auditoría v2.1.0).
-   - Colateral: reinstalar el collector con release nueva (reporta `0.1.0`:
-     nunca se aplicó el fix goreleaser `-X main.Version`).
-
-4. **recharts v2 → v3** (deuda de mantenimiento):
-   - `app/package.json` usa `^2.15.4` (deprecated en npm). PR con verificación
-     visual de las gráficas (Playwright) — riesgo bajo pero a comprobar.
-
-5. **Limpieza de ramas** (trivial):
-   - `origin/feat/go-backend`, `origin/fix/issues-3-4-5` (y `fix/netpulse-jwt-cve`
-     si quedó tras el squash) — borrar las ya mergeadas.
-
-Quedan fuera de esta cola (a propósito): Web Push (requiere decisión de infra
-HTTPS en CT 226, no es micromejora), series del collector (cubierto por el
-punto 3) y paquete del gateway (Fase 8).
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -203,9 +203,19 @@ independiente; ordenados por valor/esfuerzo.
    - `origin/feat/go-backend`, `origin/fix/issues-3-4-5` (y `fix/netpulse-jwt-cve`
      si quedó tras el squash) — borrar las ya mergeadas.
 
+6. **Auditoría de majors de frontend** (6-Ago-2026):
+   - Estado real verificado: React 19.2.8 ✅ al día; recharts 2.15.4→3.10.1
+     (2 majors detrás, deprecated — PR con verificación visual); Vite 7.3.6→8.2.0,
+     Tailwind 3.4→4.3.3, TypeScript 5.9→7.0.2, react-router 7.18.2→8.3.0.
+   - **Criterio**: subir un major solo si aporta valor al roadmap y se
+     revalida la app completa (Playwright). recharts 3 sí (deprecated);
+     Vite 8/TS 7 son muy recientes → no sin necesidad. **react-router v8:
+     NO subir** (no aporta nada, obligaría a revalidar toda la app y la línea
+     7.18.2 ya es la última estable de su rama).
+
 Quedan fuera de esta fase (a propósito): Web Push (requiere decisión de infra
-HTTPS en CT 226, no es micromejora) y series del collector (cubierto por el
-punto 3).
+HTTPS en CT 226, no es micromejora), series del collector (cubierto por el
+punto 3) y react-router v8 (decisión deliberada, ver punto 6).
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # NetPulse — Hoja de ruta
 
-> Actualizada: 2026-08-06 (v2.6.0, Fase 7 completada; Fase 8 = consolidación de deudas; Fases 9-11 reordenadas). 
+> Actualizada: 2026-08-06 (v2.6.0, Fase 7 completada; Fase 8 = consolidación de deudas; Fases 9-11 reordenadas; webhooks+API movidos a Fase 8). 
 
 ## Estado actual (v2.6.0) ✅
 
@@ -213,6 +213,17 @@ independiente; ordenados por valor/esfuerzo.
      NO subir** (no aporta nada, obligaría a revalidar toda la app y la línea
      7.18.2 ya es la última estable de su rama).
 
+7. **Webhooks y API de ingesta** (movido de Fase 10, 6-Ago-2026; verificada:
+   **no implementados en el código**, solo planificación del commit 4a4428e):
+   - **Webhook saliente**: notificaciones de alertas a URLs externas con firma
+     HMAC-SHA256, reintentos con backoff y DLQ — patrón EasyZFS v2.4.0.
+     Usar la skill `email-webhook-notifications` (ya aplicada en EasyZFS;
+     en NetPulse NO se ha usado). Complementa Web Push.
+   - **API de ingesta (webhook entrante)**: endpoint HTTP firmado para que
+     sistemas externos envíen eventos a NetPulse sin agente (lista de
+     orígenes permitida, anti-SSRF). Reutiliza el patrón HMAC de Fase 6
+     (el único HMAC que existe hoy es el de la ingesta del agente).
+
 Quedan fuera de esta fase (a propósito): Web Push (requiere decisión de infra
 HTTPS en CT 226, no es micromejora), series del collector (cubierto por el
 punto 3) y react-router v8 (decisión deliberada, ver punto 6).
@@ -321,14 +332,6 @@ Contexto:
    - Posibles futuros: VLAN simple, WiFi guest, QoS básico.
    - Cada despliegue es atómico: o se completa entero o se revierte.
    - La app deja de ser "solo lectura" para estos flujos asistidos.
-6. **Webhooks y API** (orden del usuario, 6-Ago-2026):
-   - **Webhook saliente**: notificaciones de alertas a URLs externas con firma
-     HMAC-SHA256, reintentos con backoff y DLQ — patrón EasyZFS v2.4.0
-     (skill `email-webhook-notifications`). Complementa Web Push para
-     encaminar alertas a servicios propios o de terceros.
-   - **API de ingesta (webhook entrante)**: endpoint HTTP firmado para que
-     sistemas externos envíen eventos a NetPulse sin agente (lista de
-     orígenes permitida, anti-SSRF). Reutiliza el patrón HMAC de Fase 6.
 
 **Criterios de aceptación:**
 - Cualquier apply muestra diff y pide confirmación antes de ejecutar.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -227,6 +227,13 @@ independiente; ordenados por valor/esfuerzo.
      es solo Node (no aplica a backend Go); `email-webhook-notifications`
      solo cubre saliente. Crear skill `api-ingest-go` (firma entrante +
      orígenes + anti-SSRF) o ampliar la existente antes de implementar.
+   - **Prácticas del curado `learn/skills_go_api_development.md` (6-Ago)**: de
+     ese catálogo solo aplica al entrante el **request ID** (UUID por request
+     en headers/logs; hoy no existe `x-request-id` en server-go). Ya cubiertos:
+     rate-limit por IP en ingesta (`ipRateLimit`, ventana 1 min), envelope de
+     error propio con i18n (no RFC 7807), samber golang-* instalados. El resto
+     del catálogo (pgx/sqlc/Redis, Gin/Echo/Fiber, gRPC/OTel) NO aplica:
+     stack SQLite + stdlib net/http.
 
 Quedan fuera de esta fase (a propósito): Web Push (requiere decisión de infra
 HTTPS en CT 226, no es micromejora), series del collector (cubierto por el

--- a/docs/SPEC-FASE8.md
+++ b/docs/SPEC-FASE8.md
@@ -1,0 +1,180 @@
+# SPEC — Fase 8: App on-box (servidor en el router gateway)
+
+> Estado: borrador de diseño (issue #17). Actualizada: 2026-08-06.
+> Objetivo: NetPulse corre en el propio router gateway, sin dependencia de
+> infraestructura externa (CT, servidor). Solo lectura; la escritura queda en
+> la Fase 9.
+
+## 0. Contexto verificado (no supuestos)
+
+- **Gateway real**: GL.iNet (firmware GL sobre OpenWrt 24.10), 1 GB RAM
+  (~344 MB libres), overlay 7.2 GB con ~6.9 GB libres. El server-go pesa
+  ~22 MB RSS; el agente ~12 MB. Presupuesto del nodo ≈ 35 MB de ~344 MB ✅.
+- **Binario del servidor**: `server-go` ya es un binario único con la app
+  embebida (`go:embed` del dist), config por `.env` (fail-fast) y sondeo SSH
+  por pool. Goreleaser ya emite amd64/arm64/armv7 → el build on-box no
+  requiere cross-compile nuevo, solo un target de empaquetado OpenWrt.
+- **Agente**: ya empaquetado como `.ipk` (opkg, gateway) y manual en los APs
+  (apk 25.12 pendiente). Lleva UCI config (`/etc/config/netpulse-agent`),
+  procd init y watchdog. Su cliente TLS usa `NETPULSE_INSECURE_TLS=1` →
+  `InsecureSkipVerify` (R5 del auditoría, pendiente de retirar).
+- **Nada on-box existe hoy en server-go** (grep `onbox|procd|uci` no
+  encuentra código de servidor).
+
+## 1. Retos de diseño (los que el ROADMAP no decide)
+
+### R1 — Actualización on-box
+El patrón actual es `git pull` + `update.sh` (script que vive en el CT con
+git, CI de assets y swap atómico). En un router no hay git ni CI local.
+
+**Decisión**: empaquetar el servidor como paquete OpenWrt (`.ipk` 24.10 y
+`.apk` 25.12) con el **mismo mecanismo de assets que el agente**: el binario
+viene dentro del paquete; las actualizaciones son `opkg/apk upgrade` del
+paquete. La app NO necesita conocer su propia versión desplegada más allá de
+lo que ya expone `/api/health`; el updater in-app de la webapp queda **no
+funcional on-box** (fuera de alcance: las actualizaciones las gestiona el
+gestor de paquetes del router, no la app).
+
+Alternativa descartada: binario + flag `.restart-me` como en el CT. Requeriría
+distribuir el binario por HTTP desde GitHub y validar checksums en el router,
+duplicando infraestructura que ya resuelve opkg/apk.
+
+### R2 — TLS autofirmado validado sin `--insecure`
+El servidor on-box escucha HTTPS con un cert autofirmado generado en primer
+arranque. El agente debe hablarle **sin** `InsecureSkipVerify`.
+
+**Decisión**: pinning por fingerprint (SPKI hash) del cert del servidor,
+configurado en UCI del agente durante el pairing. Sustituye a
+`NETPULSE_INSECURE_TLS`: 
+- `netpulse-agent.main.server` sigue siendo la URL (`https://192.168.1.1:3000`).
+- Nueva opción `netpulse-agent.main.server_fp` = SHA-256 del DER de la clave
+  pública (SPKI) del cert del servidor, en hex (`sha256sum` estándar).
+- El agente configura `tls.Config{InsecureSkipVerify:false}` +
+  `RootCAs`/`VerifyPeerCertificate` que valida el SPKI contra `server_fp`.
+  Sin fingerprint configurado → el agente **falla** (fail-closed), nunca
+  degrada a insecure.
+- Se elimina `NETPULSE_INSECURE_TLS` en esta fase.
+
+Cómo se obtiene el fingerprint: el servidor lo expone en un endpoint sin
+auth (`GET /fingerprint` → hex SPKI) y en el log de primer arranque. El
+pairing (R3) lo entrega automáticamente al agente.
+
+### R3 — Pairing cero-fricción
+Hoy el agente se instala con `--clave=valor` (token en argv, R8 de la
+auditoría). On-box el servidor y el agente viven en la misma máquina y hay
+que poder adoptar APs nuevos desde el móvil.
+
+**Decisión**:
+- El servidor on-box tiene un **token de pairing** de un solo uso (UUID
+  regenerado en cada instalación, guardado en UCI `/etc/config/netpulse`,
+  sección `server`). Se muestra en `logread` al primer arranque y en el
+  paquete LuCI de la Fase 10.
+- Al añadir un AP: se introduce ese token en la UI (o en el `.config` del
+  agente) → el servidor valida el token, genera `server`+`server_fp`+`token`
+  de agente y los escribe en el UCI del agente vía SSH (canal existente) o
+  vía el asistente de adopción.
+- Fuera de alcance on-box: el pairing automático por mDNS/LLDP (queda para
+  fase futura).
+
+### R4 — Bootstrap AUTH_PASS sin fail-fast en router
+`config.go` exige `AUTH_PASS` (fail-fast). En un router no se puede pedir una
+contraseña por consola.
+
+**Decisión**: en modo on-box (`NETPULSE_ONBOX=1` en UCI del servidor), si no
+hay `AUTH_PASS` se genera una aleatoria (26 chars) en el primer arranque, se
+guarda en UCI (`netpulse.server.auth_pass`, 0600 vía uci) y se imprime una
+sola vez en `logread`. El bootstrap del admin (`EnsureUsers`) la usa igual que
+hoy. El cambio en `config.go` es: `AUTH_PASS` opcional si `ONBOX` y valor
+presente en UCI; el loader UCI (R5) la inyecta en el entorno antes de `Load`.
+
+### R5 — Config por UCI en el servidor
+Hoy `config.go` lee entorno/`.env`. On-box se gestiona con UCI.
+
+**Decisión**: pequeño cargador `internal/config/uci.go` que traduce la
+sección `/etc/config/netpulse` (`config server`) a variables de entorno con
+las mismas claves (`port`, `data_dir`, `auth_user`, `auth_pass`,
+`demo_mode`, `cookie_secure`, `github_repo`…) antes de `Load`. El resto del
+código no cambia. En el CT (no on-box) se sigue usando `.env` como hoy.
+
+### R6 — Persistencia fuera de NAND
+- `data_dir` apunta a **overlay** por defecto (el gateway tiene 6.9 GB
+  libres; no hay USB conectado de serie). `journal_mode=DELETE` (no WAL) para
+  no desgastar flash: se activa con `PRAGMA journal_mode=DELETE` al abrir
+  (hoy usa WAL por defecto en modernc/sqlite).
+- Si se detecta un USB montado (`/mnt/netpulse-data`), `uci set
+  netpulse.server.data_dir=/mnt/netpulse-data` lo prioriza. La DB es un
+  fichero normal; migrar = copiar fichero + chown.
+- El resto de datos (estado del agente local, SSE) vive en `/tmp` y se
+  reconstruye en arranque.
+
+## 2. Modos de operación
+
+`NETPULSE_ONBOX=1` (UCI) activa: config UCI (R5), bootstrap AUTH_PASS (R4),
+TLS autofirmado (R2). Sin la variable, el binario se comporta exactamente
+como hoy (CT): `.env`, `:3000` http, sin pairing.
+
+Un AP (sin WAN) solo corre el agente (ya es así hoy). El gateway corre
+server + agente. Detección automática del rol: si la sección UCI `server`
+existe y está habilitada → hub; si no → solo agente. No hay heurística de
+interfaces (demasiado frágil en firmware GL).
+
+## 3. Despliegue y empaquetado
+
+- Nuevo `deploy/openwrt/netpulse-server/` (espejo del de `netpulse-agent`):
+  Makefile + `netpulse.init` (procd) + `netpulse.config` (UCI `config server`)
+  + `netpulse.defaults` (1er arranque: fingerprint, AUTH_PASS, cert).
+- El binario del paquete = build arm64 de goreleaser (o build onbox con
+  `NETPULSE_ONBOX` embebido — ver §4). ~14 MB.
+- SDK: 24.10 para `.ipk` (gateway); 25.12 para `.apk` (futuro, misma deuda
+  que el agente).
+- Reutilizar `package.sh` del agente parametrizado con el paquete nuevo.
+
+## 4. Cambios de código resumen
+
+| Área | Cambio |
+|---|---|
+| `internal/config` | `AUTH_PASS` opcional si ONBOX; `uci.go` loader R5 |
+| `cmd/netpulse/main.go` | detectar ONBOX; TLS server con cert autofirmado; `/fingerprint`; pairing |
+| `internal/staticspa` | servir HTTPS tras TLS (sin cambio de lógica) |
+| `agent/internal/push` + `sseclient` | validación SPKI por `server_fp`; eliminar `INSECURE_TLS` |
+| `deploy/openwrt/netpulse-server/` | paquete nuevo (init/config/defaults) |
+| `.goreleaser.yaml` / CI | target on-box arm64 (mismo binario; ONBOX por UCI, no por build) |
+
+**Decisión de build**: un único binario; `NETPULSE_ONBOX` es configuración,
+no compilación. Evita duplicar builds en CI y permite probar on-box en el CT
+(pasar el flag).
+
+## 5. Criterios de aceptación (verificables)
+
+1. Con el CT apagado: `https://<IP-del-router>:3000` sirve la app y hace
+   login (usuario admin con la AUTH_PASS generada).
+2. El agente del gateway y los APs reportan al servidor on-box **con TLS
+   validado por fingerprint** (sin `INSECURE_TLS`). Verificación:
+   `logread | grep netpulse-agent` sin errores de cert; `iwinfo`/heartbeat
+   frescos en `/api/agents`.
+3. Reinicio del gateway: server y agente arrancan solos (procd), DB y últimas
+   24 h intactas, `journal_mode=DELETE` confirmado (`PRAGMA journal_mode`).
+4. Adopción de un AP nuevo con el token de pairing sin escribir tokens en
+   argv.
+5. Sin ONBOX: el binario en el CT funciona idéntico a hoy (regresión: suite
+   de tests + smoke local).
+
+## 6. Fuera de alcance (explícito)
+
+- Web Push (SW del navegador no valida cert autofirmado).
+- Pairing automático por mDNS/LLDP.
+- Actualización in-app on-box (la gestiona opkg/apk).
+- Escritura en red (Fase 9).
+- El paquete LuCI (Fase 10) — aunque R3/R4 diseñan su superficie.
+- `.apk` del servidor para los APs 25.12 (misma deuda que el agente; los APs
+  solo corren el agente, no el servidor).
+
+## 7. Orden de implementación sugerido
+
+1. `internal/config/uci.go` + AUTH_PASS opcional ONBOX (testeable en el CT).
+2. TLS autofirmado + `/fingerprint` + pinning en el agente (sustituye
+   INSECURE_TLS).
+3. Pairing por token (server) + superficie en webapp (botón "Adoptar AP").
+4. Paquete `netpulse-server` (Makefile/init/config/defaults) + build arm64.
+5. Prueba real en el gateway y validación de criterios 1-5.
+6. Rollout: los APs apuntan `server` al gateway (solo UCI).

--- a/docs/SPEC-FASE8.md
+++ b/docs/SPEC-FASE8.md
@@ -1,9 +1,11 @@
-# SPEC — Fase 8: App on-box (servidor en el router gateway)
+# SPEC — Fase 9: App on-box (servidor en el router gateway)
 
 > Estado: borrador de diseño (issue #17). Actualizada: 2026-08-06.
 > Objetivo: NetPulse corre en el propio router gateway, sin dependencia de
 > infraestructura externa (CT, servidor). Solo lectura; la escritura queda en
-> la Fase 9.
+> la Fase 10.
+> Nota: esta fase es la "Fase 8" en la numeración anterior al reordenado de
+> fases del 6-Ago-2026 (la actual Fase 8 es la consolidación de deudas).
 
 ## 0. Contexto verificado (no supuestos)
 
@@ -164,8 +166,8 @@ no compilación. Evita duplicar builds en CI y permite probar on-box en el CT
 - Web Push (SW del navegador no valida cert autofirmado).
 - Pairing automático por mDNS/LLDP.
 - Actualización in-app on-box (la gestiona opkg/apk).
-- Escritura en red (Fase 9).
-- El paquete LuCI (Fase 10) — aunque R3/R4 diseñan su superficie.
+- Escritura en red (Fase 10).
+- El paquete LuCI (Fase 11) — aunque R3/R4 diseñan su superficie.
 - `.apk` del servidor para los APs 25.12 (misma deuda que el agente; los APs
   solo corren el agente, no el servidor).
 


### PR DESCRIPTION
Cierra el issue #17 (Fase 8 on-box).

## Contenido
- `docs/SPEC-FASE8.md` (renombrada a Fase 9 on-box): diseño completo con retos R1-R6 (actualización, TLS+pinning SPKI, pairing, bootstrap AUTH_PASS, config UCI, persistencia) y criterios de aceptación verificables.
- Reordenado de fases en `docs/ROADMAP.md`: la antigua cola pre-Fase 8 pasa a ser la **Fase 8 (consolidación de deudas)**; on-box → Fase 9; escritura → Fase 10; LuCI → Fase 11. Referencias cruzadas actualizadas.
- **Fase 8 con 7 ítems**: (1) métricas en /api/health, (2) registry de agentes persistente (R8), (3) integración del colector sidecar (propuesta 2: frontera read-only + historiador real + informe semanal), (4) recharts v2→v3, (5) limpieza de ramas, (6) auditoría de majors de frontend (react-router v8: NO), (7) webhooks + API de ingesta (con hueco de skill api-ingest-go anotado).

Closes #17
