### PR TITLE
docs: alinear Roadmap de los README con el ROADMAP.md renumerado

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -125,14 +125,14 @@ OpenWrt deberían funcionar, pero el tuyo sería el primero en contarlo.
 | **1 — Base read-only** | ✅ | PWA en React, sondeo SSH de solo lectura (ubus, `/proc`, iwinfo), AdGuard Home + WireGuard, auth multi-usuario, discovery LAN, backend migrado de Node a Go (binario único con la app embebida) |
 | **2 — Topología v5** | ✅ | Mapa semántico real: FDB + LLDP en vivo, backhaul, switches gestionados vs. inferidos, hipervisores con sus CTs anidados, collector de series temporales |
 | **3 — Alertas, Push y agente (piloto)** | ✅ | Alertas con 6 categorías y config por categoría (urgente/todo/nada), Web Push nativo (VAPID), refresco bajo demanda, auditoría switch/bridge con canon de datos reconciliado, agente OpenWrt piloto (ingesta con tokens, fallback SSH, procd) |
-| **4 — View-model versionado** | ✅ | API como view-model de presentación (`vm: 1`), canon demo single-source en Go → JSON, `Device.infra` sellado server-side, topología semántica en el snapshot, remodel de Preferencias (nombre de saludo, info de sistema real, AdGuard/usuarios/routers simplificados) |
-| **5 — Resiliencia del agente** | ✅ | Watchdog + heartbeat en el router (v2.3.0), rearme manual desde el servidor (v2.4.0), auto-rearme tras TTL (v2.4.0) y rutas de mutación solo-admin (v2.4.1) |
-| **6 — Fixes cosméticos y de datos** | 🚧 | Idioma auto, BD limpia + demo desde UI, IPs GL.iNet sin lease (rutas SSH y agente), layout radial (v2.4.2/v2.4.3); pendiente: espaciar iconos de clientes y detección de clusters Proxmox |
-| **7 — TLS y endurecimiento** | 🔮 | HTTPS en CT 226 (desbloquea Web Push real), HMAC-SHA256 en la ingesta del agente, servir el binario del agente desde el propio servidor |
-| **8 — Agente a fondo** | ⏳ | netlink/nl80211 nativo, eventos ubus en tiempo real, paquete `.ipk`, medición en hardware real |
+| **4 — View-model versionado** | ✅ | API como view-model de presentación (`vm: 1`), canon demo single-source en Go → JSON, `Device.infra` sellado server-side, topología semántica en el snapshot, remodel de Preferencias |
+| **5 — Resiliencia del agente** | ✅ | Watchdog + heartbeat en el router, rearme manual desde el servidor, auto-rearme tras TTL, rutas de mutación solo-admin |
+| **6 — Seguridad del agente** | ✅ | HMAC-SHA256 en la ingesta del agente, binario del agente servido desde el propio servidor |
+| **7 — Agente a fondo** | ✅ | Eventos wifi en tiempo real (`iw event`), SSE bidireccional (AgentHub + refresh), paquete `.ipk`, profiling (RSS 11-12 MB, CPU <1%) |
+| **8 — Consolidación** | ✅ | Métricas operativas en `/api/health`, registry de agentes persistente, retención larga (buckets 5 min → 1 año + daily), recharts v3, webhooks de alerta salientes (HMAC + retry + DLQ) |
 | **9 — App embebida en routers** | 🔮 | Server on-box en el gateway (la URL de la app ES la IP del router), pairing cero-fricción, `luci-app-netpulse` opcional |
 | **10 — Escritura/orquestación** | 🔮 | Plan → apply → state (patrón Terraform), `uci` transaccional, allowlist estricta; empieza por AdGuard Home |
-| **Backlog** | 📋 | Integrar las series del collector en server-go · verificación de push real (FCM) · retención de series + informe semanal |
+| **11 — Paquete LuCI** | 🔮 | `luci-app-netpulse`: estado local del agente (procd, UCI, logs, restart/rearm) + puente a la webapp |
 
 Detalle completo en [docs/ROADMAP.md](docs/ROADMAP.md).
 

