### PR TITLE
feat(server-go): persistir registry de agentes en kv (Fase 8.2)

### DIFF
--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -99,6 +99,11 @@ func run() error {
 	if cfg.DemoMode {
 		adapter = adapters.NewDemo(alerts.New(dbHandle, nil))
 	} else {
+		// Fase 8.2 (R8): restaurar el último push persistido de cada agente
+		// (kv agent.state.<slug>) para que lastSeen/versión sobrevivan a un
+		// reinicio. El siguiente push del agente refresca el estado igual.
+		restore := httpapi.NewStateRestorer(dbHandle)
+		restore(agentReg)
 		pool, err := adapters.NewSSHPool(cfg.SSHKeyPath)
 		if err != nil {
 			log.Printf("[netpulse] aviso: pool SSH no disponible (%v); sirviendo dataset demo", err)

--- a/server-go/internal/adapters/agent.go
+++ b/server-go/internal/adapters/agent.go
@@ -107,6 +107,29 @@ func (r *AgentRegistry) ActiveCount() int {
 	return n
 }
 
+// Restore repuebla el estado de un slug desde el almacén persistente
+// (arranque del servidor). No revalida TTL: la expiración la decide el
+// reloj comparando contra el LastSeen restaurado. Sobrescribe cualquier
+// estado previo del slug.
+func (r *AgentRegistry) Restore(slug string, st *AgentState) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.states[slug] = st
+}
+
+// Snapshot devuelve una copia del estado de un slug (o nil si no existe).
+// Usado para persistir el último push sin exponer el map interno.
+func (r *AgentRegistry) Snapshot(slug string) *AgentState {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	st, ok := r.states[slug]
+	if !ok {
+		return nil
+	}
+	cp := *st
+	return &cp
+}
+
 // Forget borra el estado del slug (revocación de token).
 func (r *AgentRegistry) Forget(slug string) {
 	r.mu.Lock()

--- a/server-go/internal/httpapi/agent.go
+++ b/server-go/internal/httpapi/agent.go
@@ -204,6 +204,9 @@ func (s *server) handleIngestAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.agents.Ingest(&p)
+	// Fase 8.2 (R8): persistir el último push en kv (agent.state.<slug>) para
+	// que lastSeen/versión/payload sobrevivan a un reinicio del servidor.
+	s.persistAgentState(p.Router, s.agents.Snapshot(p.Router))
 	writeJSON(w, http.StatusAccepted, map[string]any{"ok": true})
 }
 

--- a/server-go/internal/httpapi/agent_api_test.go
+++ b/server-go/internal/httpapi/agent_api_test.go
@@ -300,3 +300,39 @@ func TestAgentsCreateValidaSlug(t *testing.T) {
 		}
 	}
 }
+
+// TestAgentStatePersistenciaYRestauracion (Fase 8.2, R8): tras una ingesta,
+// el último push queda en kv (agent.state.<slug>); un registry nuevo que
+// restaura desde kv recupera lastSeen/versión/payload (simula reinicio).
+func TestAgentStatePersistenciaYRestauracion(t *testing.T) {
+	ts := makeAgentTestServer(t)
+	_, token, _ := createAgentToken(t, ts, "patio")
+
+	res := ingest(t, ts, token, "10.0.0.1", validPayload)
+	res.Body.Close()
+	if res.StatusCode != 202 {
+		t.Fatalf("ingest: %d", res.StatusCode)
+	}
+
+	// El estado debe estar en kv tras la ingesta
+	var raw string
+	if err := ts.db.QueryRow("SELECT value FROM kv WHERE key = 'agent.state.patio'").Scan(&raw); err != nil {
+		t.Fatalf("kv agent.state: %v", err)
+	}
+
+	// Simular reinicio: registry nuevo + restaurador desde la misma BD
+	reg2 := adapters.NewAgentRegistry(90 * time.Second)
+	httpapi.NewStateRestorer(ts.db)(reg2)
+
+	_, version, ok := reg2.Info("patio")
+	if !ok {
+		t.Fatal("estado no restaurado tras reinicio")
+	}
+	if version != "0.1.0" {
+		t.Fatalf("versión restaurada: %q", version)
+	}
+	payload, fresh := reg2.Fresh("patio")
+	if !fresh || payload == nil || payload.Router != "patio" {
+		t.Fatalf("payload no fresco tras restauración: fresh=%v", fresh)
+	}
+}

