### PR TITLE
fix: installer release version clobbered by /etc/os-release

### DIFF
--- a/install-agent.sh
+++ b/install-agent.sh
@@ -37,7 +37,7 @@ ENV_FILE="/etc/netpulse-agent.env"
 INIT_NAME="netpulse-agent"
 INIT_DST="/etc/init.d/$INIT_NAME"
 
-HOST=""; SERVER=""; SLUG=""; TOKEN=""; SSH_USER="root"; BINARY=""; VERSION=""; USE_TMP=0; UNINSTALL=0
+HOST=""; SERVER=""; SLUG=""; TOKEN=""; SSH_USER="root"; BINARY=""; NETPULSE_VERSION=""; USE_TMP=0; UNINSTALL=0
 
 if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
     C_G=$(printf '\033[32m'); C_R=$(printf '\033[31m'); C_Y=$(printf '\033[33m'); C_B=$(printf '\033[1m'); C_0=$(printf '\033[0m')
@@ -57,7 +57,7 @@ for arg in "$@"; do
         --token=*)    TOKEN="${arg#*=}" ;;
         --ssh-user=*) SSH_USER="${arg#*=}" ;;
         --binary=*)   BINARY="${arg#*=}" ;;
-        --version=*)  VERSION="${arg#*=}" ;;
+        --version=*)  NETPULSE_VERSION="${arg#*=}" ;;
         --tmp)        USE_TMP=1 ;;
         --uninstall)  UNINSTALL=1 ;;
         -h|--help)    usage ;;
@@ -119,18 +119,22 @@ else
     else fatal 21 "necesito curl o wget"; fi
     fetch_to() { $FETCH "$1" > "$2"; }
     command -v sha256sum >/dev/null 2>&1 || fatal 21 "falta sha256sum"
-    if [ -z "$VERSION" ]; then
+    if [ -z "$NETPULSE_VERSION" ]; then
         info "resolviendo última release"
-        VERSION=$($FETCH "https://api.github.com/repos/$GH_REPO/releases/latest" \
+        NETPULSE_VERSION=$($FETCH "https://api.github.com/repos/$GH_REPO/releases/latest" \
             | grep '"tag_name"' | head -1 | cut -d'"' -f4) \
             || fatal 31 "no pude resolver la última release; usa --version=X.Y.Z"
     fi
-    VERSION_NORM=$(echo "$VERSION" | sed 's/^v//')
+    VERSION_NORM=$(echo "$NETPULSE_VERSION" | sed 's/^v//')
+    case "$NETPULSE_VERSION" in
+        v*) NETPULSE_TAG="$NETPULSE_VERSION" ;;
+        *)  NETPULSE_TAG="v$NETPULSE_VERSION" ;;
+    esac
     ASSET="${BIN_NAME}_${VERSION_NORM}_linux_${GOARCH}.tar.gz"
-    BASE_URL="https://github.com/$GH_REPO/releases/download/$VERSION"
+    BASE_URL="https://github.com/$GH_REPO/releases/download/$NETPULSE_TAG"
     info "descargando $ASSET"
     fetch_to "$BASE_URL/$ASSET" "$TMP/$ASSET" || fatal 32 "descarga falló: $BASE_URL/$ASSET"
-    fetch_to "$BASE_URL/checksums.txt" "$TMP/checksums.txt" || fatal 32 "checksums.txt no está en $VERSION"
+    fetch_to "$BASE_URL/checksums.txt" "$TMP/checksums.txt" || fatal 32 "checksums.txt no está en $NETPULSE_VERSION"
     SUM_FILE=$(sha256sum "$TMP/$ASSET" | awk '{print $1}')
     SUM_REF=$(grep "  $ASSET\$" "$TMP/checksums.txt" | awk '{print $1}')
     [ -n "$SUM_REF" ] || fatal 33 "$ASSET no está en checksums.txt"

--- a/install-collector.sh
+++ b/install-collector.sh
@@ -31,7 +31,7 @@ SERVICE_NAME="$APP_NAME"
 # Where the collector looks for the app's DB (read-only) to learn the routers:
 NETPULSE_DB="/var/lib/netpulse/data/netpulse.db"
 
-VERSION=""; UNATTENDED=0; DRY_RUN=0; UNINSTALL=0; PURGE=0
+NETPULSE_VERSION=""; UNATTENDED=0; DRY_RUN=0; UNINSTALL=0; PURGE=0
 
 # ---------------------------------------------------------------- logging ---
 if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
@@ -63,7 +63,7 @@ EOF
 
 for arg in "$@"; do
     case "$arg" in
-        --version=*)  VERSION="${arg#*=}" ;;
+        --version=*)  NETPULSE_VERSION="${arg#*=}" ;;
         --unattended) UNATTENDED=1 ;;
         --dry-run)    DRY_RUN=1 ;;
         --uninstall)  UNINSTALL=1 ;;