--- a/README.md
+++ b/README.md
@@ -123,14 +123,14 @@ Other OpenWrt devices should work, but yours would be the first to tell.
 | **1 — Read-only base** | ✅ | React PWA, read-only SSH polling (ubus, `/proc`, iwinfo), AdGuard Home + WireGuard, multi-user auth, LAN discovery, backend migrated from Node to Go (single binary with embedded app) |
 | **2 — Topology v5** | ✅ | Real semantic map: live FDB + LLDP, backhaul, managed vs. inferred switches, hypervisors with nested CTs, time-series collector |
 | **3 — Alerts, Push & agent (pilot)** | ✅ | Alerts with 6 categories and per-category config (urgent/all/none), native Web Push (VAPID), on-demand refresh, switch/bridge audit with reconciled data canon, OpenWrt agent pilot (token ingest, SSH fallback, procd) |
-| **4 — Versioned view-model** | ✅ | API as a presentation view-model (`vm: 1`), single-sourced demo canon in Go → JSON, server-stamped `Device.infra`, semantic topology in the snapshot, Settings revamp (greeting name, real system info, streamlined AdGuard/users/routers) |
-| **5 — Agent resilience** | ✅ | Router-side watchdog + heartbeat (v2.3.0), server-side manual rearm (v2.4.0), TTL auto-rearm (v2.4.0) and admin-only mutation routes (v2.4.1) |
-| **6 — Cosmetic & data fixes** | 🚧 | Auto language, clean DB + demo from UI, GL.iNet IPs without lease (SSH and agent paths), radial layout (v2.4.2/v2.4.3); pending: more spacing between client icons and Proxmox cluster detection |
-| **7 — TLS & hardening** | 🔮 | HTTPS on CT 226 (unlocks real Web Push), HMAC-SHA256 on agent ingest, serve the agent binary from the server itself |
-| **8 — Agent deep dive** | ⏳ | Native netlink/nl80211, real-time ubus events, `.ipk` package, real-hardware benchmarking |
+| **4 — Versioned view-model** | ✅ | API as a presentation view-model (`vm: 1`), single-sourced demo canon in Go → JSON, server-stamped `Device.infra`, semantic topology in the snapshot, Settings revamp |
+| **5 — Agent resilience** | ✅ | Router-side watchdog + heartbeat, server-side manual rearm, TTL auto-rearm, admin-only mutation routes |
+| **6 — Agent security** | ✅ | HMAC-SHA256 on agent ingest, serve the agent binary from the server itself |
+| **7 — Agent deep dive** | ✅ | Real-time wifi events (`iw event`), bidirectional SSE (AgentHub + refresh), `.ipk` packaging, profiling (11-12 MB RSS, <1% CPU) |
+| **8 — Consolidation** | ✅ | Operational metrics in `/api/health`, persistent agent registry, long-term retention (5-min buckets → 1 year + daily), recharts v3, outgoing alert webhooks (HMAC + retry + DLQ) |
 | **9 — Embedded on-router app** | 🔮 | On-box server on the gateway (the app URL IS the router's IP), zero-friction pairing, optional `luci-app-netpulse` |
 | **10 — Write/orchestration** | 🔮 | Plan → apply → state (Terraform pattern), transactional `uci`, strict allowlist; starts with AdGuard Home |
-| **Backlog** | 📋 | Integrate collector series into server-go · real push verification (FCM) · series retention + weekly availability report |
+| **11 — LuCI package** | 🔮 | `luci-app-netpulse`: local agent status/view (procd, UCI, logs, restart/rearm) + bridge to the web app |
 
 Full detail in [docs/ROADMAP.md](docs/ROADMAP.md).
 


### PR DESCRIPTION
Cierra el issue #38.

La tabla Roadmap de README.md y README.es.md quedó desfasada tras el reordenado de fases. Alineada con docs/ROADMAP.md:
- Numeración real 1-11 (antes 1-10 + Backlog).
- Estados corregidos: las fases ya completadas (6 seguridad del agente, 7 agente a fondo) pasan de pendiente a ✅.
- Añadida la Fase 8 (consolidación, HECHA) con webhook saliente y el resto de hitos.
- Paridad EN/ES verificada (11 filas, mismo orden; solo cambia el idioma).

Closes #38