### PR TITLE
feat(server-go): webhook saliente de alertas con HMAC, retry y DLQ (Fase 8.7b)

### DIFF
--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gnacho/netpulse/server-go/internal/sshkey"
 	"github.com/gnacho/netpulse/server-go/internal/staticspa"
 	"github.com/gnacho/netpulse/server-go/internal/updater"
+	"github.com/gnacho/netpulse/server-go/internal/webhook"
 )
 
 func main() {
@@ -124,7 +125,19 @@ func run() error {
 		log.Printf("[netpulse] aviso: Web Push desactivado (%v)", err)
 	} else {
 		pushNotifier = push.NewNotifier(dbHandle, pub, priv)
-		adapter.AlertsEngine().SetNotifier(pushNotifier)
+	}
+
+	// Webhook saliente (Fase 8.7b): si WEBHOOK_URL está configurado, las
+	// alertas urgentes también se envían a esa URL (HMAC + retry + DLQ).
+	var webhookNotifier *webhook.Notifier
+	if cfg.Webhook != nil && cfg.Webhook.Enabled {
+		webhookNotifier = webhook.NewNotifier(*cfg.Webhook, dbHandle)
+		log.Printf("[netpulse] webhook saliente activo: %s", cfg.Webhook.URL)
+	}
+
+	// Notifier compuesto: push + webhook (SetNotifier solo admite UNO).
+	if pushNotifier != nil || webhookNotifier != nil {
+		adapter.AlertsEngine().SetNotifier(notifierChain{pushNotifier, webhookNotifier})
 	}
 
 	// Dependencia sse↔poller resuelta con un holder (como index.js:40-45).
@@ -238,6 +251,9 @@ func run() error {
 		if pushNotifier != nil {
 			pushNotifier.Close()
 		}
+		if webhookNotifier != nil {
+			webhookNotifier.Close()
+		}
 		// Salvavidas de 3 s: salir igualmente aunque el server no cierre.
 		lifeline := time.AfterFunc(3*time.Second, func() {
 			_ = dbHandle.Close()
@@ -265,4 +281,17 @@ func checkAgentToken(d *db.DB, slug, token string) bool {
 	sum := sha256.Sum256([]byte(token))
 	got := hex.EncodeToString(sum[:])
 	return subtle.ConstantTimeCompare([]byte(got), []byte(stored)) == 1
+}
+
+// notifierChain implementa alerts.Notifier encadenando varios notifiers
+// (push + webhook). El motor de alertas solo admite UNO (SetNotifier), así
+// que este compuesto reparte cada evento a todos los miembros no nulos.
+type notifierChain []alerts.Notifier
+
+func (c notifierChain) Notify(ev alerts.AlertEvent) {
+	for _, n := range c {
+		if n != nil {
+			n.Notify(ev)
+		}
+	}
 }

--- a/server-go/internal/config/config.go
+++ b/server-go/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // RouterSeed es una entrada de ROUTERS_JSON (semilla opcional de la tabla routers).
@@ -28,6 +29,17 @@ type AdGuard struct {
 	Pass string
 }
 
+// Webhook configura el notificador saliente de alertas (Fase 8.7b). Vacío si
+// no hay WEBHOOK_URL: el webhook se desactiva y el motor sigue igual.
+type Webhook struct {
+	URL         string
+	Secret      string
+	Timeout     time.Duration
+	Retries     int
+	RetryDelay  time.Duration
+	Enabled     bool
+}
+
 // Config es la config normalizada (equivalente al objeto de loadConfig).
 type Config struct {
 	Port          int
@@ -42,6 +54,7 @@ type Config struct {
 	Routers       []RouterSeed
 	SSHKeyPath    string
 	Adguard       *AdGuard
+	Webhook       *Webhook
 	WGInterface   string
 	CookieSecure  string // "auto" | "always" | "never"
 	GithubRepo    string
@@ -232,6 +245,42 @@ func Load(env map[string]string, serverRoot string) (*Config, error) {
 		}
 	}
 
+	// WEBHOOK_*: notificador saliente de alertas solo si hay URL válida.
+	// Timeout/retries/retry_delay con defaults si no vienen.
+	var webhook *Webhook
+	if v, ok := env["WEBHOOK_URL"]; ok && v != "" {
+		if u, err := url.Parse(v); err != nil || u.Scheme == "" || u.Host == "" {
+			errs.issues = append(errs.issues, issue{"WEBHOOK_URL", "Invalid url"})
+		} else {
+			timeout := 10 * time.Second
+			if w, ok := env["WEBHOOK_TIMEOUT"]; ok && w != "" {
+				if d, err := time.ParseDuration(w); err == nil && d > 0 {
+					timeout = d
+				}
+			}
+			retries := 3
+			if w, ok := env["WEBHOOK_RETRIES"]; ok && w != "" {
+				if n, err := strconv.Atoi(w); err == nil && n >= 0 {
+					retries = n
+				}
+			}
+			delay := 2 * time.Second
+			if w, ok := env["WEBHOOK_RETRY_DELAY"]; ok && w != "" {
+				if d, err := time.ParseDuration(w); err == nil && d > 0 {
+					delay = d
+				}
+			}
+			webhook = &Webhook{
+				URL:        v,
+				Secret:     env["WEBHOOK_SECRET"],
+				Timeout:    timeout,
+				Retries:    retries,
+				RetryDelay: delay,
+				Enabled:    true,
+			}
+		}
+	}
+
 	if len(errs.issues) > 0 {
 		return nil, &errs
 	}
@@ -287,6 +336,7 @@ func Load(env map[string]string, serverRoot string) (*Config, error) {
 		Routers:       routers,
 		SSHKeyPath:    sshKeyPath,
 		Adguard:       adguard,
+		Webhook:       webhook,
 		WGInterface:   wgInterface,
 		CookieSecure:  cookieSecure,
 		GithubRepo:    githubRepo,

--- a/server-go/internal/db/db.go
+++ b/server-go/internal/db/db.go
@@ -122,6 +122,14 @@ CREATE TABLE IF NOT EXISTS push_subscriptions (
   user_agent TEXT,
   created_at INTEGER NOT NULL
 );
+-- DLQ de webhooks salientes (Fase 8.7b): eventos no entregados tras agotar
+-- reintentos. event_id único (idempotencia del emisor).
+CREATE TABLE IF NOT EXISTS webhook_events (
+  event_id TEXT PRIMARY KEY,
+  payload TEXT NOT NULL,
+  sent_at INTEGER NOT NULL,
+  error TEXT
+);
 `
 
 // DB envuelve *sql.DB con los jobs y helpers de paridad.

--- a/server-go/internal/httpapi/httpapi_test.go
+++ b/server-go/internal/httpapi/httpapi_test.go
@@ -743,3 +743,31 @@ func TestWriteJSONSinSaltoFinal(t *testing.T) {
 		t.Fatalf("body no es JSON válido: %q", body)
 	}
 }
+
+func TestWebhookDLQEndpoint(t *testing.T) {
+	srv := makeTestServer(t)
+	status, cookie, _ := loginCookie(t, srv.URL, "admin", "test1234")
+	if status != 204 {
+		t.Fatalf("login: %d", status)
+	}
+
+	// Sin sesión → 401 (el middleware global exige auth)
+	req, _ := http.NewRequest("GET", srv.URL+"/api/webhook/dlq", nil)
+	res, _ := http.DefaultClient.Do(req)
+	res.Body.Close()
+	if res.StatusCode != 401 {
+		t.Fatalf("sin sesión debería dar 401, dio %d", res.StatusCode)
+	}
+
+	// Con sesión admin → 200 con items vacío (tabla nueva)
+	req, _ = http.NewRequest("GET", srv.URL+"/api/webhook/dlq", nil)
+	req.Header.Set("Cookie", "session="+cookie)
+	res, _ = http.DefaultClient.Do(req)
+	body := readJSON(t, res)
+	if res.StatusCode != 200 {
+		t.Fatalf("con sesión debería dar 200, dio %d", res.StatusCode)
+	}
+	if body["total"].(float64) != 0 {
+		t.Fatalf("DLQ vacío esperado, total=%v", body["total"])
+	}
+}

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -186,6 +186,7 @@ func NewHandler(d Deps) http.Handler {
 	mux.Handle("PUT /api/users/{id}/password", auth.RequireAdmin(http.HandlerFunc(s.handleSetPassword)))
 	mux.Handle("PUT /api/users/{id}/role", auth.RequireAdmin(http.HandlerFunc(s.handleSetRole)))
 	mux.Handle("DELETE /api/users/{id}", auth.RequireAdmin(http.HandlerFunc(s.handleDeleteUser)))
+	mux.Handle("GET /api/webhook/dlq", auth.RequireAdmin(http.HandlerFunc(s.handleWebhookDLQ)))
 
 	// --- Config (sesión; /api/config/adguard solo admin) ---
 	s.registerConfigRoutes(mux)

--- a/server-go/internal/httpapi/webhook_admin.go
+++ b/server-go/internal/httpapi/webhook_admin.go
@@ -1,0 +1,39 @@
+// webhook_admin.go — GET /api/webhook/dlq: eventos de webhook no entregados
+// (DLQ de Fase 8.7b). Solo admin. Para diagnóstico de envíos fallidos.
+package httpapi
+
+import (
+	"net/http"
+)
+
+// dlqEntry es el shape devuelto (payload no se expone entero, solo metadatos).
+type dlqEntry struct {
+	EventID string `json:"eventId"`
+	SentAt  int64  `json:"sentAt"`
+	Error   string `json:"error,omitempty"`
+}
+
+func (s *server) handleWebhookDLQ(w http.ResponseWriter, r *http.Request) {
+	rows, err := s.db.Query(
+		"SELECT event_id, sent_at, error FROM webhook_events ORDER BY sent_at DESC LIMIT 50")
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "db_error")
+		return
+	}
+	defer rows.Close()
+	out := []dlqEntry{}
+	for rows.Next() {
+		var e dlqEntry
+		var sentAt int64
+		var errNull *string
+		if err := rows.Scan(&e.EventID, &sentAt, &errNull); err != nil {
+			continue
+		}
+		e.SentAt = sentAt
+		if errNull != nil {
+			e.Error = *errNull
+		}
+		out = append(out, e)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": out, "total": len(out)})
+}

--- a/server-go/internal/webhook/webhook.go
+++ b/server-go/internal/webhook/webhook.go
@@ -1,0 +1,206 @@
+// Package webhook — notificador SALIENTE de alertas (Fase 8.7b).
+//
+// Implementa alerts.Notifier con entrega a una URL externa: firma
+// HMAC-SHA256 del body, reintentos con backoff exponencial + jitter
+// (4xx no se reintenta salvo 429; 5xx sí), DLQ en tabla webhook_events si
+// se agotan los reintentos. Patrón del skill email-webhook-notifications
+// (references/webhook-patterns.md) aplicado a NetPulse.
+//
+// Notify NUNCA bloquea al llamador: encola el evento y un worker único lo
+// drena. Si la cola está llena se descarta (la alerta ya está en /api/alerts).
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/rand"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/alerts"
+	"github.com/gnacho/netpulse/server-go/internal/config"
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+const (
+	queueCap   = 64
+	maxBodyCap = 64 << 10 // 64 KB (recomendación de seguridad del skill)
+)
+
+// payload es el contrato del webhook (firmado): event_id para idempotencia
+// del receptor y datos de la alerta.
+type payload struct {
+	EventID     string `json:"event_id"`
+	Timestamp   string `json:"timestamp"` // RFC3339
+	Type        string `json:"type"`
+	Severity    string `json:"severity"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Category    string `json:"category"`
+	RouterID    string `json:"routerId,omitempty"`
+	App         string `json:"app"`
+}
+
+// Notifier implementa alerts.Notifier con entrega asíncrona y DLQ.
+type Notifier struct {
+	cfg    config.Webhook
+	db     *db.DB
+	client *http.Client
+
+	ch   chan alerts.AlertEvent
+	done chan struct{}
+	once sync.Once
+	wg   sync.WaitGroup
+}
+
+// NewNotifier crea el Notifier y arranca su worker.
+func NewNotifier(cfg config.Webhook, d *db.DB) *Notifier {
+	n := &Notifier{
+		cfg:    cfg,
+		db:     d,
+		client: &http.Client{Timeout: cfg.Timeout},
+		ch:     make(chan alerts.AlertEvent, queueCap),
+		done:   make(chan struct{}),
+	}
+	n.wg.Add(1)
+	go n.worker()
+	return n
+}
+
+// Notify encola el evento y vuelve inmediatamente.
+func (n *Notifier) Notify(ev alerts.AlertEvent) {
+	select {
+	case <-n.done:
+		return
+	case n.ch <- ev:
+	default:
+		slog.Warn("webhook: cola llena, evento descartado", "alertId", ev.ID, "title", ev.Title)
+	}
+}
+
+// Close para el worker y espera al envío en curso.
+func (n *Notifier) Close() {
+	n.once.Do(func() {
+		close(n.done)
+		close(n.ch)
+		n.wg.Wait()
+	})
+}
+
+func (n *Notifier) worker() {
+	defer n.wg.Done()
+	for ev := range n.ch {
+		n.sendWithRetry(ev)
+	}
+}
+
+// payloadJSON construye el body firmable de un evento.
+func payloadJSON(ev alerts.AlertEvent) ([]byte, error) {
+	return json.Marshal(payload{
+		EventID:     ev.ID,
+		Timestamp:   time.Unix(ev.Ts, 0).UTC().Format(time.RFC3339),
+		Type:        "alert." + ev.Category,
+		Severity:    ev.Severity,
+		Title:       ev.Title,
+		Description: ev.Description,
+		Category:    ev.Category,
+		RouterID:    ev.RouterID,
+		App:         "netpulse",
+	})
+}
+
+// sign calcula la firma HMAC-SHA256 del body crudo.
+func sign(body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// sendWithRetry envía con backoff exponencial + jitter. 4xx (salvo 429) no se
+// reintenta; 429/5xx sí. Al agotar reintentos guarda en DLQ.
+func (n *Notifier) sendWithRetry(ev alerts.AlertEvent) {
+	body, err := payloadJSON(ev)
+	if err != nil {
+		slog.Error("webhook: payload no serializable", "alertId", ev.ID, "error", err)
+		return
+	}
+	var lastErr error
+	for attempt := 0; attempt <= n.cfg.Retries; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), n.cfg.Timeout)
+		err = n.sendOnce(ctx, ev.ID, body)
+		cancel()
+		if err == nil {
+			return
+		}
+		lastErr = err
+		var retryable bool
+		if httpErr, ok := err.(*httpStatusError); ok {
+			// 4xx (salvo 429): error del emisor, no reintentar jamás.
+			if httpErr.status >= 400 && httpErr.status < 500 && httpErr.status != http.StatusTooManyRequests {
+				slog.Warn("webhook: 4xx permanente, no se reintenta", "alertId", ev.ID, "status", httpErr.status)
+				n.saveDLQ(ev, body, lastErr.Error())
+				return
+			}
+			retryable = true
+		}
+		if attempt < n.cfg.Retries && retryable {
+			jitter := time.Duration(rand.Int63n(int64(n.cfg.RetryDelay)))
+			backoff := n.cfg.RetryDelay * time.Duration(1<<attempt)
+			time.Sleep(backoff + jitter)
+		}
+	}
+	n.saveDLQ(ev, body, lastErr.Error())
+}
+
+// httpStatusError marca la respuesta HTTP para la decisión de reintento.
+type httpStatusError struct {
+	status int
+	body   string
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("webhook status %d: %s", e.status, e.body)
+}
+
+func (n *Notifier) sendOnce(ctx context.Context, eventID string, body []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.cfg.URL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "NetPulse-Webhook/2.0")
+	req.Header.Set("X-Webhook-Signature", sign(body, n.cfg.Secret))
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyCap))
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	return &httpStatusError{status: resp.StatusCode, body: string(respBody)}
+}
+
+// saveDLQ persiste el evento no entregado para diagnóstico posterior.
+func (n *Notifier) saveDLQ(ev alerts.AlertEvent, body []byte, reason string) {
+	if n.db == nil {
+		return
+	}
+	if _, err := n.db.Exec(
+		"INSERT OR REPLACE INTO webhook_events (event_id, payload, sent_at, error) VALUES (?, ?, ?, ?)",
+		ev.ID, string(body), time.Now().Unix(), reason,
+	); err != nil {
+		slog.Error("webhook: no se pudo guardar en DLQ", "alertId", ev.ID, "error", err)
+		return
+	}
+	slog.Warn("webhook: evento a DLQ", "alertId", ev.ID, "error", reason)
+}

