### PR TITLE
fix(sse): write deadline in SSE Broadcast + ReadHeaderTimeout

### DIFF
--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -242,8 +242,9 @@ func run() error {
 	})
 
 	srv := &http.Server{
-		Addr:    fmt.Sprintf(":%d", cfg.Port),
-		Handler: handler,
+		Addr:              fmt.Sprintf(":%d", cfg.Port),
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	errCh := make(chan error, 1)

--- a/server-go/internal/sse/agenthub.go
+++ b/server-go/internal/sse/agenthub.go
@@ -79,6 +79,8 @@ func (h *AgentHub) remove(slug string) {
 }
 
 func (c *agentConn) write(payload string) error {
+	rc := http.NewResponseController(c.w)
+	_ = rc.SetWriteDeadline(time.Now().Add(10 * time.Second))
 	if _, err := fmt.Fprint(c.w, payload); err != nil {
 		return err
 	}

--- a/server-go/internal/sse/hub.go
+++ b/server-go/internal/sse/hub.go
@@ -34,6 +34,8 @@ type client struct {
 func (c *client) write(payload string) error {
 	c.wmu.Lock()
 	defer c.wmu.Unlock()
+	rc := http.NewResponseController(c.w)
+	_ = rc.SetWriteDeadline(time.Now().Add(10 * time.Second))
 	if _, err := fmt.Fprint(c.w, payload); err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #67

A dead SSE client whose TCP send buffer filled up could block the synchronous Broadcast loop for every client (up to tcp_retries2, ~15 min), freezing snapshots globally.

Added write deadline (10 s) via http.ResponseController in Hub.client.write and AgentHub.agentConn.write. If a client does not drain its buffer within 10 s, the write fails and the client is removed.

Also added ReadHeaderTimeout: 10 s to the http.Server as defense against slowloris.