### PR TITLE
feat(web): bloque Club Cloudless + Acerca de mí en la landing

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1261,9 +1261,7 @@ function initReveals() {
 
 /* ---------- widget apariencia ---------- */
 const MODE_KEY = 'netpulse-web-theme-mode'
-const ACCENT_KEY = 'netpulse-web-accent'
 let themeMode = 'dark'
-let accentId = 'cyan'
 
 function readStore(k) { try { return localStorage.getItem(k) } catch { return null } }
 function writeStore(k, v) { try { localStorage.setItem(k, v) } catch { /* privado */ } }
@@ -1278,30 +1276,23 @@ function applyTheme() {
   if (meta) meta.content = light ? '#F3F5F9' : '#070B12'
   if (typeof renderShot === 'function') renderShot()
 }
-function applyAccent() { document.documentElement.dataset.accent = accentId }
 function updateAppearancePanel() {
   document.querySelectorAll('#themeSeg button').forEach(b => b.classList.toggle('on', b.dataset.mode === themeMode))
-  document.querySelectorAll('#accentSwatches .swatch').forEach(b => b.classList.toggle('on', b.dataset.accent === accentId))
 }
 function setMode(m) {
   themeMode = m; writeStore(MODE_KEY, m); applyTheme(); updateAppearancePanel()
 }
-function setAccent(a) {
-  accentId = a; writeStore(ACCENT_KEY, a); applyAccent(); updateAppearancePanel()
-}
-window.setMode = setMode; window.setAccent = setAccent
+window.setMode = setMode
 
 function initAppearance() {
   themeMode = readStore(MODE_KEY) || 'dark'
-  accentId = readStore(ACCENT_KEY) || 'cyan'
-  applyTheme(); applyAccent(); updateAppearancePanel()
+  applyTheme(); updateAppearancePanel()
   const fab = document.getElementById('appFab')
   const panel = document.getElementById('appPanel')
   fab.addEventListener('click', () => { panel.classList.toggle('open'); fab.setAttribute('aria-expanded', panel.classList.contains('open')) })
   document.addEventListener('click', e => { if (!panel.contains(e.target) && !fab.contains(e.target)) panel.classList.remove('open') })
   document.addEventListener('keydown', e => { if (e.key === 'Escape') panel.classList.remove('open') })
   document.querySelectorAll('#themeSeg button').forEach(b => b.addEventListener('click', () => setMode(b.dataset.mode)))
-  document.querySelectorAll('#accentSwatches .swatch').forEach(b => b.addEventListener('click', () => setAccent(b.dataset.accent)))
   window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', () => { if (themeMode === 'system') applyTheme() })
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -1398,12 +1398,21 @@ function initLightbox() {
   const lightboxImg = document.getElementById('lightboxImg')
   const lightboxCaption = document.getElementById('lightboxCaption')
   const lightboxClose = document.getElementById('lightboxClose')
+  const lightboxPrev = document.getElementById('lightboxPrev')
+  const lightboxNext = document.getElementById('lightboxNext')
   if (!lightbox || !lightboxImg) return
 
+  function syncLightbox() {
+    const src = shotUrl(SHOT_SLIDES[shotIndex])
+    const lang = (document.documentElement.lang || 'en').slice(0, 2)
+    lightboxImg.src = src
+    lightboxImg.alt = (SHOT_ALT[SHOT_SLIDES[shotIndex]] && SHOT_ALT[SHOT_SLIDES[shotIndex]][lang]) || SHOT_SLIDES[shotIndex]
+    lightboxCaption.textContent = t(`shots.s${shotIndex + 1}`)
+  }
+
   function openLightbox(img) {
-    lightboxImg.src = img.currentSrc || img.src
-    lightboxImg.alt = img.alt
-    lightboxCaption.textContent = img.alt
+    shotIndex = SHOT_SLIDES.indexOf(img.dataset.view) >= 0 ? SHOT_SLIDES.indexOf(img.dataset.view) : shotIndex
+    syncLightbox()
     lightbox.hidden = false
     lightbox.setAttribute('aria-hidden', 'false')
     if (lightboxClose) lightboxClose.focus()
@@ -1416,14 +1425,23 @@ function initLightbox() {
     document.body.style.overflow = ''
   }
 
+  function nav(dir) {
+    renderShot(shotIndex + dir)
+    syncLightbox()
+  }
+
   document.querySelectorAll('img[data-shot]').forEach((img) => {
     img.addEventListener('click', () => openLightbox(img))
   })
   if (lightboxClose) lightboxClose.addEventListener('click', closeLightbox)
+  if (lightboxPrev) lightboxPrev.addEventListener('click', () => nav(-1))
+  if (lightboxNext) lightboxNext.addEventListener('click', () => nav(1))
   lightbox.addEventListener('click', (e) => { if (e.target === lightbox) closeLightbox() })
   document.addEventListener('keydown', (e) => {
     if (lightbox.hidden) return
     if (e.key === 'Escape') closeLightbox()
+    if (e.key === 'ArrowLeft') nav(-1)
+    if (e.key === 'ArrowRight') nav(1)
   })
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -69,7 +69,8 @@ function initBackgroundCanvas() {
   let layers = [], bursts = []
   let mx = -1e4, my = -1e4, tmx = -1e4, tmy = -1e4
   const rand = mulberry32(0xC0FFEE)
-  const alphaColor = (c, a) => c.replace(')', ` / ${a})`)
+  const alphaColor = (name, a) => getCssVar(name).replace(')', ` / ${a})`)
+  const isLight = () => document.documentElement.classList.contains('light')
   const PALETTE = ['accent', 'tunnel', 'ok', 'info']
 
   function buildLayout() {
@@ -136,22 +137,24 @@ function initBackgroundCanvas() {
       }
       // enlaces (respiran muy lentamente)
       ctx.lineWidth = 1
+      const lineMul = isLight() ? 0.45 : 1.25
       for (const l of L.links) {
         const a = L.nodes[l.i], b = L.nodes[l.j]
-        ctx.strokeStyle = alphaColor('text-secondary', l.a * (0.65 + 0.35 * Math.sin(t * 0.4 + l.ph)))
+        ctx.strokeStyle = alphaColor('text-secondary', l.a * lineMul * (0.65 + 0.35 * Math.sin(t * 0.4 + l.ph)))
         ctx.beginPath()
         ctx.moveTo(a.wx, a.wy)
         ctx.lineTo(b.wx, b.wy)
         ctx.stroke()
       }
       // nodos
+      const nodeMul = isLight() ? 0.5 : 1
       for (const n of L.nodes) {
-        ctx.fillStyle = alphaColor(PALETTE[n.hue], n.a)
+        ctx.fillStyle = alphaColor(PALETTE[n.hue], n.a * nodeMul)
         ctx.beginPath()
         ctx.arc(n.wx, n.wy, n.r, 0, Math.PI * 2)
         ctx.fill()
         if (n.gw) {
-          ctx.strokeStyle = alphaColor(PALETTE[n.hue], n.a * 0.5)
+          ctx.strokeStyle = alphaColor(PALETTE[n.hue], n.a * nodeMul * 0.5)
           ctx.lineWidth = 1
           ctx.beginPath()
           ctx.arc(n.wx, n.wy, n.r + 3 + Math.sin(t * 1.2 + n.ph) * 1.2, 0, Math.PI * 2)

--- a/web/i18n.js
+++ b/web/i18n.js
@@ -45,6 +45,12 @@ const I18N = {
       cta: 'Meet the club',
       href: 'https://cloudless.club',
     },
+    about: {
+      eyebrow: 'About me',
+      title: 'A person is behind NetPulse',
+      p1: 'NetPulse was not built to be published. I started it to understand what was happening on my own network, with my own routers, without depending on anyone. And I have used it every day for a long time: it is the tool I open each morning to check that everything is still in order.',
+      p2: 'Over time, and consistently with the principles I believe in, I decided to make it free and share it with the community. There is no company behind it, just a person who uses what they publish. If it helps you, I am glad. If something breaks, I want to know.',
+    },
     theater: {
       title: 'Watch it come alive',
       lead: 'Keep scrolling. These are the real widgets, fed with the demo dataset — the same numbers you get when you run NetPulse in demo mode.',
@@ -166,6 +172,12 @@ const I18N = {
       lead: 'NetPulse sigue los tres principios del Club Cloudless: soberanía digital, libre para siempre y de personas, no de empresas. Son comunes a todas las apps del club y viven en un único sitio.',
       cta: 'Conocer el club',
       href: 'https://cloudless.club',
+    },
+    about: {
+      eyebrow: 'Acerca de mí',
+      title: 'Detrás de NetPulse hay una persona',
+      p1: 'NetPulse no nació para publicarse. Lo empecé para entender qué pasaba en mi propia red, con mis propios routers, sin depender de nadie. Y lo he usado a diario durante mucho tiempo: es la herramienta que abro cada mañana para comprobar que todo sigue en orden.',
+      p2: 'Con el tiempo, y de forma consecuente con los principios en los que creo, he decidido liberarlo y compartirlo con la comunidad. No hay ninguna empresa detrás, solo una persona que usa lo que publica. Si te sirve, me alegro. Si algo falla, quiero enterarme.',
     },
     theater: {
       title: 'Míralo cobrar vida',

--- a/web/i18n.js
+++ b/web/i18n.js
@@ -40,7 +40,7 @@ const I18N = {
     strip: { health: 'Health', down: 'Download', up: 'Upload', latency: 'Latency', devices: 'Devices' },
     club: {
       eyebrow: 'Part of the Cloudless Club',
-      title: 'The principles of the club',
+      title: 'Cloudless club principles',
       lead: 'NetPulse follows the three principles of the Cloudless Club: digital sovereignty, free forever, and by people, not companies. They are shared by every app in the club and live in a single place.',
       cta: 'Meet the club',
       href: 'https://cloudless.club',
@@ -142,6 +142,8 @@ const I18N = {
     },
     lightbox: {
       close: 'Close screenshot',
+      prev: 'Previous screenshot',
+      next: 'Next screenshot',
       alt: 'Screenshot enlarged',
     },
   },
@@ -160,7 +162,7 @@ const I18N = {
     strip: { health: 'Salud', down: 'Descarga', up: 'Subida', latency: 'Latencia', devices: 'Dispositivos' },
     club: {
       eyebrow: 'Parte del Club Cloudless',
-      title: 'Los principios del club',
+      title: 'Principios del club cloudless',
       lead: 'NetPulse sigue los tres principios del Club Cloudless: soberanía digital, libre para siempre y de personas, no de empresas. Son comunes a todas las apps del club y viven en un único sitio.',
       cta: 'Conocer el club',
       href: 'https://cloudless.club',
@@ -250,6 +252,8 @@ const I18N = {
     },
     lightbox: {
       close: 'Cerrar captura',
+      prev: 'Captura anterior',
+      next: 'Captura siguiente',
       alt: 'Captura ampliada',
     },
   },

--- a/web/i18n.js
+++ b/web/i18n.js
@@ -48,7 +48,7 @@ const I18N = {
     about: {
       eyebrow: 'About me',
       title: 'A person is behind NetPulse',
-      p1: 'NetPulse was not built to be published. I started it to understand what was happening on my own network, with my own routers, without depending on anyone. And I have used it every day for a long time: it is the tool I open each morning to check that everything is still in order.',
+      p1: 'NetPulse was not built to be published. I started it to understand what was happening on my own network, with my own routers, without depending on anyone. And I have used it every day for a long time: it is my unified tool to check that everything is still in order. I develop it in my spare time, between work and family.',
       p2: 'Over time, and consistently with the principles I believe in, I decided to make it free and share it with the community. There is no company behind it, just a person who uses what they publish. If it helps you, I am glad. If something breaks, I want to know.',
     },
     theater: {
@@ -131,7 +131,7 @@ const I18N = {
       community: 'Community', issues: 'Issues', discussions: 'Discussions', contribute: 'Contribute',
       kofi: 'Support the project on Ko-fi', rights: 'AGPL-3.0 · Built at home, for home networks.',
     },
-    appearance: { title: 'Appearance', theme: 'Theme', dark: 'Dark', light: 'Light', system: 'Auto', accent: 'Accent', note: 'Same tokens as the app — try it live.' },
+    appearance: { title: 'Appearance', theme: 'Theme', dark: 'Dark', light: 'Light', system: 'Auto' },
     misc: { lang: 'Language', copy: 'Copy', copied: 'Copied to clipboard', demoBadge: 'demo data' },
     shots: {
       eyebrow: 'The app',
@@ -176,7 +176,7 @@ const I18N = {
     about: {
       eyebrow: 'Acerca de mí',
       title: 'Detrás de NetPulse hay una persona',
-      p1: 'NetPulse no nació para publicarse. Lo empecé para entender qué pasaba en mi propia red, con mis propios routers, sin depender de nadie. Y lo he usado a diario durante mucho tiempo: es la herramienta que abro cada mañana para comprobar que todo sigue en orden.',
+      p1: 'NetPulse no nació para publicarse. Lo empecé para entender qué pasaba en mi propia red, con mis propios routers, sin depender de nadie. Y lo he usado a diario durante mucho tiempo: es mi herramienta unificada para comprobar que todo sigue en orden. Lo desarrollo en mi tiempo libre, entre el trabajo y la familia.',
       p2: 'Con el tiempo, y de forma consecuente con los principios en los que creo, he decidido liberarlo y compartirlo con la comunidad. No hay ninguna empresa detrás, solo una persona que usa lo que publica. Si te sirve, me alegro. Si algo falla, quiero enterarme.',
     },
     theater: {
@@ -247,7 +247,7 @@ const I18N = {
       community: 'Comunidad', issues: 'Issues', discussions: 'Discusiones', contribute: 'Contribuir',
       kofi: 'Apoya el proyecto en Ko-fi', rights: 'AGPL-3.0 · Hecho en casa, para redes de casa.',
     },
-    appearance: { title: 'Apariencia', theme: 'Tema', dark: 'Oscuro', light: 'Claro', system: 'Auto', accent: 'Acento', note: 'Mismos tokens que la app — pruébalo en vivo.' },
+    appearance: { title: 'Apariencia', theme: 'Tema', dark: 'Oscuro', light: 'Claro', system: 'Auto' },
     misc: { lang: 'Idioma', copy: 'Copiar', copied: 'Copiado al portapapeles', demoBadge: 'datos demo' },
     shots: {
       eyebrow: 'La app',
@@ -356,7 +356,7 @@ const I18N = {
       community: '社区', issues: '议题', discussions: '讨论', contribute: '贡献',
       kofi: '在 Ko-fi 上支持项目', rights: 'AGPL-3.0 · 在家中打造，为家庭网络而生。',
     },
-    appearance: { title: '外观', theme: '主题', dark: '深色', light: '浅色', system: '自动', accent: '强调色', note: '与应用使用相同的令牌——实时体验。' },
+    appearance: { title: '外观', theme: '主题', dark: '深色', light: '浅色', system: '自动' },
     misc: { lang: '语言', copy: '复制', copied: '已复制！', demoBadge: '演示数据' },
   },
 
@@ -446,7 +446,7 @@ const I18N = {
       community: 'المجتمع', issues: 'البلاغات', discussions: 'النقاشات', contribute: 'ساهم',
       kofi: 'ادعم المشروع على Ko-fi', rights: 'AGPL-3.0 · صُنع في البيت، لشبكات البيوت.',
     },
-    appearance: { title: 'المظهر', theme: 'السمة', dark: 'داكن', light: 'فاتح', system: 'تلقائي', accent: 'اللون', note: 'نفس رموز التطبيق — جرّبه مباشرة.' },
+    appearance: { title: 'المظهر', theme: 'السمة', dark: 'داكن', light: 'فاتح', system: 'تلقائي' },
     misc: { lang: 'اللغة', copy: 'نسخ', copied: 'نُسخ!', demoBadge: 'بيانات عرض' },
   },
 
@@ -536,7 +536,7 @@ const I18N = {
       community: 'समुदाय', issues: 'इश्यू', discussions: 'चर्चाएँ', contribute: 'योगदान',
       kofi: 'Ko-fi पर प्रोजेक्ट का समर्थन करें', rights: 'AGPL-3.0 · घर पर बना, घर के नेटवर्क के लिए।',
     },
-    appearance: { title: 'रूप-रंग', theme: 'थीम', dark: 'डार्क', light: 'लाइट', system: 'ऑटो', accent: 'ऐक्सेंट', note: 'ऐप वाले ही टोकन — लाइव आज़माएँ।' },
+    appearance: { title: 'रूप-रंग', theme: 'थीम', dark: 'डार्क', light: 'लाइट', system: 'ऑटो' },
     misc: { lang: 'भाषा', copy: 'कॉपी करें', copied: 'कॉपी हो गया!', demoBadge: 'डेमो डेटा' },
   },
 
@@ -626,7 +626,7 @@ const I18N = {
       community: 'Comunidade', issues: 'Issues', discussions: 'Discussões', contribute: 'Contribuir',
       kofi: 'Apoie o projeto no Ko-fi', rights: 'AGPL-3.0 · Feito em casa, para redes de casa.',
     },
-    appearance: { title: 'Aparência', theme: 'Tema', dark: 'Escuro', light: 'Claro', system: 'Auto', accent: 'Destaque', note: 'Mesmos tokens do app — experimente ao vivo.' },
+    appearance: { title: 'Aparência', theme: 'Tema', dark: 'Escuro', light: 'Claro', system: 'Auto' },
     misc: { lang: 'Idioma', copy: 'Copiar', copied: 'Copiado!', demoBadge: 'dados demo' },
   },
 
@@ -716,7 +716,7 @@ const I18N = {
       community: 'Communauté', issues: 'Issues', discussions: 'Discussions', contribute: 'Contribuer',
       kofi: 'Soutenir le projet sur Ko-fi', rights: 'AGPL-3.0 · Fait maison, pour les réseaux maison.',
     },
-    appearance: { title: 'Apparence', theme: 'Thème', dark: 'Sombre', light: 'Clair', system: 'Auto', accent: 'Accent', note: 'Mêmes tokens que l’app — essayez en direct.' },
+    appearance: { title: 'Apparence', theme: 'Thème', dark: 'Sombre', light: 'Clair', system: 'Auto' },
     misc: { lang: 'Langue', copy: 'Copier', copied: 'Copié !', demoBadge: 'données démo' },
   },
 
@@ -806,7 +806,7 @@ const I18N = {
       community: 'コミュニティ', issues: 'Issues', discussions: '議論', contribute: '貢献',
       kofi: 'Ko-fi でプロジェクトを応援', rights: 'AGPL-3.0 · 家庭のネットワークのために、家庭で作られました。',
     },
-    appearance: { title: '外観', theme: 'テーマ', dark: 'ダーク', light: 'ライト', system: '自動', accent: 'アクセント', note: 'アプリと同じトークン — ライブでお試しください。' },
+    appearance: { title: '外観', theme: 'テーマ', dark: 'ダーク', light: 'ライト', system: '自動' },
     misc: { lang: '言語', copy: 'コピー', copied: 'コピーしました', demoBadge: 'デモデータ' },
   },
 
@@ -896,7 +896,7 @@ const I18N = {
       community: 'Сообщество', issues: 'Issues', discussions: 'Обсуждения', contribute: 'Внести вклад',
       kofi: 'Поддержать проект на Ko-fi', rights: 'AGPL-3.0 · Сделано дома, для домашних сетей.',
     },
-    appearance: { title: 'Внешний вид', theme: 'Тема', dark: 'Тёмная', light: 'Светлая', system: 'Авто', accent: 'Акцент', note: 'Те же токены, что в приложении — попробуйте вживую.' },
+    appearance: { title: 'Внешний вид', theme: 'Тема', dark: 'Тёмная', light: 'Светлая', system: 'Авто' },
     misc: { lang: 'Язык', copy: 'Копировать', copied: 'Скопировано!', demoBadge: 'демо-данные' },
   },
 
@@ -986,7 +986,7 @@ const I18N = {
       community: 'Community', issues: 'Issues', discussions: 'Diskussionen', contribute: 'Mitwirken',
       kofi: 'Unterstütze das Projekt auf Ko-fi', rights: 'AGPL-3.0 · Zuhause gebaut, für Heimnetze.',
     },
-    appearance: { title: 'Erscheinungsbild', theme: 'Thema', dark: 'Dunkel', light: 'Hell', system: 'Auto', accent: 'Akzent', note: 'Dieselben Tokens wie die App — live ausprobieren.' },
+    appearance: { title: 'Erscheinungsbild', theme: 'Thema', dark: 'Dunkel', light: 'Hell', system: 'Auto' },
     misc: { lang: 'Sprache', copy: 'Kopieren', copied: 'Kopiert!', demoBadge: 'Demo-Daten' },
   },
 }

--- a/web/i18n.js
+++ b/web/i18n.js
@@ -28,7 +28,7 @@ const DEMO = {
 const I18N = {
   /* ---------------- ENGLISH ---------------- */
   en: {
-    nav: { features: 'Features', install: 'Install', github: 'GitHub' },
+    nav: { features: 'Features', club: 'The club', install: 'Install', github: 'GitHub' },
     hero: {
       eyebrow: 'Read-only home network monitoring',
       t1: 'Your network’s pulse.',
@@ -38,15 +38,12 @@ const I18N = {
     },
     facts: { noCloud: 'No cloud', free: '100% free · AGPL-3.0', data: 'Your app, your data', binary: 'One static binary', hw: 'OpenWrt / GL.iNet', package: 'OpenWrt .ipk package' },
     strip: { health: 'Health', down: 'Download', up: 'Upload', latency: 'Latency', devices: 'Devices' },
-    principles: {
-      title: 'Built on three stubborn principles',
-      lead: 'Not marketing lines. They are the reason NetPulse exists, and they shape every decision.',
-      p1t: 'No cloud',
-      p1p: 'No account, no subscription, no telemetry phoning home. NetPulse runs on a small box in your network and nowhere else. If your internet goes down, it keeps working.',
-      p2t: '100% free and open source',
-      p2p: 'AGPL-3.0, forever. Read the code, audit it, fork it, run it. There is no premium tier and there never will be.',
-      p3t: 'Your app, your data',
-      p3p: 'The server reads from your routers and never writes. Metrics live in a local SQLite file you own. Delete it, back it up, move it — it’s yours.',
+    club: {
+      eyebrow: 'Part of the Cloudless Club',
+      title: 'The principles of the club',
+      lead: 'NetPulse follows the three principles of the Cloudless Club: digital sovereignty, free forever, and by people, not companies. They are shared by every app in the club and live in a single place.',
+      cta: 'Meet the club',
+      href: 'https://cloudless.club',
     },
     theater: {
       title: 'Watch it come alive',
@@ -151,7 +148,7 @@ const I18N = {
 
   /* ---------------- ESPAÑOL ---------------- */
   es: {
-    nav: { features: 'Funciones', install: 'Instalar', github: 'GitHub' },
+    nav: { features: 'Funciones', club: 'El club', install: 'Instalar', github: 'GitHub' },
     hero: {
       eyebrow: 'Monitorización de solo lectura para tu red doméstica',
       t1: 'El pulso de tu red.',
@@ -161,15 +158,12 @@ const I18N = {
     },
     facts: { noCloud: 'Sin nube', free: '100% libre · AGPL-3.0', data: 'Tu app, tus datos', binary: 'Un solo binario', hw: 'OpenWrt / GL.iNet', package: 'Paquete .ipk OpenWrt' },
     strip: { health: 'Salud', down: 'Descarga', up: 'Subida', latency: 'Latencia', devices: 'Dispositivos' },
-    principles: {
-      title: 'Construido sobre tres principios tercos',
-      lead: 'No son frases de marketing. Son la razón de que NetPulse exista, y condicionan cada decisión.',
-      p1t: 'Sin nube',
-      p1p: 'Sin cuentas, sin suscripción, sin telemetría llamando a casa. NetPulse corre en una caja pequeña dentro de tu red y en ningún otro sitio. Si se cae Internet, sigue funcionando.',
-      p2t: '100% libre y open source',
-      p2p: 'AGPL-3.0, para siempre. Lee el código, audítalo, haz un fork, ejecútalo. No hay versión premium ni la habrá.',
-      p3t: 'Tu app, tus datos',
-      p3p: 'El servidor lee de tus routers y nunca escribe. Las métricas viven en un SQLite local que es tuyo. Bórralo, haz copias, muévelo — es tuyo.',
+    club: {
+      eyebrow: 'Parte del Club Cloudless',
+      title: 'Los principios del club',
+      lead: 'NetPulse sigue los tres principios del Club Cloudless: soberanía digital, libre para siempre y de personas, no de empresas. Son comunes a todas las apps del club y viven en un único sitio.',
+      cta: 'Conocer el club',
+      href: 'https://cloudless.club',
     },
     theater: {
       title: 'Míralo cobrar vida',
@@ -272,16 +266,6 @@ const I18N = {
     },
     facts: { noCloud: '无云端', free: '100% 自由 · AGPL-3.0', data: '你的应用，你的数据', binary: '单一静态二进制', hw: 'OpenWrt / GL.iNet' },
     strip: { health: '健康度', down: '下载', up: '上传', latency: '延迟', devices: '设备' },
-    principles: {
-      title: '建立在三个固执的原则之上',
-      lead: '这不是营销口号。它们是 NetPulse 存在的理由，也决定了每一个设计选择。',
-      p1t: '无云端',
-      p1p: '没有账号、没有订阅、没有上报遥测。NetPulse 运行在你网络里的一台小设备上，别处没有。断网时它照常工作。',
-      p2t: '100% 自由开源',
-      p2p: 'AGPL-3.0，永远如此。阅读代码、审计、分叉、运行。没有付费版，永远不会有。',
-      p3t: '你的应用，你的数据',
-      p3p: '服务器只读取路由器数据，从不写入。指标存在你拥有的本地 SQLite 文件中。删除、备份、迁移——都由你。',
-    },
     theater: {
       title: '看它活起来',
       lead: '继续滚动。这些是真实的组件，用演示数据集驱动——与你在演示模式下运行 NetPulse 看到的数字完全一致。',
@@ -372,16 +356,6 @@ const I18N = {
     },
     facts: { noCloud: 'بلا سحابة', free: 'حر 100% · AGPL-3.0', data: 'تطبيقك، بياناتك', binary: 'ملف ثنائي واحد', hw: 'OpenWrt / GL.iNet' },
     strip: { health: 'الصحة', down: 'تنزيل', up: 'رفع', latency: 'زمن الاستجابة', devices: 'الأجهزة' },
-    principles: {
-      title: 'مبني على ثلاثة مبادئ عنيدة',
-      lead: 'ليست عبارات تسويقية. إنها سبب وجود NetPulse، وهي التي تشكّل كل قرار.',
-      p1t: 'بلا سحابة',
-      p1p: 'لا حسابات، لا اشتراكات، لا قياسات عن بُعد ترسل بياناتك. يعمل NetPulse على جهاز صغير داخل شبكتك ولا مكان آخر. إذا انقطع الإنترنت، يستمر في العمل.',
-      p2t: 'حر ومفتوح المصدر 100%',
-      p2p: 'AGPL-3.0، إلى الأبد. اقرأ الشفرة، افحصها، انسخها، شغّلها. لا توجد نسخة مدفوعة ولن توجد.',
-      p3t: 'تطبيقك، بياناتك',
-      p3p: 'الخادم يقرأ من راوتراتك ولا يكتب أبدًا. المقاييس تعيش في ملف SQLite محلي تملكه أنت. احذفه، انسخه احتياطيًا، انقله — إنه لك.',
-    },
     theater: {
       title: 'شاهده ينبض بالحياة',
       lead: 'واصل التمرير. هذه هي الودجات الحقيقية، تغذّيها بيانات العرض التجريبي — نفس الأرقام التي تراها عند تشغيل NetPulse في وضع العرض.',
@@ -472,16 +446,6 @@ const I18N = {
     },
     facts: { noCloud: 'कोई क्लाउड नहीं', free: '100% स्वतंत्र · AGPL-3.0', data: 'आपका ऐप, आपका डेटा', binary: 'एक ही बाइनरी', hw: 'OpenWrt / GL.iNet' },
     strip: { health: 'स्वास्थ्य', down: 'डाउनलोड', up: 'अपलोड', latency: 'लेटेंसी', devices: 'डिवाइस' },
-    principles: {
-      title: 'तीन ज़िद्दी सिद्धांतों पर बना',
-      lead: 'मार्केटिंग वाक्य नहीं। ये NetPulse के अस्तित्व का कारण हैं, और हर फ़ैसले को आकार देते हैं।',
-      p1t: 'कोई क्लाउड नहीं',
-      p1p: 'कोई खाता नहीं, कोई सदस्यता नहीं, कोई टेलीमेट्री घर फ़ोन नहीं करती। NetPulse आपके नेटवर्क के एक छोटे बॉक्स पर चलता है और कहीं नहीं। इंटरनेट गिर जाए तो भी यह चलता रहता है।',
-      p2t: '100% स्वतंत्र और ओपन सोर्स',
-      p2p: 'AGPL-3.0, हमेशा के लिए। कोड पढ़ें, ऑडिट करें, फ़ोर्क करें, चलाएँ। कोई प्रीमियम टियर नहीं है और कभी नहीं होगा।',
-      p3t: 'आपका ऐप, आपका डेटा',
-      p3p: 'सर्वर आपके राउटरों से पढ़ता है और कभी लिखता नहीं। मेट्रिक्स एक स्थानीय SQLite फ़ाइल में रहते हैं जो आपकी है। मिटाएँ, बैकअप लें, ले जाएँ — यह आपका है।',
-    },
     theater: {
       title: 'इसे जीवंत होते देखें',
       lead: 'स्क्रॉल करते रहें। ये असली विजेट हैं, डेमो डेटासेट से भरे हुए — वही आँकड़े जो डेमो मोड में NetPulse चलाने पर दिखते हैं।',
@@ -572,16 +536,6 @@ const I18N = {
     },
     facts: { noCloud: 'Sem nuvem', free: '100% livre · AGPL-3.0', data: 'Seu app, seus dados', binary: 'Um único binário', hw: 'OpenWrt / GL.iNet' },
     strip: { health: 'Saúde', down: 'Download', up: 'Upload', latency: 'Latência', devices: 'Dispositivos' },
-    principles: {
-      title: 'Construído sobre três princípios teimosos',
-      lead: 'Não são frases de marketing. São a razão de o NetPulse existir, e moldam cada decisão.',
-      p1t: 'Sem nuvem',
-      p1p: 'Sem conta, sem assinatura, sem telemetria ligando para casa. O NetPulse roda numa caixinha dentro da sua rede e em nenhum outro lugar. Se a internet cair, ele continua funcionando.',
-      p2t: '100% livre e open source',
-      p2p: 'AGPL-3.0, para sempre. Leia o código, audite, faça fork, execute. Não existe versão premium e nunca existirá.',
-      p3t: 'Seu app, seus dados',
-      p3p: 'O servidor lê dos seus roteadores e nunca escreve. As métricas vivem num SQLite local que é seu. Apague, faça backup, mova — é seu.',
-    },
     theater: {
       title: 'Veja ganhar vida',
       lead: 'Continue rolando. Estes são os widgets reais, alimentados com o dataset de demo — os mesmos números que você vê ao rodar o NetPulse em modo demo.',
@@ -672,16 +626,6 @@ const I18N = {
     },
     facts: { noCloud: 'Sans cloud', free: '100 % libre · AGPL-3.0', data: 'Votre app, vos données', binary: 'Un seul binaire', hw: 'OpenWrt / GL.iNet' },
     strip: { health: 'Santé', down: 'Descendant', up: 'Montant', latency: 'Latence', devices: 'Appareils' },
-    principles: {
-      title: 'Construit sur trois principes obstinés',
-      lead: 'Pas des slogans marketing. C’est la raison d’être de NetPulse, et ils façonnent chaque décision.',
-      p1t: 'Sans cloud',
-      p1p: 'Pas de compte, pas d’abonnement, pas de télémétrie qui téléphone à la maison. NetPulse tourne sur un petit boîtier dans votre réseau, et nulle part ailleurs. Si Internet tombe, il continue.',
-      p2t: '100 % libre et open source',
-      p2p: 'AGPL-3.0, pour toujours. Lisez le code, auditez-le, forkez-le, exécutez-le. Pas de version premium, il n’y en aura jamais.',
-      p3t: 'Votre app, vos données',
-      p3p: 'Le serveur lit depuis vos routeurs et n’écrit jamais. Les métriques vivent dans un fichier SQLite local qui vous appartient. Supprimez-le, sauvegardez-le, déplacez-le — c’est le vôtre.',
-    },
     theater: {
       title: 'Regardez-le prendre vie',
       lead: 'Continuez à défiler. Ce sont les vrais widgets, nourris par le jeu de données démo — les mêmes chiffres que vous obtenez en lançant NetPulse en mode démo.',
@@ -772,16 +716,6 @@ const I18N = {
     },
     facts: { noCloud: 'クラウドなし', free: '100% フリー · AGPL-3.0', data: 'あなたのアプリ、あなたのデータ', binary: '単一静的バイナリ', hw: 'OpenWrt / GL.iNet' },
     strip: { health: '健全性', down: 'ダウンロード', up: 'アップロード', latency: 'レイテンシ', devices: 'デバイス' },
-    principles: {
-      title: '三つの頑固な原則の上に',
-      lead: 'マーケティング文句ではありません。NetPulse が存在する理由であり、すべての決断を形作ります。',
-      p1t: 'クラウドなし',
-      p1p: 'アカウントもサブスクリプションも、家に電話するテレメトリもなし。NetPulse はあなたのネットワーク内の小さな箱で動き、他所では動きません。インターネットが落ちても動き続けます。',
-      p2t: '100% フリーでオープンソース',
-      p2p: 'AGPL-3.0、ずっと。コードを読み、監査し、フォークし、実行してください。プレミアム版はなく、今後もありません。',
-      p3t: 'あなたのアプリ、あなたのデータ',
-      p3p: 'サーバーはルーターから読むだけで、書き込みはしません。メトリクスはあなたの所有するローカル SQLite ファイルにあります。削除、バックアップ、移動 — すべてあなた次第。',
-    },
     theater: {
       title: '動き出す様子をご覧ください',
       lead: 'スクロールを続けてください。これらは本物のウィジェットで、デモデータセットで動いています — デモモードで NetPulse を実行したときと同じ数字です。',
@@ -872,16 +806,6 @@ const I18N = {
     },
     facts: { noCloud: 'Без облака', free: '100% свободный · AGPL-3.0', data: 'Ваше приложение, ваши данные', binary: 'Один статический бинарник', hw: 'OpenWrt / GL.iNet' },
     strip: { health: 'Здоровье', down: 'Загрузка', up: 'Отдача', latency: 'Задержка', devices: 'Устройства' },
-    principles: {
-      title: 'Построен на трёх упрямых принципах',
-      lead: 'Это не маркетинговые лозунги. Это причина существования NetPulse, и они определяют каждое решение.',
-      p1t: 'Без облака',
-      p1p: 'Ни аккаунтов, ни подписок, ни телеметрии, звонящей домой. NetPulse работает на маленькой коробке в вашей сети — и больше нигде. Если интернет упал, он продолжает работать.',
-      p2t: '100% свободный и open source',
-      p2p: 'AGPL-3.0, навсегда. Читайте код, проверяйте, форкайте, запускайте. Премиум-версии нет и не будет.',
-      p3t: 'Ваше приложение, ваши данные',
-      p3p: 'Сервер читает с роутеров и никогда не пишет. Метрики живут в локальном файле SQLite, который принадлежит вам. Удаляйте, делайте бэкапы, переносите — он ваш.',
-    },
     theater: {
       title: 'Смотрите, как это оживает',
       lead: 'Продолжайте прокручивать. Это настоящие виджеты, питаемые демо-датасетом — те самые цифры, что вы увидите, запустив NetPulse в демо-режиме.',
@@ -972,16 +896,6 @@ const I18N = {
     },
     facts: { noCloud: 'Keine Cloud', free: '100 % frei · AGPL-3.0', data: 'Deine App, deine Daten', binary: 'Eine Binärdatei', hw: 'OpenWrt / GL.iNet' },
     strip: { health: 'Gesundheit', down: 'Download', up: 'Upload', latency: 'Latenz', devices: 'Geräte' },
-    principles: {
-      title: 'Gebaut auf drei eigensinnigen Prinzipien',
-      lead: 'Keine Marketingsprüche. Sie sind der Grund, warum NetPulse existiert, und prägen jede Entscheidung.',
-      p1t: 'Keine Cloud',
-      p1p: 'Kein Konto, kein Abo, keine Telemetrie, die nach Hause telefoniert. NetPulse läuft auf einer kleinen Box in deinem Netz und nirgendwo sonst. Fällt das Internet aus, läuft es weiter.',
-      p2t: '100 % frei und Open Source',
-      p2p: 'AGPL-3.0, für immer. Lies den Code, prüfe ihn, forke ihn, führe ihn aus. Es gibt keine Premiumstufe und wird nie eine geben.',
-      p3t: 'Deine App, deine Daten',
-      p3p: 'Der Server liest von deinen Routern und schreibt nie. Metriken leben in einer lokalen SQLite-Datei, die dir gehört. Lösche sie, sichere sie, verschiebe sie — sie gehört dir.',
-    },
     theater: {
       title: 'Sieh zu, wie es lebendig wird',
       lead: 'Scrolle weiter. Das sind die echten Widgets, gespeist aus dem Demo-Datensatz — dieselben Zahlen, die du bekommst, wenn du NetPulse im Demo-Modus startest.',

--- a/web/index.html
+++ b/web/index.html
@@ -102,7 +102,8 @@
         NetPulse
       </a>
       <div class="nav-links">
-        <a href="#principles" data-i18n="nav.features">Funciones</a>
+        <a href="#features" data-i18n="nav.features">Funciones</a>
+        <a href="#club" data-i18n="nav.club">El club</a>
         <a href="#install" data-i18n="nav.install">Instalar</a>
         <a href="https://github.com/gnacho/netpulse" target="_blank" rel="noopener" data-i18n="nav.github">GitHub</a>
       </div>
@@ -175,30 +176,17 @@
     <div class="ticker" id="ticker"></div>
   </div>
 
-  <!-- ============ PRINCIPIOS ============ -->
-  <section class="block" id="principles">
+  <!-- ============ CLUB CLOUDLESS ============ -->
+  <section class="block" id="club">
     <div class="container">
       <div class="reveal">
-        <span class="eyebrow">NetPulse</span>
-        <h2 class="font-display text-balance" data-i18n="principles.title">Construido sobre tres principios tercos</h2>
-        <p class="lead" data-i18n="principles.lead">No son frases de marketing. Son la razón de que NetPulse exista, y condicionan cada decisión.</p>
-      </div>
-      <div class="principles">
-        <div class="card principle reveal">
-          <svg class="big" viewBox="0 0 24 24" fill="none" stroke="rgb(var(--ok))" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/><line x1="4" y1="4" x2="20" y2="20"/></svg>
-          <h3 data-i18n="principles.p1t">Sin nube</h3>
-          <p data-i18n="principles.p1p">Sin cuentas, sin suscripción, sin telemetría llamando a casa. NetPulse corre en una caja pequeña dentro de tu red y en ningún otro sitio.</p>
-        </div>
-        <div class="card principle reveal">
-          <svg class="big" viewBox="0 0 24 24" fill="none" stroke="rgb(var(--accent))" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
-          <h3 data-i18n="principles.p2t">100% libre y open source</h3>
-          <p data-i18n="principles.p2p">AGPL-3.0, para siempre. Lee el código, audítalo, haz un fork, ejecútalo. No hay versión premium ni la habrá.</p>
-        </div>
-        <div class="card principle reveal">
-          <svg class="big" viewBox="0 0 24 24" fill="none" stroke="rgb(var(--tunnel))" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
-          <h3 data-i18n="principles.p3t">Tu app, tus datos</h3>
-          <p data-i18n="principles.p3p">El servidor lee de tus routers y nunca escribe. Las métricas viven en un SQLite local que es tuyo. Bórralo, haz copias, muévelo.</p>
-        </div>
+        <span class="eyebrow" data-i18n="club.eyebrow">Parte del Club Cloudless</span>
+        <h2 class="font-display text-balance" data-i18n="club.title">Los principios del club</h2>
+        <p class="lead" data-i18n="club.lead">NetPulse sigue los tres principios del Club Cloudless: soberanía digital, libre para siempre y de personas, no de empresas. Son comunes a todas las apps del club y viven en un único sitio.</p>
+        <a class="btn-primary" style="margin-top:1.75rem;" href="https://cloudless.club" target="_blank" rel="noopener">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/><line x1="4" y1="4" x2="20" y2="20"/></svg>
+          <span data-i18n="club.cta">Conocer el club</span>
+        </a>
       </div>
     </div>
   </section>

--- a/web/index.html
+++ b/web/index.html
@@ -179,11 +179,13 @@
   <!-- ============ CLUB CLOUDLESS ============ -->
   <section class="block" id="club">
     <div class="container">
-      <div class="reveal">
-        <span class="eyebrow" data-i18n="club.eyebrow">Parte del Club Cloudless</span>
-        <h2 class="font-display text-balance" data-i18n="club.title">Los principios del club</h2>
-        <p class="lead" data-i18n="club.lead">NetPulse sigue los tres principios del Club Cloudless: soberanía digital, libre para siempre y de personas, no de empresas. Son comunes a todas las apps del club y viven en un único sitio.</p>
-        <a class="btn-primary" style="margin-top:1.75rem;" href="https://cloudless.club" target="_blank" rel="noopener">
+      <div class="club-inner reveal">
+        <div class="club-copy">
+          <span class="eyebrow" data-i18n="club.eyebrow">Parte del Club Cloudless</span>
+          <h2 class="font-display text-balance" data-i18n="club.title">Los principios del club</h2>
+          <p class="lead" data-i18n="club.lead">NetPulse sigue los tres principios del Club Cloudless: soberanía digital, libre para siempre y de personas, no de empresas. Son comunes a todas las apps del club y viven en un único sitio.</p>
+        </div>
+        <a class="btn-primary club-cta" href="https://cloudless.club" target="_blank" rel="noopener">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/><line x1="4" y1="4" x2="20" y2="20"/></svg>
           <span data-i18n="club.cta">Conocer el club</span>
         </a>

--- a/web/index.html
+++ b/web/index.html
@@ -554,6 +554,20 @@
     </div>
   </section>
 
+  <!-- ============ ACERCA DE MÍ ============ -->
+  <section class="block" id="about" style="padding-top:1rem;">
+    <div class="container">
+      <div class="reveal">
+        <span class="eyebrow" data-i18n="about.eyebrow">Acerca de mí</span>
+        <h2 class="font-display text-balance" data-i18n="about.title">Detrás de NetPulse hay una persona</h2>
+      </div>
+      <div class="about-body">
+        <p data-i18n="about.p1">NetPulse no nació para publicarse. Lo empecé para entender qué pasaba en mi propia red, con mis propios routers, sin depender de nadie. Y lo he usado a diario durante mucho tiempo: es la herramienta que abro cada mañana para comprobar que todo sigue en orden.</p>
+        <p data-i18n="about.p2">Con el tiempo, y de forma consecuente con los principios en los que creo, he decidido liberarlo y compartirlo con la comunidad. No hay ninguna empresa detrás, solo una persona que usa lo que publica. Si te sirve, me alegro. Si algo falla, quiero enterarme.</p>
+      </div>
+    </div>
+  </section>
+
   <!-- ============ FOOTER ============ -->
   <footer>
     <div class="container">

--- a/web/index.html
+++ b/web/index.html
@@ -613,6 +613,10 @@
       <button class="swatch" data-accent="violet" style="--sw:#A78BFA" aria-label="Violet"></button>
       <button class="swatch" data-accent="emerald" style="--sw:#34D399" aria-label="Emerald"></button>
       <button class="swatch" data-accent="amber" style="--sw:#FBBF24" aria-label="Amber"></button>
+      <button class="swatch" data-accent="rose" style="--sw:#FB7185" aria-label="Rose"></button>
+      <button class="swatch" data-accent="orange" style="--sw:#FB923C" aria-label="Orange"></button>
+      <button class="swatch" data-accent="blue" style="--sw:#60A5FA" aria-label="Blue"></button>
+      <button class="swatch" data-accent="teal" style="--sw:#2DD4BF" aria-label="Teal"></button>
     </div>
     <div class="panel-note" data-i18n="appearance.note">Mismos tokens que la app — pruébalo en vivo.</div>
   </div>

--- a/web/index.html
+++ b/web/index.html
@@ -621,18 +621,6 @@
       <button data-mode="light" data-i18n="appearance.light">Claro</button>
       <button data-mode="system" data-i18n="appearance.system">Auto</button>
     </div>
-    <div class="label text-muted" style="margin:0.9rem 0 0.5rem;" data-i18n="appearance.accent">Acento</div>
-    <div class="swatches" id="accentSwatches">
-      <button class="swatch" data-accent="cyan" style="--sw:#22D3EE" aria-label="Cyan"></button>
-      <button class="swatch" data-accent="violet" style="--sw:#A78BFA" aria-label="Violet"></button>
-      <button class="swatch" data-accent="emerald" style="--sw:#34D399" aria-label="Emerald"></button>
-      <button class="swatch" data-accent="amber" style="--sw:#FBBF24" aria-label="Amber"></button>
-      <button class="swatch" data-accent="rose" style="--sw:#FB7185" aria-label="Rose"></button>
-      <button class="swatch" data-accent="orange" style="--sw:#FB923C" aria-label="Orange"></button>
-      <button class="swatch" data-accent="blue" style="--sw:#60A5FA" aria-label="Blue"></button>
-      <button class="swatch" data-accent="teal" style="--sw:#2DD4BF" aria-label="Teal"></button>
-    </div>
-    <div class="panel-note" data-i18n="appearance.note">Mismos tokens que la app — pruébalo en vivo.</div>
   </div>
 
   <!-- ============ LIGHTBOX CAPTURAS ============ -->

--- a/web/index.html
+++ b/web/index.html
@@ -620,7 +620,13 @@
   <!-- ============ LIGHTBOX CAPTURAS ============ -->
   <div id="lightbox" class="lightbox" hidden aria-hidden="true">
     <button class="lightbox-close" id="lightboxClose" data-i18n-aria="lightbox.close" aria-label="Cerrar">×</button>
+    <button class="lightbox-arrow prev" id="lightboxPrev" data-i18n-aria="lightbox.prev" aria-label="Captura anterior">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" width="20" height="20" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
+    </button>
     <img id="lightboxImg" class="lightbox-img" src="" alt="" data-i18n-alt="lightbox.alt" />
+    <button class="lightbox-arrow next" id="lightboxNext" data-i18n-aria="lightbox.next" aria-label="Captura siguiente">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" width="20" height="20" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>
+    </button>
     <p class="lightbox-caption" id="lightboxCaption"></p>
   </div>
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -225,6 +225,11 @@ section.block { padding: 5rem 0; }
   .club-copy .lead { max-width: 48rem; }
 }
 
+/* ---------- acerca de mí ---------- */
+.about-body { max-width: 52rem; margin-top: 1.5rem; }
+.about-body p { color: rgb(var(--text-secondary)); font-size: 1.1rem; line-height: 1.65; margin: 0 0 1rem; }
+.about-body p:last-child { margin-bottom: 0; }
+
 /* ---------- teatro sticky ---------- */
 .theater { display: grid; grid-template-columns: 38% 62%; gap: 1.75rem; align-items: start; margin-top: 2rem; }
 .theater-steps { display: flex; flex-direction: column; gap: 48vh; padding-bottom: 30vh; }

--- a/web/styles.css
+++ b/web/styles.css
@@ -34,7 +34,7 @@ html.light {
   --text-primary: 15 23 42;
   --text-secondary: 71 85 105;
   --text-muted: 76 88 104;
-  --accent: 8 145 178;
+  --accent: 14 116 144;
   --tunnel: 124 58 237;
   --ok: 5 150 105;
   --warn: 217 119 6;
@@ -46,9 +46,17 @@ html.light {
 html[data-accent="violet"] { --accent: 167 139 250; }
 html[data-accent="emerald"] { --accent: 52 211 153; }
 html[data-accent="amber"]   { --accent: 251 191 36; }
+html[data-accent="rose"]    { --accent: 251 113 133; }
+html[data-accent="orange"]  { --accent: 251 146 60; }
+html[data-accent="blue"]    { --accent: 96 165 250; }
+html[data-accent="teal"]    { --accent: 45 212 191; }
 html.light[data-accent="violet"] { --accent: 124 58 237; }
-html.light[data-accent="emerald"] { --accent: 5 150 105; }
-html.light[data-accent="amber"]   { --accent: 217 119 6; }
+html.light[data-accent="emerald"] { --accent: 4 120 87; }
+html.light[data-accent="amber"]   { --accent: 180 83 9; }
+html.light[data-accent="rose"]    { --accent: 190 18 60; }
+html.light[data-accent="orange"]  { --accent: 194 65 12; }
+html.light[data-accent="blue"]    { --accent: 29 78 216; }
+html.light[data-accent="teal"]    { --accent: 15 118 110; }
 
 /* ---------- base ---------- */
 * { box-sizing: border-box; border-color: rgb(var(--border)); }

--- a/web/styles.css
+++ b/web/styles.css
@@ -207,14 +207,6 @@ section.block { padding: 5rem 0; }
 .reveal { opacity: 0; transform: translateY(26px); transition: opacity 650ms ease, transform 650ms ease; }
 .reveal.in { opacity: 1; transform: none; }
 
-/* principios */
-.principles { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.25rem; margin-top: 2.75rem; }
-.principle { padding: 1.75rem; position: relative; overflow: hidden; }
-.principle svg.big { width: 2.2rem; height: 2.2rem; margin-bottom: 1.25rem; }
-.principle h3 { font-family: "Space Grotesk", sans-serif; font-size: 1.35rem; margin: 0 0 0.6rem; }
-.principle p { margin: 0; color: rgb(var(--text-secondary)); font-size: 0.95rem; line-height: 1.55; }
-@media (max-width: 860px) { .principles { grid-template-columns: 1fr; } }
-
 /* ---------- teatro sticky ---------- */
 .theater { display: grid; grid-template-columns: 38% 62%; gap: 1.75rem; align-items: start; margin-top: 2rem; }
 .theater-steps { display: flex; flex-direction: column; gap: 48vh; padding-bottom: 30vh; }

--- a/web/styles.css
+++ b/web/styles.css
@@ -43,21 +43,6 @@ html.light {
   color-scheme: light;
 }
 
-html[data-accent="violet"] { --accent: 167 139 250; }
-html[data-accent="emerald"] { --accent: 52 211 153; }
-html[data-accent="amber"]   { --accent: 251 191 36; }
-html[data-accent="rose"]    { --accent: 251 113 133; }
-html[data-accent="orange"]  { --accent: 251 146 60; }
-html[data-accent="blue"]    { --accent: 96 165 250; }
-html[data-accent="teal"]    { --accent: 45 212 191; }
-html.light[data-accent="violet"] { --accent: 124 58 237; }
-html.light[data-accent="emerald"] { --accent: 4 120 87; }
-html.light[data-accent="amber"]   { --accent: 180 83 9; }
-html.light[data-accent="rose"]    { --accent: 190 18 60; }
-html.light[data-accent="orange"]  { --accent: 194 65 12; }
-html.light[data-accent="blue"]    { --accent: 29 78 216; }
-html.light[data-accent="teal"]    { --accent: 15 118 110; }
-
 /* ---------- base ---------- */
 * { box-sizing: border-box; border-color: rgb(var(--border)); }
 html { scroll-behavior: smooth; -webkit-tap-highlight-color: transparent; }
@@ -465,15 +450,6 @@ html[dir="rtl"] .appearance-panel { right: auto; left: 1.25rem; }
   font-family: inherit;
 }
 .seg button.on { background: rgb(var(--accent) / 0.12); border-color: rgb(var(--accent) / 0.5); color: rgb(var(--accent)); }
-.swatches { display: flex; gap: 0.75rem; }
-.swatch {
-  width: 1.85rem; height: 1.85rem; border-radius: 50%; cursor: pointer; border: 2px solid transparent;
-  position: relative; background: rgb(var(--sw));
-  transition: transform 120ms ease, box-shadow 120ms ease;
-}
-.swatch:hover { transform: scale(1.12); box-shadow: 0 0 16px -2px rgb(var(--sw) / 0.55); }
-.swatch.on { border-color: rgb(var(--text-primary)); box-shadow: 0 0 0 2px rgb(var(--surface)), 0 0 0 4px rgb(var(--text-primary) / 0.5); }
-.panel-note { margin-top: 0.9rem; font-size: 0.75rem; color: rgb(var(--text-muted)); }
 
 /* ---------- i18n / rtl ---------- */
 html[dir="rtl"] .mini-stat { border-left: none; border-right: 1px solid rgb(var(--border)); padding-left: 0; padding-right: 1.25rem; }

--- a/web/styles.css
+++ b/web/styles.css
@@ -552,3 +552,15 @@ html[dir="rtl"] .honest { border-left: none; border-right: 3px solid rgb(var(--w
 }
 .lightbox-close:hover { background: rgb(255 255 255 / 0.15); }
 .lightbox-close:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.lightbox-arrow {
+  position: absolute; top: 50%; transform: translateY(-50%);
+  width: 46px; height: 46px; border-radius: 50%;
+  border: 1px solid rgb(255 255 255 / 0.3);
+  background: rgb(0 0 0 / 0.4); color: #fff;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer; z-index: 1;
+}
+.lightbox-arrow.prev { left: 1.5rem; }
+.lightbox-arrow.next { right: 1.5rem; }
+.lightbox-arrow:hover { background: rgb(255 255 255 / 0.15); }
+.lightbox-arrow:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }

--- a/web/styles.css
+++ b/web/styles.css
@@ -207,6 +207,16 @@ section.block { padding: 5rem 0; }
 .reveal { opacity: 0; transform: translateY(26px); transition: opacity 650ms ease, transform 650ms ease; }
 .reveal.in { opacity: 1; transform: none; }
 
+/* ---------- club cloudless ---------- */
+.club-inner { display: flex; align-items: center; gap: 2.5rem; }
+.club-copy { flex: 1; min-width: 0; }
+.club-copy .lead { max-width: none; }
+.club-cta { flex-shrink: 0; white-space: nowrap; }
+@media (max-width: 860px) {
+  .club-inner { flex-direction: column; align-items: flex-start; gap: 1.5rem; }
+  .club-copy .lead { max-width: 48rem; }
+}
+
 /* ---------- teatro sticky ---------- */
 .theater { display: grid; grid-template-columns: 38% 62%; gap: 1.75rem; align-items: start; margin-top: 2rem; }
 .theater-steps { display: flex; flex-direction: column; gap: 48vh; padding-bottom: 30vh; }


### PR DESCRIPTION
Sustituye la sección de principios de la landing por un bloque que enlaza al Club Cloudless (cloudless.club), añade la sección 'Acerca de mí' con la historia del autor y simplifica el panel de apariencia a solo tema (sin acentos).

- `#principles` → `#club` con botón a https://cloudless.club
- Nueva sección `#about` 'Acerca de mí' (2 párrafos personales, ES/EN)
- Panel de apariencia: solo selector de tema; limpiado el código de acentos (JS/CSS/i18n)
- Fix bug fondo canvas (colores reales por tema) + flechas prev/next en el lightbox

Closes #42