### PR TITLE
fix(server): rollup nocturno — up_min en minutos + flag NETPULSE_ROLLUP (repair)

### DIFF
--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -68,6 +68,26 @@ func run() error {
 		return err
 	}
 
+	// Modo mantenimiento: `-rollup` ejecuta el rollup nocturno de la escalera
+	// de retención y sale. Con `-rollup-repair` primero purga metrics_buckets
+	// y metrics_daily (útil tras un rollup previo mal formado, issue #54).
+	if os.Getenv("NETPULSE_ROLLUP") == "1" {
+		if os.Getenv("NETPULSE_ROLLUP_REPAIR") == "1" {
+			log.Print("[netpulse] rollup: purgando metrics_buckets y metrics_daily")
+			if _, err := dbHandle.Exec("DELETE FROM metrics_buckets"); err != nil {
+				return err
+			}
+			if _, err := dbHandle.Exec("DELETE FROM metrics_daily"); err != nil {
+				return err
+			}
+		}
+		log.Print("[netpulse] rollup: ejecutando NightlyJob (buckets 5 min + daily)")
+		dbHandle.NightlyJob()
+		_ = dbHandle.Close()
+		log.Print("[netpulse] rollup: OK")
+		os.Exit(0)
+	}
+
 	secret, err := auth.EnsureSessionSecret(dbHandle, cfg)
 	if err != nil {
 		return err

--- a/server-go/internal/db/db.go
+++ b/server-go/internal/db/db.go
@@ -78,7 +78,10 @@ CREATE TABLE IF NOT EXISTS metrics_daily (
   cpu_avg REAL, ram_avg REAL, temp_avg REAL,
   lat_avg REAL, rx_avg REAL, tx_avg REAL,
   rx_total REAL, tx_total REAL,
+  -- up_min: minutos de recolección del día (SUM(n) * 5 / 60; n = muestras a
+  -- 5 s → día completo ≈ 17280 muestras ≈ 1440 min).
   up_min INTEGER NOT NULL DEFAULT 0,
+  -- up_count: nº de buckets de 5 min con datos (288 = día completo).
   up_count INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (router_id, date)
 );
@@ -350,7 +353,7 @@ func (d *DB) rollupBucketsToDaily(window time.Duration) error {
 			AVG(cpu_avg), AVG(ram_avg), AVG(temp_avg),
 			AVG(lat_avg), AVG(rx_avg), AVG(tx_avg),
 			SUM(rx_avg * n), SUM(tx_avg * n),
-			MIN(min_ts), COUNT(*)
+			SUM(n) * 5 / 60, COUNT(*)
 		FROM metrics_buckets
 		WHERE bucket_ts >= ?
 		GROUP BY router_id, strftime('%Y-%m-%d', bucket_ts / 1000, 'unixepoch')`,

--- a/server-go/internal/db/rollup_test.go
+++ b/server-go/internal/db/rollup_test.go
@@ -77,6 +77,27 @@ func TestRollupSamplesToBucketsYDaily(t *testing.T) {
 		t.Fatalf("daily n = %d, esperaba 3", dn)
 	}
 
+	// up_min en MINUTOS (issue #54): 3 muestras a 5 s → 0 min (3*5/60 = 0).
+	var upMin, upCount int
+	if err := d.QueryRow("SELECT up_min, up_count FROM metrics_daily WHERE router_id='r1'").Scan(&upMin, &upCount); err != nil {
+		t.Fatalf("query daily up_min/up_count: %v", err)
+	}
+	if upMin != 0 {
+		t.Fatalf("up_min = %d, esperaba 0 (3 muestras * 5 s / 60 = 0 min)", upMin)
+	}
+	if upCount != 1 {
+		t.Fatalf("up_count = %d, esperaba 1 (un bucket de 5 min)", upCount)
+	}
+
+	// Los buckets deben estar alineados a BucketMS (5 min): bucket_ts % 300000 == 0.
+	var tsAligned int64
+	if err := d.QueryRow("SELECT bucket_ts % 300000 FROM metrics_buckets WHERE router_id='r1'").Scan(&tsAligned); err != nil {
+		t.Fatalf("query bucket_ts: %v", err)
+	}
+	if tsAligned != 0 {
+		t.Fatalf("bucket_ts no alineado a 5 min (mod 300000 = %d)", tsAligned)
+	}
+
 	// Idempotencia: repetir el rollup no cambia los agregados (REPLACE).
 	d.NightlyJob()
 	var n2 int


### PR DESCRIPTION
Closes #54

## Qué
1. **up_min en minutos reales** (db.go rollupBucketsToDaily): antes guardaba MIN(min_ts) (timestamp). Ahora SUM(n) * 5 / 60 (n = muestras a 5 s; día completo ≈ 17280 muestras ≈ 1440 min). Comentado en el schema.
2. **Flag de mantenimiento** en cmd/netpulse: NETPULSE_ROLLUP=1 ejecuta NightlyJob y sale; con NETPULSE_ROLLUP_REPAIR=1 primero purga metrics_buckets y metrics_daily (issue #54: residuos de un rollup manual previo con bucket_ts sin alinear).

## Verificación
- Test extendido: up_min en minutos (3 muestras → 0 min), up_count = buckets, bucket_ts alineado a 300000 ms. Suite completa verde.
- **Aplicado en prod (CT 226)**: purga + rollup → buckets de 5 min alineados (n 1-61), daily del 05 = 1390 min (283/288 buckets), 06 parcial = 740 min. Endpoint /api/reports/weekly refleja los minutos reales. Health live 4/4 agentes. Backups: netpulse.db.bak-pre-rollup + netpulse.bak-pre-rollup.
- Pendiente (issue aparte): lat_avg NULL porque las últimas 48h metrics.latency_ms es NULL.