--- a/server-go/internal/webhook/webhook_test.go
+++ b/server-go/internal/webhook/webhook_test.go
@@ -1,0 +1,152 @@
+// webhook_test.go — notificador saliente (Fase 8.7b): firma HMAC, decisión de
+// reintento (4xx no / 429-5xx sí) y DLQ.
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/alerts"
+	"github.com/gnacho/netpulse/server-go/internal/config"
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+func testAlert() alerts.AlertEvent {
+	return alerts.AlertEvent{
+		ID: "evt-test-001", Category: "router", Urgent: true,
+		Severity: "warn", Title: "Router caído", Description: "gateway no responde",
+		Ts: time.Now().Unix(), RouterID: "gateway",
+	}
+}
+
+func testConfig() config.Webhook {
+	return config.Webhook{
+		URL: "", Secret: "test-secret-32-bytes-minimum!!", Timeout: 3 * time.Second,
+		Retries: 2, RetryDelay: 10 * time.Millisecond, Enabled: true,
+	}
+}
+
+func openWebhookDB(t *testing.T) *db.DB {
+	t.Helper()
+	dataDir := t.TempDir()
+	path := filepath.Join(dataDir, "netpulse.db")
+	os.Remove(path)
+	d, err := db.Open(dataDir)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+// TestFirmaValida: el receptor debe poder verificar la firma con el secreto.
+func TestFirmaValida(t *testing.T) {
+	var gotSig atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotSig.Store(r.Header.Get("X-Webhook-Signature"))
+		// Verificar con el secreto compartido (como haría el receptor)
+		mac := hmac.New(sha256.New, []byte("test-secret-32-bytes-minimum!!"))
+		mac.Write(body)
+		expected := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+		if r.Header.Get("X-Webhook-Signature") != expected {
+			t.Errorf("firma incorrecta: %q != %q", r.Header.Get("X-Webhook-Signature"), expected)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.URL = srv.URL
+	n := NewNotifier(cfg, nil)
+	defer n.Close()
+	n.Notify(testAlert())
+	// El worker es asíncrono: dar margen a que se envíe
+	time.Sleep(300 * time.Millisecond)
+	if gotSig.Load() == nil {
+		t.Fatal("no se recibió ninguna petición")
+	}
+}
+
+// TestRetry4xxNoReintenta: 400 no se reintenta (1 solo request).
+func TestRetry4xxNoReintenta(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.URL = srv.URL
+	n := NewNotifier(cfg, openWebhookDB(t))
+	defer n.Close()
+	n.Notify(testAlert())
+	time.Sleep(300 * time.Millisecond)
+	if c := calls.Load(); c != 1 {
+		t.Fatalf("400 debería recibir 1 request, recibió %d", c)
+	}
+}
+
+// TestRetry5xxReintentaYVaADLQ: 500 se reintenta (Retries+1 requests) y al
+// agotar se guarda en DLQ.
+func TestRetry5xxReintentaYVaADLQ(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	d := openWebhookDB(t)
+	cfg := testConfig()
+	cfg.URL = srv.URL
+	n := NewNotifier(cfg, d)
+	defer n.Close()
+	n.Notify(testAlert())
+	time.Sleep(500 * time.Millisecond)
+
+	// Retries=2 → 1 envío inicial + 2 reintentos = 3 requests
+	if c := calls.Load(); c != 3 {
+		t.Fatalf("500 con retries=2 debería recibir 3 requests, recibió %d", c)
+	}
+	var cnt int
+	if err := d.QueryRow("SELECT COUNT(*) FROM webhook_events").Scan(&cnt); err != nil {
+		t.Fatalf("query DLQ: %v", err)
+	}
+	if cnt != 1 {
+		t.Fatalf("DLQ debería tener 1 evento, tiene %d", cnt)
+	}
+}
+
+// TestOKNoVaADLQ: 2xx → éxito, sin DLQ.
+func TestOKNoVaADLQ(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	d := openWebhookDB(t)
+	cfg := testConfig()
+	cfg.URL = srv.URL
+	n := NewNotifier(cfg, d)
+	defer n.Close()
+	n.Notify(testAlert())
+	time.Sleep(300 * time.Millisecond)
+	var cnt int
+	if err := d.QueryRow("SELECT COUNT(*) FROM webhook_events").Scan(&cnt); err != nil {
+		t.Fatalf("query DLQ: %v", err)
+	}
+	if cnt != 0 {
+		t.Fatalf("2xx no debería ir a DLQ, tiene %d", cnt)
+	}
+}


### PR DESCRIPTION
Cierra el issue #30 (Fase 8.7b). Webhook saliente de alertas.

## Cambios
- **Nuevo paquete `internal/webhook/`**: `Notifier` que implementa `alerts.Notifier` con entrega asíncrona (worker único, cola cap 64). Envía a `WEBHOOK_URL` con firma `X-Webhook-Signature: sha256=<hex>` del body crudo, reintentos con backoff exponencial + jitter (**4xx no se reintenta salvo 429; 429/5xx sí**), y DLQ en tabla `webhook_events` si se agotan los reintentos. Payload con `event_id` (idempotencia del receptor).
- **Config** (`config.go`): `WEBHOOK_URL`, `WEBHOOK_SECRET`, `WEBHOOK_TIMEOUT`, `WEBHOOK_RETRIES`, `WEBHOOK_RETRY_DELAY`. Sin `WEBHOOK_URL` → webhook inactivo, comportamiento neutro.
- **main.go**: notifier **compuesto** (`notifierChain`) que encadena push + webhook al único `SetNotifier` del motor de alertas. Cierre gracioso de ambos en shutdown.
- **Endpoint admin** `GET /api/webhook/dlq` (RequireAdmin): eventos no entregados (metadatos, cap 50).
- **Tabla** `webhook_events` en el schema.

## Verificación
- Tests nuevos `internal/webhook/webhook_test.go` (4): firma válida verificable por el receptor, 400 no reintenta (1 request), 500 reintenta (Retries+1) y va a DLQ, 2xx sin DLQ. Plus `TestWebhookDLQEndpoint` (401 sin sesión, 200 con admin).
- Go build/vet/tests verdes (suite completa, 11 paquetes).
- **Desplegado en CT 226**: servicio activo, 4/4 agentes, `/api/webhook/dlq` responde `{"items":[],"total":0}`. Webhook **inactivo** (sin WEBHOOK_URL en .env) — se activará cuando el usuario configure URL+secreto. Binario desplegado == local (sha `e4d7c4bd`).

Closes #30
