### PR TITLE
fix(web): bloque Club Cloudless — CTA 'Conocer el club' junto al texto (fullHD)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -28,7 +28,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css?v=20260806c" />
+  <link rel="stylesheet" href="styles.css?v=20260806d" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -181,10 +181,8 @@
     <div class="container">
       <div class="club-inner reveal">
         <div class="club-copy">
-          <div class="club-head">
-            <span class="eyebrow" data-i18n="club.eyebrow">Parte del Club Cloudless</span>
-            <h2 class="font-display text-balance" data-i18n="club.title">Los principios del club</h2>
-          </div>
+          <span class="eyebrow" data-i18n="club.eyebrow">Parte del Club Cloudless</span>
+          <h2 class="font-display text-balance" data-i18n="club.title">Los principios del club</h2>
           <div class="club-body">
             <p class="lead" data-i18n="club.lead">NetPulse sigue los tres principios del Club Cloudless: soberanía digital, libre para siempre y de personas, no de empresas. Son comunes a todas las apps del club y viven en un único sitio.</p>
             <a class="btn-primary club-cta" href="https://cloudless.club" target="_blank" rel="noopener">
@@ -640,7 +638,7 @@
     <p class="lightbox-caption" id="lightboxCaption"></p>
   </div>
 
-  <script src="i18n.js?v=20260806c"></script>
-  <script src="app.js?v=20260806c"></script>
+  <script src="i18n.js?v=20260806d"></script>
+  <script src="app.js?v=20260806d"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -28,7 +28,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css?v=20260806b" />
+  <link rel="stylesheet" href="styles.css?v=20260806c" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -181,14 +181,18 @@
     <div class="container">
       <div class="club-inner reveal">
         <div class="club-copy">
-          <span class="eyebrow" data-i18n="club.eyebrow">Parte del Club Cloudless</span>
-          <h2 class="font-display text-balance" data-i18n="club.title">Los principios del club</h2>
-          <p class="lead" data-i18n="club.lead">NetPulse sigue los tres principios del Club Cloudless: soberanía digital, libre para siempre y de personas, no de empresas. Son comunes a todas las apps del club y viven en un único sitio.</p>
+          <div class="club-head">
+            <span class="eyebrow" data-i18n="club.eyebrow">Parte del Club Cloudless</span>
+            <h2 class="font-display text-balance" data-i18n="club.title">Los principios del club</h2>
+          </div>
+          <div class="club-body">
+            <p class="lead" data-i18n="club.lead">NetPulse sigue los tres principios del Club Cloudless: soberanía digital, libre para siempre y de personas, no de empresas. Son comunes a todas las apps del club y viven en un único sitio.</p>
+            <a class="btn-primary club-cta" href="https://cloudless.club" target="_blank" rel="noopener">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/><line x1="4" y1="4" x2="20" y2="20"/></svg>
+              <span data-i18n="club.cta">Conocer el club</span>
+            </a>
+          </div>
         </div>
-        <a class="btn-primary club-cta" href="https://cloudless.club" target="_blank" rel="noopener">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/><line x1="4" y1="4" x2="20" y2="20"/></svg>
-          <span data-i18n="club.cta">Conocer el club</span>
-        </a>
       </div>
     </div>
   </section>
@@ -636,7 +640,7 @@
     <p class="lightbox-caption" id="lightboxCaption"></p>
   </div>
 
-  <script src="i18n.js?v=20260806b"></script>
-  <script src="app.js?v=20260806b"></script>
+  <script src="i18n.js?v=20260806c"></script>
+  <script src="app.js?v=20260806c"></script>
 </body>
 </html>

--- a/web/styles.css
+++ b/web/styles.css
@@ -203,11 +203,20 @@ section.block { padding: 5rem 0; }
 /* ---------- club cloudless ---------- */
 .club-inner { display: flex; align-items: center; gap: 2.5rem; }
 .club-copy { flex: 1; min-width: 0; }
-.club-copy .lead { max-width: none; }
+/* Cabecera: eyebrow + título en la misma línea (fullHD). El h2 del bloque
+   (clamp hasta 5rem) no cabía junto al eyebrow, así que aquí se compacta. */
+.club-head { display: flex; align-items: baseline; flex-wrap: nowrap; gap: 0.5rem 1.25rem; }
+.club-head .eyebrow { margin: 0; flex-shrink: 0; }
+.club-head h2 { margin: 0; font-size: clamp(1.9rem, 4.5vw, 3.4rem); }
+/* Cuerpo: texto + CTA al lado (fullHD). */
+.club-body { display: flex; align-items: center; gap: 2rem; }
+.club-body .lead { flex: 1; min-width: 0; margin-top: 1.25rem; max-width: none; }
 .club-cta { flex-shrink: 0; white-space: nowrap; }
 @media (max-width: 860px) {
   .club-inner { flex-direction: column; align-items: flex-start; gap: 1.5rem; }
-  .club-copy .lead { max-width: 48rem; }
+  .club-head { flex-direction: column; align-items: flex-start; gap: 0.15rem; }
+  .club-body { flex-direction: column; align-items: flex-start; gap: 1.25rem; }
+  .club-body .lead { max-width: 48rem; }
 }
 
 /* ---------- acerca de mí ---------- */

--- a/web/styles.css
+++ b/web/styles.css
@@ -203,18 +203,12 @@ section.block { padding: 5rem 0; }
 /* ---------- club cloudless ---------- */
 .club-inner { display: flex; align-items: center; gap: 2.5rem; }
 .club-copy { flex: 1; min-width: 0; }
-/* Cabecera: eyebrow + título en la misma línea (fullHD). El h2 del bloque
-   (clamp hasta 5rem) no cabía junto al eyebrow, así que aquí se compacta. */
-.club-head { display: flex; align-items: baseline; flex-wrap: nowrap; gap: 0.5rem 1.25rem; }
-.club-head .eyebrow { margin: 0; flex-shrink: 0; }
-.club-head h2 { margin: 0; font-size: clamp(1.9rem, 4.5vw, 3.4rem); }
 /* Cuerpo: texto + CTA al lado (fullHD). */
 .club-body { display: flex; align-items: center; gap: 2rem; }
-.club-body .lead { flex: 1; min-width: 0; margin-top: 1.25rem; max-width: none; }
+.club-body .lead { flex: 1; min-width: 0; margin-top: 1rem; max-width: none; }
 .club-cta { flex-shrink: 0; white-space: nowrap; }
 @media (max-width: 860px) {
   .club-inner { flex-direction: column; align-items: flex-start; gap: 1.5rem; }
-  .club-head { flex-direction: column; align-items: flex-start; gap: 0.15rem; }
   .club-body { flex-direction: column; align-items: flex-start; gap: 1.25rem; }
   .club-body .lead { max-width: 48rem; }
 }


### PR DESCRIPTION
## Qué
En el bloque #club de la landing: el botón 'Conocer el club' (CTA a cloudless.club) se coloca **al lado del texto** en fullHD. Eyebrow ('Parte del Club Cloudless') y título ('Principios del club cloudless') se mantienen **apilados** en sus líneas (como el resto de bloques).

Estructura: .club-copy > eyebrow, h2, .club-body (lead + CTA en fila en fullHD; apilado en móvil <860px).

## Verificación
- Playwright local y PROD (netpulse.cloudless.club): eyebrow/título en líneas separadas ✓, CTA al lado del texto y a la derecha ✓, 0 errores JS. Móvil apilado ✓.
- Desplegado en VPS npm2 (/opt/netpulse-web/public, backup backup-pre-club-layout). Bump assets a ?v=20260806d.