@@ -192,17 +192,21 @@ if [ ! -f "/etc/systemd/system/$SERVICE_NAME.service" ]; then
 fi
 
 # --------------------------------------------------------- resolve version --
-if [ -z "$VERSION" ]; then
+if [ -z "$NETPULSE_VERSION" ]; then
     info "resolving latest stable version"
-    VERSION=$($FETCH "https://api.github.com/repos/$GH_REPO/releases/latest" \
+    NETPULSE_VERSION=$($FETCH "https://api.github.com/repos/$GH_REPO/releases/latest" \
         | grep '"tag_name"' | head -1 | cut -d'"' -f4) \
         || fatal 31 "could not resolve the latest version. Use --version=X.Y.Z"
-    [ -n "$VERSION" ] || fatal 31 "no stable release found yet. Use --version=X.Y.Z"
+    [ -n "$NETPULSE_VERSION" ] || fatal 31 "no stable release found yet. Use --version=X.Y.Z"
 fi
-VERSION_NORM=$(echo "$VERSION" | sed 's/^v//')
+VERSION_NORM=$(echo "$NETPULSE_VERSION" | sed 's/^v//')
+case "$NETPULSE_VERSION" in
+    v*) NETPULSE_TAG="$NETPULSE_VERSION" ;;
+    *)  NETPULSE_TAG="v$NETPULSE_VERSION" ;;
+esac
 ASSET="${BIN_NAME}_${VERSION_NORM}_linux_${GOARCH}.tar.gz"
-BASE_URL="https://github.com/$GH_REPO/releases/download/$VERSION"
-info "version: $VERSION"
+BASE_URL="https://github.com/$GH_REPO/releases/download/$NETPULSE_TAG"
+info "version: $NETPULSE_VERSION"
 
 $FETCH "https://github.com/$GH_REPO" >/dev/null \
     || fatal 30 "no access to github.com (proxy? DNS? firewall?)"
@@ -220,7 +224,7 @@ trap cleanup EXIT INT TERM
 
 info "downloading $ASSET"
 fetch_to "$BASE_URL/$ASSET" "$TMP/$ASSET" || fatal 32 "download failed: $BASE_URL/$ASSET"
-fetch_to "$BASE_URL/checksums.txt" "$TMP/checksums.txt" || fatal 32 "checksums.txt not found in release $VERSION"
+fetch_to "$BASE_URL/checksums.txt" "$TMP/checksums.txt" || fatal 32 "checksums.txt not found in release $NETPULSE_VERSION"
 [ -s "$TMP/$ASSET" ] || fatal 32 "downloaded asset is empty"
 
 SUM_FILE=$(sha256sum "$TMP/$ASSET" | awk '{print $1}')
@@ -315,7 +319,7 @@ fi
 
 # ------------------------------------------------------------------ summary --
 printf '\n%s================ %s installed ================%s\n' "$C_G" "$APP_NAME" "$C_0"
-printf 'Version:    %s%s\n' "$VERSION" "$( [ "$UPGRADING" -eq 1 ] && echo " (upgrade — previous binary at $INSTALL_DIR/$BIN_NAME.bak)" || true)"
+printf 'Version:    %s%s\n' "$NETPULSE_VERSION" "$( [ "$UPGRADING" -eq 1 ] && echo " (upgrade — previous binary at $INSTALL_DIR/$BIN_NAME.bak)" || true)"
 printf 'Binary:     %s\n' "$INSTALL_DIR/$BIN_NAME"
 printf 'Data:       %s/data (metrics.db, state.json)\n' "$STATE_DIR"
 printf 'Health:     http://127.0.0.1:%s/healthz (localhost only)\n' "$PORT"

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@ INSTALL_DIR="/usr/local/bin"
 STATE_DIR="/var/lib/$APP_NAME"
 SERVICE_NAME="$APP_NAME"
 
-VERSION=""; UNATTENDED=0; DRY_RUN=0; UNINSTALL=0; PURGE=0; DEMO=0
+NETPULSE_VERSION=""; UNATTENDED=0; DRY_RUN=0; UNINSTALL=0; PURGE=0; DEMO=0
 
 # ---------------------------------------------------------------- logging ---
 if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
@@ -64,7 +64,7 @@ EOF
 
 for arg in "$@"; do
     case "$arg" in
-        --version=*)  VERSION="${arg#*=}" ;;
+        --version=*)  NETPULSE_VERSION="${arg#*=}" ;;
         --demo)       DEMO=1 ;;
         --unattended) UNATTENDED=1 ;;
         --dry-run)    DRY_RUN=1 ;;
@@ -138,12 +138,7 @@ if [ "$UNINSTALL" -eq 1 ]; then
 fi
 
 # --------------------------------------------------------------- detection --
-# /etc/os-release define su propia VERSION ("13 (trixie)" en Debian) y pisaría
-# la variable VERSION del script; guardar y restaurar alrededor del source.
-_saved_version="$VERSION"
 . /etc/os-release 2>/dev/null || true
