### PR TITLE
fix: use %w instead of %v in two error wrapping sites (config, rearmer)

### DIFF
--- a/server-go/internal/config/config.go
+++ b/server-go/internal/config/config.go
@@ -318,7 +318,7 @@ func Load(env map[string]string, serverRoot string) (*Config, error) {
 	if v, ok := env["ROUTERS_JSON"]; ok && v != "" {
 		var raw []RouterSeed
 		if err := json.Unmarshal([]byte(v), &raw); err != nil {
-			return nil, fmt.Errorf("[netpulse] ROUTERS_JSON inválido: %v", err)
+			return nil, fmt.Errorf("[netpulse] ROUTERS_JSON inválido: %w", err)
 		}
 		for i, r := range raw {
 			if r.ID == "" || r.Host == "" {

--- a/server-go/internal/rearmer/rearmer.go
+++ b/server-go/internal/rearmer/rearmer.go
@@ -155,7 +155,7 @@ func (r *Rearmer) Rearm(slug string) (Result, error) {
 	}
 
 	if _, err := r.pool.Run(host, Cmd, SSHWait); err != nil {
-		return Result{}, fmt.Errorf("no pude reiniciar el servicio en %s: %v", host, err)
+		return Result{}, fmt.Errorf("no pude reiniciar el servicio en %s: %w", host, err)
 	}
 
 	// Esperar a que el agente vuelva a empujar (poll cada 2 s hasta pollWait).


### PR DESCRIPTION
Closes #72

%v breaks errors.Is/As for callers inspecting ROUTERS_JSON parse errors and rearm SSH failures.

Two sites changed, no message change.