### PR TITLE
fix(web): cache-busting on static assets

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -28,7 +28,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="styles.css?v=20260806" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -627,7 +627,7 @@
     <div class="panel-note" data-i18n="appearance.note">Mismos tokens que la app — pruébalo en vivo.</div>
   </div>
 
-  <script src="i18n.js"></script>
-  <script src="app.js"></script>
+  <script src="i18n.js?v=20260806"></script>
+  <script src="app.js?v=20260806"></script>
 </body>
 </html>


### PR DESCRIPTION
## What

The landing references `styles.css` / `i18n.js` / `app.js` without any versioning, while the server sends `cache-control: max-age=3600` for `.js/.css`. Browsers that loaded the landing before a deploy keep the stale assets for up to 1 hour even though `index.html` itself is served with `expires epoch`.

## Changes

- `web/index.html`: added `?v=20260806` query string to the three static assets. Next visit (after HTML reload) fetches the fresh files; the version string bumps on future deploys.

## Verification

- `node --check` N/A (HTML only).
- Deploy: scp `web/index.html` to `/opt/netpulse-web/public/`; Playwright cold-cache check on `https://netpulse.cloudless.club` confirms step 07 renders (ES/EN).