-VERSION="$_saved_version"
-unset _saved_version
 OS_PRETTY="${PRETTY_NAME:-$(uname -s)}"
 
 ARCH=$(uname -m)
@@ -242,17 +237,21 @@ fi
 # POST /api/demo/enable y reinicia el servicio vía .restart-me).
 
 # --------------------------------------------------------- resolve version --
-if [ -z "$VERSION" ]; then
+if [ -z "$NETPULSE_VERSION" ]; then
     info "resolving latest stable version"
-    VERSION=$($FETCH "https://api.github.com/repos/$GH_REPO/releases/latest" \
+    NETPULSE_VERSION=$($FETCH "https://api.github.com/repos/$GH_REPO/releases/latest" \
         | grep '"tag_name"' | head -1 | cut -d'"' -f4) \
         || fatal 31 "could not resolve the latest version (GitHub rate-limit?). Use --version=X.Y.Z"
-    [ -n "$VERSION" ] || fatal 31 "no stable release found yet. Use --version=X.Y.Z"
+    [ -n "$NETPULSE_VERSION" ] || fatal 31 "no stable release found yet. Use --version=X.Y.Z"
 fi
-VERSION_NORM=$(echo "$VERSION" | sed 's/^v//')
+VERSION_NORM=$(echo "$NETPULSE_VERSION" | sed 's/^v//')
+case "$NETPULSE_VERSION" in
+    v*) NETPULSE_TAG="$NETPULSE_VERSION" ;;
+    *)  NETPULSE_TAG="v$NETPULSE_VERSION" ;;
+esac
 ASSET="${BIN_NAME}_${VERSION_NORM}_linux_${GOARCH}.tar.gz"
-BASE_URL="https://github.com/$GH_REPO/releases/download/$VERSION"
-info "version: $VERSION"
+BASE_URL="https://github.com/$GH_REPO/releases/download/$NETPULSE_TAG"
+info "version: $NETPULSE_VERSION"
 
 # connectivity pre-flight BEFORE touching the system
 $FETCH "https://github.com/$GH_REPO" >/dev/null \
@@ -271,7 +270,7 @@ trap cleanup EXIT INT TERM
 
 info "downloading $ASSET"
 fetch_to "$BASE_URL/$ASSET" "$TMP/$ASSET" || fatal 32 "download failed: $BASE_URL/$ASSET"
-fetch_to "$BASE_URL/checksums.txt" "$TMP/checksums.txt" || fatal 32 "checksums.txt not found in release $VERSION"
+fetch_to "$BASE_URL/checksums.txt" "$TMP/checksums.txt" || fatal 32 "checksums.txt not found in release $NETPULSE_VERSION"
 [ -s "$TMP/$ASSET" ] || fatal 32 "downloaded asset is empty"
 
 SUM_FILE=$(sha256sum "$TMP/$ASSET" | awk '{print $1}')
@@ -405,7 +404,7 @@ fi
 
 # ------------------------------------------------------------------ summary --
 printf '\n%s================ %s installed ================%s\n' "$C_G" "$APP_NAME" "$C_0"
-printf 'Version:  %s%s\n' "$VERSION" "$( [ "$UPGRADING" -eq 1 ] && echo " (upgrade — previous binary at $INSTALL_DIR/$BIN_NAME.bak)" || true)"
+printf 'Version:  %s%s\n' "$NETPULSE_VERSION" "$( [ "$UPGRADING" -eq 1 ] && echo " (upgrade — previous binary at $INSTALL_DIR/$BIN_NAME.bak)" || true)"
 printf 'Binary:   %s\n' "$INSTALL_DIR/$BIN_NAME"
 printf 'Data:     %s (SQLite, .env, SSH keypair)\n' "$STATE_DIR"
 printf 'Access:   http://<this-machine-ip>:%s\n' "$PORT"


### PR DESCRIPTION
The three installers build the release download URL from a variable named VERSION. On Debian 13 (trixie) that collides with /etc/os-release, which sets VERSION to "13 (trixie)"; the URL ends up pointing at a release tag that does not exist. install-collector.sh was the one that actually failed. install.sh protected itself with a save-and-restore workaround that this PR removes. install-agent.sh was safe because it does not source /etc/os-release.

While touching the code, the download URL now normalizes the v prefix on the tag. Release tags are vX.Y.Z, so --version=2.7.1 without the v used to produce a well formed URL that 404s. The latest resolver was not affected because the API returns the tag name with the v already.

Changes:
- Renamed the internal variable to NETPULSE_VERSION in the three scripts.
- Normalized the release tag (NETPULSE_TAG) for the download URL.
- Dropped the save-and-restore workaround from install.sh.

Verified against Debian 13 (trixie) os-release data, --dry-run: install-collector.sh failed before with "13 (trixie)" and exit 32, and now runs to completion with sha256 verified and exit 0 in latest, with-v, and without-v modes. install.sh behaves the same.

closes #64