--- a/server-go/internal/httpapi/agentstate.go
+++ b/server-go/internal/httpapi/agentstate.go
@@ -1,0 +1,88 @@
+// agentstate.go — Persistencia del registry de agentes (Fase 8.2, R8).
+//
+// El registry vive en RAM; sin persistir, lastSeen/versión/payload de cada
+// agente se pierden al reiniciar el servidor. Aquí se vuelca el último push
+// a la tabla kv (clave "agent.state.<slug>") en cada ingesta y se restaura
+// al arrancar. La BD (kv) es la única fuente de verdad del estado previo;
+// el siguiente push del agente la refresca igualmente (self-healing).
+package httpapi
+
+import (
+	"encoding/json"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/gnacho/netpulse/agent/probe"
+	"github.com/gnacho/netpulse/server-go/internal/adapters"
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+// agentStateKeyPrefix: kv agent.state.<slug> = último push serializado.
+const agentStateKeyPrefix = "agent.state."
+
+// persistedAgentState es el formato en kv: el payload + cuándo llegó.
+type persistedAgentState struct {
+	Payload  *probe.Payload `json:"payload"`
+	LastSeen int64          `json:"lastSeen"` // unix segundos
+	Version  string         `json:"version"`
+}
+
+func agentStateKey(slug string) string { return agentStateKeyPrefix + slug }
+
+// persistAgentState vuelca el último push del slug a kv. Best-effort: si la
+// escritura falla se loguea y se sigue (el agente reintentará su push).
+func (s *server) persistAgentState(slug string, st *adapters.AgentState) {
+	if st == nil || st.Payload == nil {
+		return
+	}
+	raw, err := json.Marshal(persistedAgentState{
+		Payload:  st.Payload,
+		LastSeen: st.LastSeen.Unix(),
+		Version:  st.Version,
+	})
+	if err != nil {
+		log.Printf("[netpulse] aviso: no se pudo serializar el estado del agente %s: %v", slug, err)
+		return
+	}
+	_, err = s.db.Exec(
+		"INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+		agentStateKey(slug), string(raw),
+	)
+	if err != nil {
+		log.Printf("[netpulse] aviso: no se pudo persistir el estado del agente %s: %v", slug, err)
+	}
+}
+
+// NewStateRestorer devuelve una función que restaura en el registry los
+// estados persistidos de kv (agent.state.<slug>). Se invoca en el arranque
+// del servidor, antes de construir el handler (no hay server todavía).
+func NewStateRestorer(d *db.DB) func(*adapters.AgentRegistry) {
+	return func(reg *adapters.AgentRegistry) {
+		rows, err := d.Query("SELECT key, value FROM kv WHERE key LIKE '" + agentStateKeyPrefix + "%'")
+		if err != nil {
+			log.Printf("[netpulse] aviso: no se pudieron restaurar los estados de agentes: %v", err)
+			return
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var key, raw string
+			if err := rows.Scan(&key, &raw); err != nil {
+				continue
+			}
+			slug := strings.TrimPrefix(key, agentStateKeyPrefix)
+			if slug == "" {
+				continue
+			}
+			var ps persistedAgentState
+			if err := json.Unmarshal([]byte(raw), &ps); err != nil || ps.Payload == nil {
+				continue
+			}
+			reg.Restore(slug, &adapters.AgentState{
+				Payload:  ps.Payload,
+				LastSeen: time.Unix(ps.LastSeen, 0),
+				Version:  ps.Version,
+			})
+		}
+	}
+}


### PR DESCRIPTION
Cierra el issue #21 (Fase 8.2, R8).

Persiste el registry de agentes: antes, AgentRegistry era un map en RAM y lastSeen/versión/payload se perdían al reiniciar el servidor.

Cambios:
- `AgentRegistry.Restore()` + `Snapshot()` en `internal/adapters/agent.go`.
- Nuevo `internal/httpapi/agentstate.go`: `persistAgentState` escribe el último push en kv (`agent.state.<slug>`, JSON) en cada ingesta; `NewStateRestorer(db)` los restaura al arranque.
- Conectado en `cmd/netpulse/main.go` (restauración) y en `handleIngestAgent` (persistencia).
- Test nuevo `TestAgentStatePersistenciaYRestauracion`: round-trip ingesta → kv → registry nuevo (simula reinicio).

Los slugs sin token ya se rechazaban con 401 en la ingesta (`checkAgentToken`), así que "solo slugs conocidos" quedaba cubierto por diseño.

**Desplegado y verificado en CT 226**: tras un reinicio real, `/api/agents` muestra los lastSeen previos a los 2 s (restaurados del kv, no de un push nuevo — los agentes empujan cada ~15 s). Antes salía `null`. 4/4 agentes con estado restaurado. Go build/vet/tests verdes.

Closes #21
