### PR TITLE
fix(live): single-flight panic recovery and correct N-follower broadcast

### DIFF
--- a/server-go/internal/adapters/adapters_test.go
+++ b/server-go/internal/adapters/adapters_test.go
@@ -5,7 +5,12 @@ package adapters
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/alerts"
+	"github.com/gnacho/netpulse/server-go/internal/config"
 )
 
 // --- snapshot.test.js: el PRIMER snapshot del demo es el canon EXACTO ---
@@ -584,5 +589,101 @@ func TestDemoRouterLldpCanon(t *testing.T) {
 	}
 	if seen != 4 {
 		t.Fatalf("routers: %d", seen)
+	}
+}
+
+// --- Regresión single-flight GetOverview ---
+
+func TestLiveGetOverviewConcurrent(t *testing.T) {
+	cfg := &config.Config{}
+	eng := alerts.New(nil, nil)
+	l := &Live{
+		cfg:         cfg,
+		engine:      eng,
+		routers:     []RouterConfig{},
+		lastGood:    map[string]*Router{},
+		lastStatus:  map[string]string{},
+		boardCache:  map[string]*BoardInfo{},
+		layoutCache: map[string][]PortLayout{},
+		extrasCache: map[string]*extrasSnapshot{},
+		lastPolled:  map[string]*routerPolled{},
+		failCount:   map[string]int{},
+		wanDown:     map[string]int{},
+		onlineMacs:  map[string]bool{},
+		weakAlerted: map[string]int64{},
+		backhaulCache: map[string]backhaulCacheEntry{},
+		lldpCache:   map[string]lldpCacheEntry{},
+	}
+
+	const N = 3
+	results := make([]*Overview, N)
+	errs := make([]error, N)
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i], errs[i] = l.GetOverview(context.Background())
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < N; i++ {
+		if errs[i] != nil {
+			t.Errorf("goroutine %d: %v", i, errs[i])
+		}
+		if results[i] == nil {
+			t.Errorf("goroutine %d: result nil (canal defectuoso?)", i)
+		}
+	}
+}
+
+func TestLiveGetOverviewRecoversFromPanic(t *testing.T) {
+	eng := alerts.New(nil, nil)
+	l := &Live{
+		cfg:         nil, // nil → panic en l.cfg.WGInterface
+		engine:      eng,
+		routers:     []RouterConfig{},
+		lastGood:    map[string]*Router{},
+		lastStatus:  map[string]string{},
+		boardCache:  map[string]*BoardInfo{},
+		layoutCache: map[string][]PortLayout{},
+		extrasCache: map[string]*extrasSnapshot{},
+		lastPolled:  map[string]*routerPolled{},
+		failCount:   map[string]int{},
+		wanDown:     map[string]int{},
+		onlineMacs:  map[string]bool{},
+		weakAlerted: map[string]int64{},
+		backhaulCache: map[string]backhaulCacheEntry{},
+		lldpCache:   map[string]lldpCacheEntry{},
+	}
+
+	ov, err := l.GetOverview(context.Background())
+	if err == nil {
+		t.Error("tras panic esperaba error")
+	}
+	if ov != nil {
+		t.Error("tras panic esperaba Overview nil")
+	}
+	if err.Error() == "" || err.Error()[:5] != "panic" {
+		t.Errorf("mensaje de error sin prefijo 'panic': %v", err)
+	}
+
+	l.sfMu.Lock()
+	if l.sfCall != nil {
+		t.Error("sfCall no se limpió tras el panic")
+	}
+	l.sfMu.Unlock()
+
+	// La siguiente llamada NO debe bloquear
+	done := make(chan struct{})
+	go func() {
+		l.GetOverview(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetOverview bloqueado tras panic (sfCall no reseteado)")
 	}
 }

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"sync"
@@ -148,13 +149,14 @@ type Live struct {
 	agGL  *AdGuardGlinetClient
 	agKey string
 
-	sfMu       sync.Mutex
-	sfInFlight chan sfResult
+	sfMu   sync.Mutex
+	sfCall *sfCall
 }
 
-type sfResult struct {
-	ov  *Overview
-	err error
+type sfCall struct {
+	done chan struct{}
+	ov   *Overview
+	err  error
 }
 
 // NewLive crea el adapter live (db puede ser nil en tests).
@@ -1204,26 +1206,31 @@ func (l *Live) defaultWan(gw *RouterConfig) WAN {
 }
 
 // GetOverview: single-flight (los llamantes concurrentes comparten sondeo).
-func (l *Live) GetOverview(ctx context.Context) (*Overview, error) {
+// Si buildOverview paniquea, el líder lo transforma en error y todos los
+// seguidores reciben ese error en vez de bloquear para siempre.
+func (l *Live) GetOverview(ctx context.Context) (ov *Overview, err error) {
 	l.sfMu.Lock()
-	if l.sfInFlight != nil {
-		ch := l.sfInFlight
+	if c := l.sfCall; c != nil {
 		l.sfMu.Unlock()
-		r := <-ch
-		return r.ov, r.err
+		<-c.done
+		return c.ov, c.err
 	}
-	ch := make(chan sfResult, 1)
-	l.sfInFlight = ch
+	c := &sfCall{done: make(chan struct{})}
+	l.sfCall = c
 	l.sfMu.Unlock()
 
-	ov, err := l.buildOverview(ctx)
-	ch <- sfResult{ov, err}
-	close(ch)
-
-	l.sfMu.Lock()
-	l.sfInFlight = nil
-	l.sfMu.Unlock()
-	return ov, err
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic en buildOverview: %v\n%s", r, debug.Stack())
+			ov = nil
+		}
+		c.ov, c.err = ov, err
+		close(c.done)
+		l.sfMu.Lock()
+		l.sfCall = nil
+		l.sfMu.Unlock()
+	}()
+	return l.buildOverview(ctx)
 }
 
 func (l *Live) buildOverview(ctx context.Context) (*Overview, error) {


### PR DESCRIPTION
Closes #66

Two defects in the GetOverview single-flight:

1. No defer: a panic in buildOverview left sfInFlight dangling and the channel never closed, freezing the poller permanently.
2. ch <- result + close(ch) on a buffered channel (size 1): only the first follower got the real result. The rest got (nil, nil) from the drained, closed channel.

Replaced with a shared sfCall struct and close(done) as a pure signal (correct for N followers), reset in defer, and leader recover that converts panic into error.

Tests: concurrent callers always get non-nil results (regression for defect 2), and a panic in buildOverview is caught + the next call does not block (regression for defect 1).