### PR TITLE
fix(collector): inyectar Version real con -ldflags (reportaba 0.1.0)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,7 +37,12 @@ builds:
     goarch: [amd64, arm64, arm]
     goarm: [7]
     flags: [-trimpath]
-    ldflags: [-s, -w]
+    # -X main.Version: sin esto el collector reporta "0.1.0" para siempre
+    # (main.go declara var Version con fallback para builds locales).
+    ldflags:
+      - -s
+      - -w
+      - "-X main.Version={{.Version}}"
 
   # Agente nativo OpenWrt (Fase 6): binario stateless que empuja al servidor.
   # arm64 = GL-MT6000 + APs (Cortex-A53); armv7 por si aparece un AP más

--- a/collector/main.go
+++ b/collector/main.go
@@ -36,8 +36,11 @@ const (
 	probeInterval = 5 * time.Second
 	probeTimeout  = 2 * time.Second
 	reloadEvery   = 5 * time.Minute
-	version       = "0.1.0"
 )
+
+// Version del collector (la reporta /healthz y state.json; se fija con
+// -ldflags "-X main.Version=x.y.z" en las releases).
+var Version = "0.1.0"
 
 type Target struct {
 	Name string
@@ -51,7 +54,7 @@ type probeResult struct {
 }
 
 func main() {
-	slog.Info("netpulse-collector arrancando", "version", version)
+	slog.Info("netpulse-collector arrancando", "version", Version)
 
 	dataDir := envOr("DATA_DIR", "/opt/netpulse-collector/data")
 	// Ruta real donde install.sh del servidor deja netpulse.db
@@ -186,7 +189,7 @@ func main() {
 		targets := snapshotLast()
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
-			"version":  version,
+			"version":  Version,
 			"uptime_s": int(time.Since(started).Seconds()),
 			"store":    ts.Health(filepath.Join(dataDir, "metrics.db")),
 			"targets":  targets,
@@ -363,7 +366,7 @@ func probe(addr string) probeResult {
 func writeStateFile(dataDir string, started time.Time, last map[string]probeResult) {
 	state := map[string]any{
 		"ts":       time.Now().Unix(),
-		"version":  version,
+		"version":  Version,
 		"uptime_s": int(time.Since(started).Seconds()),
 		"targets":  last,
 	}


### PR DESCRIPTION
Closes #43

## Qué
- collector/main.go:39: `const version` → `var Version` (patrón del agente). Una const no es inyectable con -ldflags.
- .goreleaser.yaml: el build netpulse-collector ahora pasa `-X main.Version={{.Version}}`.

## Verificación
- Build local con `-X main.Version=2.6.1` → log de arranque 'version=2.6.1'.
- Desplegado en CT 226 (backup .bak-0.1.0): /healthz reporta **version: 2.6.1**, 4/4 targets OK.