### PR TITLE
fix(server): nil-encapsulado en notifierChain paniquea el poller (#57)

### DIFF
--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"syscall"
 	"time"
@@ -158,8 +159,19 @@ func run() error {
 	}
 
 	// Notifier compuesto: push + webhook (SetNotifier solo admite UNO).
+	// OJO nil-encapsulado (issue #57): meter un `(*webhook.Notifier)(nil)` en
+	// la cadena lo empaqueta en la interfaz con tipo pero valor nil → la
+	// interfaz NO es nil y `if n != nil` de notifierChain no lo filtra →
+	// panic al Notify. Filtrar ANTES de empaquetar.
 	if pushNotifier != nil || webhookNotifier != nil {
-		adapter.AlertsEngine().SetNotifier(notifierChain{pushNotifier, webhookNotifier})
+		chain := notifierChain{}
+		if pushNotifier != nil {
+			chain = append(chain, pushNotifier)
+		}
+		if webhookNotifier != nil {
+			chain = append(chain, webhookNotifier)
+		}
+		adapter.AlertsEngine().SetNotifier(chain)
 	}
 
 	// Dependencia sse↔poller resuelta con un holder (como index.js:40-45).
@@ -211,16 +223,16 @@ func run() error {
 	})
 
 	handler := httpapi.NewHandler(httpapi.Deps{
-		Config:  cfg,
-		DB:      dbHandle,
-		Adapter: adapter,
-		Hub:     hub,
-		Secret:  secret,
-		Static:  static,
-		Updater: upd,
-		Agents:  agentReg,
-		Pool:    sshPool,
-		Rearmer: arm,
+		Config:   cfg,
+		DB:       dbHandle,
+		Adapter:  adapter,
+		Hub:      hub,
+		Secret:   secret,
+		Static:   static,
+		Updater:  upd,
+		Agents:   agentReg,
+		Pool:     sshPool,
+		Rearmer:  arm,
 		AgentHub: agentHub,
 		LastOverview: func() *adapters.Overview {
 			return p.LastOverview()
@@ -312,8 +324,14 @@ type notifierChain []alerts.Notifier
 
 func (c notifierChain) Notify(ev alerts.AlertEvent) {
 	for _, n := range c {
-		if n != nil {
-			n.Notify(ev)
+		if n == nil {
+			continue
 		}
+		// Defensa en profundidad (issue #57): si un nil-encapsulado entra en
+		// la cadena, la interfaz no es nil pero el valor sí. No debe paniquear.
+		if reflect.ValueOf(n).Kind() == reflect.Ptr && reflect.ValueOf(n).IsNil() {
+			continue
+		}
+		n.Notify(ev)
 	}
 }

--- a/server-go/cmd/netpulse/main_test.go
+++ b/server-go/cmd/netpulse/main_test.go
@@ -1,0 +1,38 @@
+// main_test.go — regresión issue #57: notifierChain no debe paniquear con un
+// nil-encapsulado (interfaz con tipo pero valor nil) entre sus miembros.
+package main
+
+import (
+	"testing"
+
+	"github.com/gnacho/netpulse/server-go/internal/alerts"
+)
+
+// nilNotifier implementa alerts.Notifier; un puntero nil a este tipo,
+// empaquetado en la interfaz, simula el bug (interfaz no-nil, valor nil).
+// Notify accede a un campo del receiver (como webhook.Notifier.Notify accede
+// a n.done/n.ch): con receiver nil esto paniquea si no se filtra.
+type nilNotifier struct {
+	done chan struct{}
+}
+
+func (n *nilNotifier) Notify(alerts.AlertEvent) {
+	_ = n.done // accede al receiver: con n nil → panic (como webhook.Notify)
+}
+
+func TestNotifierChainIgnoraNilEncapsulado(t *testing.T) {
+	// Cadena con: notifier real + puntero nil a *nilNotifier empaquetado en
+	// la interfaz. Sin el fix, n.Notify paniquea (receiver nil).
+	var real alerts.Notifier = &nilNotifier{}
+	var nilPtr *nilNotifier
+	chain := notifierChain{real, nilPtr}
+
+	ev := alerts.AlertEvent{ID: "test", Title: "x", Urgent: true}
+	chain.Notify(ev) // no debe paniquear
+}
+
+func TestNotifierChainConNilPlano(t *testing.T) {
+	var real alerts.Notifier = &nilNotifier{}
+	chain := notifierChain{real, nil}
+	chain.Notify(alerts.AlertEvent{ID: "test2"}) // no debe paniquear
+}

--- a/server-go/internal/adapters/repro_panic_test.go
+++ b/server-go/internal/adapters/repro_panic_test.go
@@ -1,0 +1,59 @@
+package adapters
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/agent/probe"
+)
+
+// TestReproNilDerefRealPayloads reproduce el panic del poller (issue #57)
+// con los payloads reales de los 4 agentes extraídos de prod (kv agent.state.*).
+// Ruta: /tmp/opencode/payload-<slug>.json y gateway-payload.json.
+func TestReproNilDerefRealPayloads(t *testing.T) {
+	files := []string{
+		"/tmp/opencode/gateway-payload.json",
+		"/tmp/opencode/payload-redmi-ax6.json",
+		"/tmp/opencode/payload-redmi-ax6-2.json",
+		"/tmp/opencode/payload-redmi-ax6-3.json",
+	}
+	payloads := []*probe.Payload{}
+	for _, f := range files {
+		raw, err := os.ReadFile(f)
+		if err != nil {
+			t.Logf("skip %s: %v", filepath.Base(f), err)
+			continue
+		}
+		var p probe.Payload
+		if err := json.Unmarshal(raw, &p); err != nil {
+			t.Fatalf("unmarshal %s: %v", f, err)
+		}
+		payloads = append(payloads, &p)
+	}
+	if len(payloads) == 0 {
+		t.Skip("sin payloads reales")
+	}
+
+	reg := NewAgentRegistry(90 * time.Second)
+	l := newLiveAgentTest(t, reg)
+	cfg := RouterConfig{ID: "patio", Name: "Patio", Host: "127.0.0.1"}
+
+	// Ingiere todos los payloads (con el slug del test) y sondea en bucle.
+	for _, p := range payloads {
+		cp := *p
+		cp.Router = "patio"
+		reg.Ingest(&cp)
+	}
+	for i := 0; i < 2000; i++ {
+		rp, err := l.pollRouter(t.Context(), cfg)
+		if err != nil {
+			t.Fatalf("pollRouter iter %d: %v", i, err)
+		}
+		_ = l.buildRouter(rp, nil)
+		_ = l.GetMetricsRows(t.Context())
+	}
+	t.Logf("2000 iteraciones con %d payloads reales sin panic", len(payloads))
+}

--- a/server-go/internal/poller/poller.go
+++ b/server-go/internal/poller/poller.go
@@ -10,6 +10,7 @@ package poller
 import (
 	"context"
 	"log"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -105,7 +106,7 @@ func (p *Poller) Stop() {
 func (p *Poller) tick() {
 	defer func() {
 		if rec := recover(); rec != nil {
-			log.Printf("[netpulse] error en tick del poller: %v", rec)
+			log.Printf("[netpulse] error en tick del poller: %v\n%s", rec, debug.Stack())
 		}
 	}()
 	ctx := context.Background()


### PR DESCRIPTION
Closes #57

## Causa raíz (capturada con stack trace del panic real en prod)
El tick del poller paniqueaba (`nil pointer dereference`) al emitir una alerta **urgente** de "dispositivo desconocido" (`emitUnknownDevice`, live.go:890):

```
webhook.(*Notifier).Notify — webhook.go:81   ← panic en n.done
main.notifierChain.Notify — main.go:316      ← el nil-check NO filtra
alerts.(*Engine).Emit — alerts.go:230
adapters.(*Live).emitUnknownDevice — live.go:890
```

**Bug: nil-encapsulado en la interfaz Go.** En main.go la cadena se construía con `notifierChain{pushNotifier, webhookNotifier}`. Cuando `webhookNotifier` es `(*webhook.Notifier)(nil)` (sin WEBHOOK_URL, **inactivo** — nuestro caso), al empaquetarlo en la interfaz `alerts.Notifier` queda **con tipo pero valor nil → la interfaz NO es nil**. El `if n != nil` de `notifierChain.Notify` lo deja pasar → `n.Notify(ev)` con receiver nil → panic al acceder `n.done`.

Este es el **mismo webhook que teníamos INACTIVO** — por eso "no afectaba" hasta que una alerta urgente lo activaba.

## Fix
1. **main.go**: filtrar los notifiers en su tipo concreto ANTES de empaquetar en la interfaz (solo se añaden los no-nil).
2. **notifierChain.Notify**: defensa en profundidad con `reflect` — ignora punteros nil encapsulados por si un futuro cambio reintroduce el patrón.

## Verificación
- Test `TestNotifierChainIgnoraNilEncapsulado`: **falla sin el fix** (mismo panic "invalid memory address") y **pasa con el fix** (confirmación red-green del bug real).
- Suite completa Go verde.
- Instrumentación `debug.Stack()` en el recover del tick (poller.go) añadida para futuros panics.
- Desplegado en CT 226 (backup .bak-pre-fix). En observación ~30 min: los panics ocurrían a los 15-30 min del arranque.
