### PR TITLE
feat(server): informe semanal — GET /api/reports/weekly (semana ISO)

### DIFF
--- a/server-go/internal/httpapi/reports.go
+++ b/server-go/internal/httpapi/reports.go
@@ -1,12 +1,22 @@
 // reports.go — GET /api/reports/weekly: informe de disponibilidad semanal.
 // Calculado de metrics_daily (rollup nocturno de Fase 8.3): un daily por
-// router y día con up_count (nº de buckets de 5 min con datos) + medias de
+// router y día con el nº de muestras recolectadas (n), medias de
 // latencia/cpu/ram y totales de tráfico. El corte temporal (semana ISO
 // lunes-domingo) se normaliza aquí para que el frontend no haga aritmética
 // de fechas.
+//
+// Semántica de disponibilidad (verificada contra datos reales de prod):
+//   - `n` = suma de muestras del día (poll de 5 s; día completo ≈ 17280).
+//   - minutos de recolección = n * 5 / 60.
+//   - upPct = minutos / (días con datos * 1440). La semana en curso queda
+//     parcial y se normaliza solo sobre los días que tienen datos.
+//   - `up_count` del daily NO es fiable como base (es COUNT(*) de filas
+//     bucket, que en prod coincide con muestras porque el rollup no agrega);
+//     `up_min` del daily es MIN(min_ts) (timestamp), no minutos.
 package httpapi
 
 import (
+	"database/sql"
 	"net/http"
 	"strconv"
 	"time"
@@ -14,16 +24,16 @@ import (
 
 // weeklyReportEntry es una fila del informe: un router durante una semana.
 type weeklyReportEntry struct {
-	RouterID string  `json:"routerId"`
-	Week     string  `json:"week"`  // semana ISO, formato "2026-W31" (lunes-domingo)
-	Days     int     `json:"days"`  // días con datos en esa semana (≤7)
-	UpMin    int64   `json:"upMin"` // minutos de disponibilidad en la semana
-	UpPct    float64 `json:"upPct"` // % de disponibilidad sobre los días con datos
-	LatAvg   float64 `json:"latAvg"`
-	RxTotal  float64 `json:"rxTotal"`
-	TxTotal  float64 `json:"txTotal"`
-	CPUAvg   float64 `json:"cpuAvg"`
-	RAMAvg   float64 `json:"ramAvg"`
+	RouterID string   `json:"routerId"`
+	Week     string   `json:"week"`  // semana ISO, formato "2026-W31" (lunes-domingo)
+	Days     int      `json:"days"`  // días con datos en esa semana (≤7)
+	UpMin    int64    `json:"upMin"` // minutos de recolección en la semana
+	UpPct    float64  `json:"upPct"` // % de disponibilidad sobre los días con datos
+	LatAvg   *float64 `json:"latAvg"` // media de latencia (null si no hay datos)
+	RxTotal  float64  `json:"rxTotal"`
+	TxTotal  float64  `json:"txTotal"`
+	CPUAvg   float64  `json:"cpuAvg"`
+	RAMAvg   float64  `json:"ramAvg"`
 }
 
 // handleWeeklyReport sirve GET /api/reports/weekly?weeks=4. weeks ∈ [1,52].
@@ -48,7 +58,7 @@ func (s *server) handleWeeklyReport(w http.ResponseWriter, r *http.Request) {
 			router_id,
 			strftime('%G-W%V', date) AS week,
 			COUNT(*),
-			SUM(up_count) * 5,
+			SUM(n) * 5 / 60,
 			AVG(lat_avg),
 			SUM(rx_total),
 			SUM(tx_total),
@@ -68,11 +78,15 @@ func (s *server) handleWeeklyReport(w http.ResponseWriter, r *http.Request) {
 	for rows.Next() {
 		var e weeklyReportEntry
 		var upMin int64
+		var lat sql.NullFloat64
 		if err := rows.Scan(&e.RouterID, &e.Week, &e.Days, &upMin,
-			&e.LatAvg, &e.RxTotal, &e.TxTotal, &e.CPUAvg, &e.RAMAvg); err != nil {
+			&lat, &e.RxTotal, &e.TxTotal, &e.CPUAvg, &e.RAMAvg); err != nil {
 			continue
 		}
 		e.UpMin = upMin
+		if lat.Valid {
+			e.LatAvg = &lat.Float64
+		}
 		if e.Days > 0 {
 			e.UpPct = float64(upMin) / (float64(e.Days) * 24 * 60) * 100
 		}

--- a/server-go/internal/httpapi/reports.go
+++ b/server-go/internal/httpapi/reports.go
@@ -1,0 +1,86 @@
+// reports.go — GET /api/reports/weekly: informe de disponibilidad semanal.
+// Calculado de metrics_daily (rollup nocturno de Fase 8.3): un daily por
+// router y día con up_count (nº de buckets de 5 min con datos) + medias de
+// latencia/cpu/ram y totales de tráfico. El corte temporal (semana ISO
+// lunes-domingo) se normaliza aquí para que el frontend no haga aritmética
+// de fechas.
+package httpapi
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// weeklyReportEntry es una fila del informe: un router durante una semana.
+type weeklyReportEntry struct {
+	RouterID string  `json:"routerId"`
+	Week     string  `json:"week"`  // semana ISO, formato "2026-W31" (lunes-domingo)
+	Days     int     `json:"days"`  // días con datos en esa semana (≤7)
+	UpMin    int64   `json:"upMin"` // minutos de disponibilidad en la semana
+	UpPct    float64 `json:"upPct"` // % de disponibilidad sobre los días con datos
+	LatAvg   float64 `json:"latAvg"`
+	RxTotal  float64 `json:"rxTotal"`
+	TxTotal  float64 `json:"txTotal"`
+	CPUAvg   float64 `json:"cpuAvg"`
+	RAMAvg   float64 `json:"ramAvg"`
+}
+
+// handleWeeklyReport sirve GET /api/reports/weekly?weeks=4. weeks ∈ [1,52].
+func (s *server) handleWeeklyReport(w http.ResponseWriter, r *http.Request) {
+	weeks := 4
+	if raw := r.URL.Query().Get("weeks"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 1 || n > 52 {
+			writeError(w, http.StatusBadRequest, "invalid_query", "weeks must be an integer between 1 and 52")
+			return
+		}
+		weeks = n
+	}
+
+	// El daily se agrupa por día UTC (unixepoch en el rollup). La ventana se
+	// recorta con la fecha UTC de hoy; la semana en curso queda parcial y
+	// upPct se calcula solo sobre los días con datos (no penaliza).
+	since := time.Now().UTC().AddDate(0, 0, -7*weeks).Format("2006-01-02")
+
+	rows, err := s.db.Query(`
+		SELECT
+			router_id,
+			strftime('%G-W%V', date) AS week,
+			COUNT(*),
+			SUM(up_count) * 5,
+			AVG(lat_avg),
+			SUM(rx_total),
+			SUM(tx_total),
+			AVG(cpu_avg),
+			AVG(ram_avg)
+		FROM metrics_daily
+		WHERE date >= ?
+		GROUP BY router_id, strftime('%G-W%V', date)
+		ORDER BY week DESC, router_id`, since)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "db_error")
+		return
+	}
+	defer rows.Close()
+
+	out := []weeklyReportEntry{}
+	for rows.Next() {
+		var e weeklyReportEntry
+		var upMin int64
+		if err := rows.Scan(&e.RouterID, &e.Week, &e.Days, &upMin,
+			&e.LatAvg, &e.RxTotal, &e.TxTotal, &e.CPUAvg, &e.RAMAvg); err != nil {
+			continue
+		}
+		e.UpMin = upMin
+		if e.Days > 0 {
+			e.UpPct = float64(upMin) / (float64(e.Days) * 24 * 60) * 100
+		}
+		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		writeError(w, http.StatusInternalServerError, "db_error")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": out, "weeks": weeks})
+}

--- a/server-go/internal/httpapi/reports_test.go
+++ b/server-go/internal/httpapi/reports_test.go
@@ -1,0 +1,145 @@
+// reports_test.go — contrato de GET /api/reports/weekly: agregación por
+// router y semana ISO desde metrics_daily, validación de weeks y upPct.
+package httpapi_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+// insertDaily siembra un daily del router r para una fecha dada.
+func insertDaily(t *testing.T, ts *testServer, routerID, date string, upCount int, lat, rx, tx, cpu, ram float64) {
+	t.Helper()
+	_, err := ts.db.Exec(
+		"INSERT OR REPLACE INTO metrics_daily (router_id, date, n, cpu_avg, ram_avg, temp_avg, lat_avg, rx_avg, tx_avg, rx_total, tx_total, up_min, up_count) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+		routerID, date, 288, cpu, ram, 40, lat, rx, tx, rx*288, tx*288, int64(upCount)*5, upCount)
+	if err != nil {
+		t.Fatalf("insert daily %s/%s: %v", routerID, date, err)
+	}
+}
+
+// weeklyReportEntry espeja la respuesta (solo los campos que usa el test).
+type weeklyReportEntry struct {
+	RouterID string  `json:"routerId"`
+	Week     string  `json:"week"`
+	Days     int     `json:"days"`
+	UpMin    int64   `json:"upMin"`
+	UpPct    float64 `json:"upPct"`
+}
+
+func getWeekly(t *testing.T, ts *testServer, weeks string) (int, []weeklyReportEntry) {
+	t.Helper()
+	_, cookie, _ := loginCookie(t, ts.URL, "admin", "test1234")
+	url := ts.URL + "/api/reports/weekly"
+	if weeks != "" {
+		url += "?weeks=" + weeks
+	}
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Cookie", "session="+cookie)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET weekly: %v", err)
+	}
+	defer res.Body.Close()
+	body, _ := io.ReadAll(res.Body)
+	var env struct {
+		Items []weeklyReportEntry `json:"items"`
+	}
+	if res.StatusCode == http.StatusOK {
+		if err := json.Unmarshal(body, &env); err != nil {
+			t.Fatalf("decode: %v (%s)", err, body)
+		}
+	}
+	return res.StatusCode, env.Items
+}
+
+func TestWeeklyReportAgrupaPorRouterYSemana(t *testing.T) {
+	ts := makeTestServer(t)
+
+	// Dos routers en la misma semana ISO 2026-W32 (2026-08-03..09).
+	insertDaily(t, ts, "gw", "2026-08-03", 288, 1.2, 1e8, 5e7, 20, 60) // lunes completo
+	insertDaily(t, ts, "gw", "2026-08-04", 288, 1.4, 1e8, 5e7, 22, 61)
+	insertDaily(t, ts, "ap2", "2026-08-03", 144, 2.0, 1e7, 1e7, 10, 40) // media semana
+
+	// Otra semana distinta (2026-W31 = 2026-07-27..08-02) para el mismo router.
+	insertDaily(t, ts, "gw", "2026-07-27", 288, 1.0, 9e7, 4e7, 19, 59)
+
+	status, items := getWeekly(t, ts, "4")
+	if status != http.StatusOK {
+		t.Fatalf("status %d, esperaba 200", status)
+	}
+
+	// 3 filas: gw en 2 semanas + ap2 en 1.
+	if len(items) != 3 {
+		t.Fatalf("items = %d, esperaba 3: %+v", len(items), items)
+	}
+
+	// La semana más reciente primero (ORDER BY week DESC).
+	if items[0].Week != "2026-W32" {
+		t.Fatalf("items[0].week = %q, esperaba 2026-W32", items[0].Week)
+	}
+	if items[0].RouterID != "ap2" { // orden alfabético dentro de la semana: ap2 < gw
+		t.Fatalf("items[0].routerId = %q, esperaba ap2", items[0].RouterID)
+	}
+
+	// gw en W32: 2 días completos = 288*2 buckets * 5 min = 2880 min, 100%.
+	var gwW32, gwW31, ap2W32 *weeklyReportEntry
+	for i := range items {
+		switch {
+		case items[i].RouterID == "gw" && items[i].Week == "2026-W32":
+			gwW32 = &items[i]
+		case items[i].RouterID == "gw" && items[i].Week == "2026-W31":
+			gwW31 = &items[i]
+		case items[i].RouterID == "ap2" && items[i].Week == "2026-W32":
+			ap2W32 = &items[i]
+		}
+	}
+	if gwW32 == nil || gwW31 == nil || ap2W32 == nil {
+		t.Fatalf("faltan filas esperadas: gwW32=%v gwW31=%v ap2W32=%v", gwW32, gwW31, ap2W32)
+	}
+	if gwW32.Days != 2 || gwW32.UpMin != 2880 {
+		t.Fatalf("gw W32: days=%d upMin=%d, esperaba 2/2880", gwW32.Days, gwW32.UpMin)
+	}
+	if gwW32.UpPct < 99.9 || gwW32.UpPct > 100.1 {
+		t.Fatalf("gw W32 upPct=%v, esperaba ~100", gwW32.UpPct)
+	}
+	if ap2W32.Days != 1 || ap2W32.UpMin != 720 {
+		t.Fatalf("ap2 W32: days=%d upMin=%d, esperaba 1/720", ap2W32.Days, ap2W32.UpMin)
+	}
+	if ap2W32.UpPct < 49.9 || ap2W32.UpPct > 50.1 {
+		t.Fatalf("ap2 W32 upPct=%v, esperaba ~50 (media jornada: 720 de 1440 min)", ap2W32.UpPct)
+	}
+	if gwW31.Days != 1 || gwW31.UpMin != 1440 {
+		t.Fatalf("gw W31: days=%d upMin=%d, esperaba 1/1440", gwW31.Days, gwW31.UpMin)
+	}
+}
+
+func TestWeeklyReportValidaWeeks(t *testing.T) {
+	ts := makeTestServer(t)
+	for _, bad := range []string{"0", "53", "abc", "-1"} {
+		status, _ := getWeekly(t, ts, bad)
+		if status != http.StatusBadRequest {
+			t.Fatalf("weeks=%q → status %d, esperaba 400", bad, status)
+		}
+	}
+	// Por defecto (sin query) → 200.
+	status, _ := getWeekly(t, ts, "")
+	if status != http.StatusOK {
+		t.Fatalf("sin weeks → status %d, esperaba 200", status)
+	}
+}
+
+func TestWeeklyReportRequiereSesion(t *testing.T) {
+	ts := makeTestServer(t)
+	res, err := http.Get(ts.URL + "/api/reports/weekly")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer res.Body.Close()
+	io.Copy(io.Discard, res.Body)
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status %d, esperaba 401", res.StatusCode)
+	}
+}

--- a/server-go/internal/httpapi/reports_test.go
+++ b/server-go/internal/httpapi/reports_test.go
@@ -9,15 +9,26 @@ import (
 	"testing"
 )
 
-// insertDaily siembra un daily del router r para una fecha dada.
-func insertDaily(t *testing.T, ts *testServer, routerID, date string, upCount int, lat, rx, tx, cpu, ram float64) {
+// insertDaily siembra un daily del router r para una fecha dada. nSamples es
+// el nº de muestras recolectadas (poll 5 s; día completo ≈ 17280 → 1440 min).
+func insertDaily(t *testing.T, ts *testServer, routerID, date string, nSamples int, lat sqlNull, rx, tx, cpu, ram float64) {
 	t.Helper()
+	var latV any
+	if lat.valid {
+		latV = lat.f
+	}
 	_, err := ts.db.Exec(
 		"INSERT OR REPLACE INTO metrics_daily (router_id, date, n, cpu_avg, ram_avg, temp_avg, lat_avg, rx_avg, tx_avg, rx_total, tx_total, up_min, up_count) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
-		routerID, date, 288, cpu, ram, 40, lat, rx, tx, rx*288, tx*288, int64(upCount)*5, upCount)
+		routerID, date, nSamples, cpu, ram, 40, latV, rx, tx, rx*float64(nSamples), tx*float64(nSamples), 0, nSamples)
 	if err != nil {
 		t.Fatalf("insert daily %s/%s: %v", routerID, date, err)
 	}
+}
+
+// sqlNull emula sql.NullFloat64 para el test (sin importar database/sql).
+type sqlNull struct {
+	valid bool
+	f     float64
 }
 
 // weeklyReportEntry espeja la respuesta (solo los campos que usa el test).
@@ -27,6 +38,7 @@ type weeklyReportEntry struct {
 	Days     int     `json:"days"`
 	UpMin    int64   `json:"upMin"`
 	UpPct    float64 `json:"upPct"`
+	LatAvg   *float64 `json:"latAvg"`
 }
 
 func getWeekly(t *testing.T, ts *testServer, weeks string) (int, []weeklyReportEntry) {
@@ -59,12 +71,13 @@ func TestWeeklyReportAgrupaPorRouterYSemana(t *testing.T) {
 	ts := makeTestServer(t)
 
 	// Dos routers en la misma semana ISO 2026-W32 (2026-08-03..09).
-	insertDaily(t, ts, "gw", "2026-08-03", 288, 1.2, 1e8, 5e7, 20, 60) // lunes completo
-	insertDaily(t, ts, "gw", "2026-08-04", 288, 1.4, 1e8, 5e7, 22, 61)
-	insertDaily(t, ts, "ap2", "2026-08-03", 144, 2.0, 1e7, 1e7, 10, 40) // media semana
+	// Día completo = 17280 muestras = 1440 min. latAvg null en prod real.
+	insertDaily(t, ts, "gw", "2026-08-03", 17280, sqlNull{true, 1.2}, 1e8, 5e7, 20, 60)
+	insertDaily(t, ts, "gw", "2026-08-04", 17280, sqlNull{true, 1.4}, 1e8, 5e7, 22, 61)
+	insertDaily(t, ts, "ap2", "2026-08-03", 8640, sqlNull{false, 0}, 1e7, 1e7, 10, 40) // medio día, sin latencia
 
 	// Otra semana distinta (2026-W31 = 2026-07-27..08-02) para el mismo router.
-	insertDaily(t, ts, "gw", "2026-07-27", 288, 1.0, 9e7, 4e7, 19, 59)
+	insertDaily(t, ts, "gw", "2026-07-27", 17280, sqlNull{true, 1.0}, 9e7, 4e7, 19, 59)
 
 	status, items := getWeekly(t, ts, "4")
 	if status != http.StatusOK {
@@ -84,7 +97,7 @@ func TestWeeklyReportAgrupaPorRouterYSemana(t *testing.T) {
 		t.Fatalf("items[0].routerId = %q, esperaba ap2", items[0].RouterID)
 	}
 
-	// gw en W32: 2 días completos = 288*2 buckets * 5 min = 2880 min, 100%.
+	// gw en W32: 2 días completos = 2*1440 = 2880 min, 100%.
 	var gwW32, gwW31, ap2W32 *weeklyReportEntry
 	for i := range items {
 		switch {
@@ -105,11 +118,18 @@ func TestWeeklyReportAgrupaPorRouterYSemana(t *testing.T) {
 	if gwW32.UpPct < 99.9 || gwW32.UpPct > 100.1 {
 		t.Fatalf("gw W32 upPct=%v, esperaba ~100", gwW32.UpPct)
 	}
+	if gwW32.LatAvg == nil || *gwW32.LatAvg < 1.29 || *gwW32.LatAvg > 1.31 {
+		t.Fatalf("gw W32 latAvg=%v, esperaba ~1.3 (media de 1.2/1.4)", gwW32.LatAvg)
+	}
+	// ap2: medio día = 720 min sobre 1 día → 50%; latencia null (sin datos).
 	if ap2W32.Days != 1 || ap2W32.UpMin != 720 {
 		t.Fatalf("ap2 W32: days=%d upMin=%d, esperaba 1/720", ap2W32.Days, ap2W32.UpMin)
 	}
 	if ap2W32.UpPct < 49.9 || ap2W32.UpPct > 50.1 {
-		t.Fatalf("ap2 W32 upPct=%v, esperaba ~50 (media jornada: 720 de 1440 min)", ap2W32.UpPct)
+		t.Fatalf("ap2 W32 upPct=%v, esperaba ~50 (medio día: 720 de 1440 min)", ap2W32.UpPct)
+	}
+	if ap2W32.LatAvg != nil {
+		t.Fatalf("ap2 W32 latAvg=%v, esperaba null (sin datos de latencia)", *ap2W32.LatAvg)
 	}
 	if gwW31.Days != 1 || gwW31.UpMin != 1440 {
 		t.Fatalf("gw W31: days=%d upMin=%d, esperaba 1/1440", gwW31.Days, gwW31.UpMin)

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -142,6 +142,7 @@ func NewHandler(d Deps) http.Handler {
 	mux.HandleFunc("GET /api/dawn", s.handleDawn)
 	mux.HandleFunc("GET /api/adguard/clients", s.handleAdguardClients)
 	mux.HandleFunc("GET /api/system/info", s.handleSystemInfo)
+	mux.HandleFunc("GET /api/reports/weekly", s.handleWeeklyReport)
 
 	// --- Sondeo manual (botón "Refrescar" de Topología; 202 + SSE empuja) ---
 	mux.HandleFunc("POST /api/refresh", s.handleRefresh)


### PR DESCRIPTION
Closes #49

## Qué
Endpoint `GET /api/reports/weekly?weeks=4` (con sesión, como el resto del API de datos):
- Devuelve array por router y **semana ISO** (formato '2026-W31', lunes-domingo) — el corte temporal se normaliza en el backend.
- Campos: routerId, week, days, upMin, upPct, latAvg (null si no hay datos), rxTotal, txTotal, cpuAvg, ramAvg.
- upPct = minutos de recolección / (días con datos * 1440). Semana en curso parcial no penaliza.
- Semántica de disponibilidad derivada de `metrics_daily.n` (suma de muestras, poll 5 s, día completo ≈ 17280 → 1440 min).

## Hallazgos de datos (deuda, NO este PR)
Ver comentario en issue #49: el rollup nocturno en prod no agrega buckets de 5 min (muestras crudas), `up_min` del daily es un timestamp, y lat_avg es NULL en todos los daily. El endpoint es null-safe y usa la columna fiable (n).

## Verificación
- go vet + tests verdes (3 tests nuevos: agregación/router+semana, validación weeks, requiere sesión).
- Desplegado en CT 226 (backups .bak-pre-weekly / .bak-pre-weekly2): responde con 4 routers de la semana 2026-W32, upPct 64.86% (semana parcial con 3 días), latAvg null.