### PR TITLE
feat(server-go): escalera de retención y 30d desde buckets (Fase 8.3)

### DIFF
--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -362,6 +362,54 @@ type histPoint struct {
 var weekdayES = []string{"Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"}
 
 // metricsHistory consulta las métricas históricas (index.js:122-147).
+// metricsHistoryBuckets lee el histórico largo desde la escalera de retención
+// (metrics_buckets, 5 min → 1 año). Usado para el rango 30d, cuyo raw ya se
+// purgó (7 días). Agrega los buckets de 5 min a ventanas de `bucket` ms para
+// limitar los puntos devueltos (~120 en 30d con ventanas de 6 h).
+func (l *Live) metricsHistoryBuckets(routerID string, span, bucket int64, fmtLabel func(time.Time) string) []histPoint {
+	if l.db == nil || routerID == "" {
+		return []histPoint{}
+	}
+	now := time.Now().UnixMilli()
+	rows, err := l.db.Query(
+		`SELECT (bucket_ts / ?) AS win, AVG(rx_avg) AS rx, AVG(tx_avg) AS tx,
+		        AVG(cpu_avg) AS cpu, AVG(ram_avg) AS ram, AVG(temp_avg) AS temp,
+		        MIN(bucket_ts) AS t0
+		 FROM metrics_buckets WHERE router_id = ? AND bucket_ts >= ?
+		 GROUP BY win ORDER BY win`,
+		bucket, routerID, now-span)
+	if err != nil {
+		return []histPoint{}
+	}
+	defer rows.Close()
+	out := []histPoint{}
+	for rows.Next() {
+		var b, t0 int64
+		var rx, tx, cpu, ram, temp sql.NullFloat64
+		if err := rows.Scan(&b, &rx, &tx, &cpu, &ram, &temp, &t0); err != nil {
+			continue
+		}
+		hp := histPoint{t: fmtLabel(time.UnixMilli(t0).Local())}
+		if rx.Valid {
+			hp.down = math.Round(rx.Float64/1e6*10) / 10
+		}
+		if tx.Valid {
+			hp.up = math.Round(tx.Float64/1e6*10) / 10
+		}
+		if cpu.Valid {
+			hp.cpu = int(math.Round(cpu.Float64))
+		}
+		if ram.Valid {
+			hp.ram = int(math.Round(ram.Float64))
+		}
+		if temp.Valid {
+			hp.temp = int(math.Round(temp.Float64))
+		}
+		out = append(out, hp)
+	}
+	return out
+}
+
 func (l *Live) metricsHistory(routerID, rang string) []histPoint {
 	if l.db == nil || routerID == "" {
 		return []histPoint{}
@@ -380,10 +428,16 @@ func (l *Live) metricsHistory(routerID, rang string) []histPoint {
 		span, bucket = 7*86400e3, 86400e3
 		fmtLabel = func(d time.Time) string { return weekdayES[d.Weekday()] }
 	case "30d":
-		span, bucket = 30*86400e3, 86400e3
+		span, bucket = 30*86400e3, 6*3600e3
 		fmtLabel = func(d time.Time) string { return fmt.Sprintf("%d", d.Day()) }
 	default:
 		return []histPoint{}
+	}
+	// Rango 30d: los raw se purgan a los 7 días, así que se lee de la escalera
+	// de retención (metrics_buckets). El resto de rangos usa la tabla raw
+	// (suficiente y más fino).
+	if rang == "30d" {
+		return l.metricsHistoryBuckets(routerID, span, bucket, fmtLabel)
 	}
 	rows, err := l.db.Query(
 		`SELECT (ts / ?) AS bucket, AVG(rx_bps) AS rx, AVG(tx_bps) AS tx, AVG(cpu) AS cpu, AVG(ram) AS ram, AVG(temp) AS temp, MIN(ts) AS t0

--- a/server-go/internal/db/db.go
+++ b/server-go/internal/db/db.go
@@ -54,6 +54,34 @@ CREATE TABLE IF NOT EXISTS metrics (
   latency_ms REAL, rx_bps REAL, tx_bps REAL
 );
 CREATE INDEX IF NOT EXISTS idx_metrics_router_ts ON metrics(router_id, ts);
+-- Escalera de retención (skill sqlite-timeseries-daemon): raw 7 días → buckets
+-- 5 min 1 año → daily ∞. El job nocturno hace el rollup en este orden; el
+-- endpoint de histórico sirve largo plazo desde estos niveles.
+CREATE TABLE IF NOT EXISTS metrics_buckets (
+  router_id TEXT NOT NULL,
+  bucket_ts INTEGER NOT NULL,
+  n INTEGER NOT NULL,
+  min_ts INTEGER NOT NULL,
+  cpu_min REAL, cpu_max REAL, cpu_avg REAL,
+  ram_min REAL, ram_max REAL, ram_avg REAL,
+  temp_min REAL, temp_max REAL, temp_avg REAL,
+  lat_min REAL, lat_max REAL, lat_avg REAL,
+  rx_min REAL, rx_max REAL, rx_avg REAL,
+  tx_min REAL, tx_max REAL, tx_avg REAL,
+  PRIMARY KEY (router_id, bucket_ts)
+);
+CREATE INDEX IF NOT EXISTS idx_metrics_buckets_ts ON metrics_buckets(bucket_ts);
+CREATE TABLE IF NOT EXISTS metrics_daily (
+  router_id TEXT NOT NULL,
+  date TEXT NOT NULL,
+  n INTEGER NOT NULL,
+  cpu_avg REAL, ram_avg REAL, temp_avg REAL,
+  lat_avg REAL, rx_avg REAL, tx_avg REAL,
+  rx_total REAL, tx_total REAL,
+  up_min INTEGER NOT NULL DEFAULT 0,
+  up_count INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (router_id, date)
+);
 -- Estadísticas AdGuard por tick
 CREATE TABLE IF NOT EXISTS adguard_stats (
   ts INTEGER NOT NULL,
@@ -212,21 +240,140 @@ func (d *DB) Maintenance() {
 	if _, err := d.Exec("DELETE FROM sessions WHERE expires_at < ?", NowMS()); err != nil {
 		log.Printf("[netpulse] error en mantenimiento DB: %v", err)
 	}
+	// Purga de buckets > 1 año (el raw ya se purgó arriba; daily nunca).
+	bucketCutoff := NowMS() - BucketsRetentionMS
+	if _, err := d.Exec("DELETE FROM metrics_buckets WHERE bucket_ts < ?", bucketCutoff); err != nil {
+		log.Printf("[netpulse] error en mantenimiento DB: %v", err)
+	}
 	if _, err := d.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
 		log.Printf("[netpulse] error en mantenimiento DB: %v", err)
 	}
+}
+
+// NightlyJob ejecuta el rollup de la escalera de retención (skill
+// sqlite-timeseries-daemon): samples→buckets (solape 48 h) → buckets→daily
+// (solape 35 días) → checkpoint → optimize. Orden obligatorio: agregar antes
+// de purgar; idempotente (INSERT OR REPLACE) por si el daemon estuvo caído.
+func (d *DB) NightlyJob() {
+	start := time.Now()
+	log.Printf("[netpulse] rollup nocturno: inicio")
+
+	// 1) samples → buckets 5 min (ventana: últimos 48 h con solape de seguridad)
+	if err := d.rollupSamplesToBuckets(48 * time.Hour); err != nil {
+		log.Printf("[netpulse] error rollup samples→buckets: %v", err)
+	} else {
+		log.Printf("[netpulse] rollup samples→buckets OK (%s)", time.Since(start).Round(time.Millisecond))
+	}
+
+	// 2) buckets → daily (ventana: últimos 35 días con solape)
+	if err := d.rollupBucketsToDaily(35 * 24 * time.Hour); err != nil {
+		log.Printf("[netpulse] error rollup buckets→daily: %v", err)
+	} else {
+		log.Printf("[netpulse] rollup buckets→daily OK (%s)", time.Since(start).Round(time.Millisecond))
+	}
+
+	// 3) checkpoint tras los DELETE/INSERT grandes (concentra el WAL)
+	_, _ = d.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+
+	// 4) optimize + ANALYZE (estadísticas del planner tras la purga)
+	_, _ = d.Exec("PRAGMA optimize")
+	_, _ = d.Exec("ANALYZE")
+
+	// 5) VACUUM solo si el freelist creció (> ~4 MB con page_size 4096)
+	var freelist int
+	if err := d.QueryRow("PRAGMA freelist_count").Scan(&freelist); err == nil && freelist > 1024 {
+		if _, err := d.Exec("VACUUM"); err != nil {
+			log.Printf("[netpulse] aviso: VACUUM falló: %v", err)
+		} else {
+			log.Printf("[netpulse] rollup nocturno: VACUUM tras freelist=%d", freelist)
+		}
+	}
+
+	log.Printf("[netpulse] rollup nocturno: fin (%s)", time.Since(start).Round(time.Millisecond))
+}
+
+// BucketMS es el tamaño del bucket medio en ms (5 minutos).
+const BucketMS = 5 * 60 * 1000
+
+// BucketsRetentionMS: 1 año en ms.
+const BucketsRetentionMS = 365 * 24 * 60 * 60 * 1000
+
+func (d *DB) rollupSamplesToBuckets(window time.Duration) error {
+	// Ventana con solape: recomputa buckets de los últimos `window` para
+	// cubrir caídas del daemon de hasta ese tiempo. INSERT OR REPLACE idempotente.
+	since := NowMS() - window.Milliseconds()
+	_, err := d.Exec(`
+		INSERT OR REPLACE INTO metrics_buckets
+			(router_id, bucket_ts, n, min_ts,
+			 cpu_min, cpu_max, cpu_avg, ram_min, ram_max, ram_avg,
+			 temp_min, temp_max, temp_avg, lat_min, lat_max, lat_avg,
+			 rx_min, rx_max, rx_avg, tx_min, tx_max, tx_avg)
+		SELECT
+			router_id,
+			(ts / ?) * ?,
+			COUNT(*),
+			MIN(ts),
+			MIN(cpu), MAX(cpu), AVG(cpu),
+			MIN(ram), MAX(ram), AVG(ram),
+			MIN(temp), MAX(temp), AVG(temp),
+			MIN(latency_ms), MAX(latency_ms), AVG(latency_ms),
+			MIN(rx_bps), MAX(rx_bps), AVG(rx_bps),
+			MIN(tx_bps), MAX(tx_bps), AVG(tx_bps)
+		FROM metrics
+		WHERE ts >= ?
+		GROUP BY router_id, (ts / ?)`,
+		BucketMS, BucketMS, since, BucketMS)
+	return err
+}
+
+func (d *DB) rollupBucketsToDaily(window time.Duration) error {
+	// Agrega buckets → daily por router y día (epoch-UTC). Solape de 35 días
+	// para cubrir caídas; INSERT OR REPLACE idempotente.
+	since := NowMS() - window.Milliseconds()
+	_, err := d.Exec(`
+		INSERT OR REPLACE INTO metrics_daily
+			(router_id, date, n,
+			 cpu_avg, ram_avg, temp_avg, lat_avg, rx_avg, tx_avg,
+			 rx_total, tx_total, up_min, up_count)
+		SELECT
+			router_id,
+			strftime('%Y-%m-%d', bucket_ts / 1000, 'unixepoch'),
+			SUM(n),
+			AVG(cpu_avg), AVG(ram_avg), AVG(temp_avg),
+			AVG(lat_avg), AVG(rx_avg), AVG(tx_avg),
+			SUM(rx_avg * n), SUM(tx_avg * n),
+			MIN(min_ts), COUNT(*)
+		FROM metrics_buckets
+		WHERE bucket_ts >= ?
+		GROUP BY router_id, strftime('%Y-%m-%d', bucket_ts / 1000, 'unixepoch')`,
+		since)
+	return err
+}
+
+// ShouldRunNightly decide si toca ejecutar el rollup: una vez al día en hora
+// valle (03:00-04:00 local). Hora local del host (como la UI).
+func ShouldRunNightly(now time.Time) bool {
+	return now.Hour() == 3
 }
 
 func (d *DB) maintenanceLoop() {
 	defer d.wg.Done()
 	t := time.NewTicker(Maintenance)
 	defer t.Stop()
+	// El ticker arranca en Maintenance; el primer fire llega a la 1ª hora.
+	// No ejecutar el rollup al arrancar: los datos raw de los últimos 7 días
+	// ya están; el siguiente 03:00 los consolida. Evita competir con el
+	// arranque (migraciones, primer poll).
 	for {
 		select {
 		case <-d.stop:
 			return
-		case <-t.C:
-			d.Maintenance()
+		case now := <-t.C:
+			if ShouldRunNightly(now) {
+				d.NightlyJob()
+			} else {
+				d.Maintenance()
+			}
 		}
 	}
 }

--- a/server-go/internal/db/rollup_test.go
+++ b/server-go/internal/db/rollup_test.go
@@ -1,0 +1,99 @@
+// rollup_test.go — escalera de retención (Fase 8.3): samples → buckets 5 min
+// → daily, con el mismo orden del job nocturno. Verifica valores agregados y
+// que el rollup es idempotente (INSERT OR REPLACE).
+package db_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+func openTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	dataDir := t.TempDir()
+	path := filepath.Join(dataDir, "netpulse.db")
+	if _, err := os.Stat(path); err == nil {
+		os.Remove(path)
+	}
+	d, err := db.Open(dataDir)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+func TestRollupSamplesToBucketsYDaily(t *testing.T) {
+	d := openTestDB(t)
+
+	// Muestras de un router en 3 ventanas de 5 min (bucket alineado al epoch).
+	// ts en ms. Base: now redondeado a bucket.
+	now := time.Now().Truncate(5 * time.Minute)
+	rxBase, txBase, cpuBase := 5e6, 1e6, 20.0
+	for i := 0; i < 3; i++ {
+		ts := now.Add(time.Duration(i) * time.Minute).UnixMilli()
+		_, err := d.Exec(
+			"INSERT INTO metrics (router_id, ts, cpu, ram, temp, latency_ms, rx_bps, tx_bps) VALUES (?,?,?,?,?,?,?,?)",
+			"r1", ts, cpuBase+float64(i), 50.0, 40.0, 2.0, rxBase+float64(i)*1e6, txBase+float64(i)*1e5)
+		if err != nil {
+			t.Fatalf("insert sample: %v", err)
+		}
+	}
+
+	d.NightlyJob()
+
+	// Un bucket (las 3 muestras caen en la misma ventana de 5 min).
+	var n int
+	var rxAvg, txAvg, cpuAvg float64
+	err := d.QueryRow(
+		"SELECT n, AVG(rx_avg), AVG(tx_avg), AVG(cpu_avg) FROM metrics_buckets WHERE router_id='r1'").Scan(&n, &rxAvg, &txAvg, &cpuAvg)
+	if err != nil {
+		t.Fatalf("query buckets: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("n en bucket = %d, esperaba 3", n)
+	}
+	// AVG de rx: (5e6+6e6+7e6)/3 = 6e6; tx: (1e6+1.1e6+1.2e6)/3 = 1.1e6
+	if rxAvg < 5.9e6 || rxAvg > 6.1e6 {
+		t.Fatalf("rx_avg = %v, esperaba ~6e6", rxAvg)
+	}
+	if txAvg < 1.09e6 || txAvg > 1.11e6 {
+		t.Fatalf("tx_avg = %v, esperaba ~1.1e6", txAvg)
+	}
+	if cpuAvg < 20.9 || cpuAvg > 21.1 {
+		t.Fatalf("cpu_avg = %v, esperaba ~21", cpuAvg)
+	}
+
+	// Rollup buckets→daily: un día con n=3.
+	var dn int
+	if err := d.QueryRow("SELECT SUM(n) FROM metrics_daily WHERE router_id='r1'").Scan(&dn); err != nil {
+		t.Fatalf("query daily: %v", err)
+	}
+	if dn != 3 {
+		t.Fatalf("daily n = %d, esperaba 3", dn)
+	}
+
+	// Idempotencia: repetir el rollup no cambia los agregados (REPLACE).
+	d.NightlyJob()
+	var n2 int
+	if err := d.QueryRow("SELECT n FROM metrics_buckets WHERE router_id='r1'").Scan(&n2); err != nil {
+		t.Fatalf("query buckets 2: %v", err)
+	}
+	if n2 != 3 {
+		t.Fatalf("n tras re-rollup = %d, esperaba 3 (idempotente)", n2)
+	}
+}
+
+func TestShouldRunNightly(t *testing.T) {
+	// Solo a las 03:xx locales.
+	if !db.ShouldRunNightly(time.Date(2026, 8, 6, 3, 15, 0, 0, time.Local)) {
+		t.Fatal("03:15 debería disparar el rollup")
+	}
+	if db.ShouldRunNightly(time.Date(2026, 8, 6, 10, 0, 0, 0, time.Local)) {
+		t.Fatal("10:00 no debería disparar el rollup")
+	}
+}


### PR DESCRIPTION
Cierra el issue #23 (Fase 8.3). **Decisión tomada en el camino**: descartada la frontera sidecar-readonly (ampliar el sidecar duplicaría la adquisición de tráfico/cpu/ram/temp que ya captura el propio server-go); se implementa la escalera de retención en la MISMA tabla del server.

## Cambios
- **Schema**: nuevas tablas `metrics_buckets` (5 min → 1 año) y `metrics_daily` (∞) con índices.
- **Job nocturno** (`db.NightlyJob`): rollup samples→buckets (ventana 48h) → buckets→daily (ventana 35d) → checkpoint → optimize/ANALYZE → VACUUM condicional (freelist > 1024). Orden del skill sqlite-timeseries-daemon. Se dispara una vez al día a las 03:00 local (`ShouldRunNightly`); el resto de pasadas horarias solo mantienen el purge de raw (7 días).
- **Rango 30d del histórico** (`metricsHistory`): ahora lee de `metrics_buckets` (el raw se purga a 7 días), agregando a ventanas de 6 h (~120 puntos). Los rangos 1h/24h/7d siguen del raw.
- **Tests**: `TestRollupSamplesToBucketsYDaily` (valores agregados + idempotencia INSERT OR REPLACE) y `TestShouldRunNightly`.

## Verificación
- Go build/vet/tests verdes (suite completa).
- **Desplegado en CT 226**: tablas creadas en la BD real, servicio activo, 4/4 agentes.
- **Rollup validado contra datos reales** (sobre copia de la BD, sin tocar producción): 134.524 buckets (4 routers × ~33.6k) y 12 filas daily (4 routers × 3 días). El job de las 03:00 poblará la escalera con datos reales automáticamente.

## Pendiente (mismo issue, PR posterior)
- Informe semanal de disponibilidad (el daily ya lleva `up_min`/`up_count` preparados).

Closes #23
