### PR TITLE
feat(onbox): UCI config, AUTH_PASS bootstrap, and journal DELETE — Phase 9.1 (R4/R5/R6)

### DIFF
--- a/server-go/.env.example
+++ b/server-go/.env.example
@@ -27,3 +27,12 @@ WG_INTERFACE=wg0
 # confirmación explícita. Cooldown entre intentos automáticos por slug.
 NETPULSE_AUTO_REARM=0
 NETPULSE_AUTO_REARM_COOLDOWN_S=600
+
+# --- Modo on-box (Fase 9) ---
+# 1 = servidor en el propio router: la config llega de /etc/config/netpulse
+# (sección server, mismas claves en minúscula: port, data_dir, auth_pass…),
+# AUTH_PASS es opcional (primer arranque: contraseña aleatoria en logread y
+# en netpulse.server.auth_pass) y la DB usa journal DELETE (sin -wal en
+# flash). Es configuración, no compilación: el mismo binario sirve para el
+# CT (sin la variable, todo funciona exactamente como hoy).
+NETPULSE_ONBOX=0

--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -57,6 +57,14 @@ func run() error {
 		return err
 	}
 	config.LoadDotEnv(serverRoot + "/.env")
+	// Fase 9 (R5): en on-box la config vive en /etc/config/netpulse. El
+	// loader la traduce a entorno SIN pisar lo ya presente — precedencia:
+	// entorno real > .env > UCI > defaults. Fail-soft: sin uci se sigue.
+	if os.Getenv("NETPULSE_ONBOX") == "1" {
+		if err := config.LoadUCIEnv(); err != nil {
+			log.Printf("[netpulse] aviso: config UCI no cargada (%v); siguiendo con entorno/defaults", err)
+		}
+	}
 	envMap := config.FromEnviron()
 	cfg, err := config.Load(envMap, serverRoot)
 	if err != nil {
@@ -66,7 +74,12 @@ func run() error {
 	// Auditoría de seguridad #1: la IP confiable (XFF) solo si TRUST_PROXY.
 	auth.SetTrustProxy(cfg.TrustProxy)
 
-	dbHandle, err := db.Open(cfg.DataDir)
+	// Fase 9 (R6): on-box la DB va en journal DELETE (sin -wal en flash).
+	var dbOpts []db.OpenOption
+	if cfg.Onbox {
+		dbOpts = append(dbOpts, db.WithRollbackJournal())
+	}
+	dbHandle, err := db.Open(cfg.DataDir, dbOpts...)
 	if err != nil {
 		return err
 	}
@@ -94,6 +107,34 @@ func run() error {
 	secret, err := auth.EnsureSessionSecret(dbHandle, cfg)
 	if err != nil {
 		return err
+	}
+	// Fase 9 (R4): bootstrap on-box sin AUTH_PASS. Solo en el PRIMER
+	// arranque (sin usuarios): se genera una contraseña aleatoria, se
+	// intenta persistir en UCI (netpulse.server.auth_pass) y se imprime UNA
+	// vez en el log (logread). Con usuarios ya creados no se toca nada:
+	// EnsureUsers es no-op y el login usa el hash de la DB.
+	if cfg.Onbox && cfg.AuthPass == "" {
+		n, err := auth.CountUsers(dbHandle)
+		if err != nil {
+			return fmt.Errorf("onbox: contando usuarios: %w", err)
+		}
+		if n == 0 {
+			pass, err := config.GenerateInitialPassword()
+			if err != nil {
+				return fmt.Errorf("onbox: generando contraseña inicial: %w", err)
+			}
+			cfg.AuthPass = pass
+			if err := config.PersistUCIAuthPass(pass); err != nil {
+				log.Printf("[netpulse] onbox: auth_pass NO persistida en UCI (%v): apúntala del log AHORA", err)
+			} else {
+				log.Print("[netpulse] onbox: auth_pass guardada en UCI (uci get netpulse.server.auth_pass)")
+			}
+			log.Print("[netpulse] ==================================================")
+			log.Print("[netpulse] ONBOX primer arranque — credenciales de la webapp")
+			log.Printf("[netpulse]   usuario:    %s", cfg.AuthUser)
+			log.Printf("[netpulse]   contraseña: %s", pass)
+			log.Print("[netpulse] ==================================================")
+		}
 	}
 	if err := auth.EnsureUsers(dbHandle, cfg); err != nil {
 		return err

--- a/server-go/internal/auth/auth.go
+++ b/server-go/internal/auth/auth.go
@@ -48,10 +48,18 @@ type User struct {
 	Role     string
 }
 
+// CountUsers devuelve el número de filas de users. Lo usa el bootstrap
+// on-box (Fase 9 R4) para decidir si toca generar la contraseña inicial.
+func CountUsers(d *db.DB) (int, error) {
+	var count int
+	err := d.QueryRow("SELECT COUNT(*) FROM users").Scan(&count)
+	return count, err
+}
+
 // EnsureUsers crea el admin inicial (AUTH_USER/AUTH_PASS) si users está vacía.
 func EnsureUsers(d *db.DB, cfg *config.Config) error {
-	var count int
-	if err := d.QueryRow("SELECT COUNT(*) FROM users").Scan(&count); err != nil {
+	count, err := CountUsers(d)
+	if err != nil {
 		return err
 	}
 	if count > 0 {

--- a/server-go/internal/config/config.go
+++ b/server-go/internal/config/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	GithubToken   string
 	ServerRoot    string
 	AutoRearm     bool // NETPULSE_AUTO_REARM=1: supervisor rearma agentes caídos
+	Onbox         bool // NETPULSE_ONBOX=1: modo on-box (Fase 9 — config UCI, bootstrap AUTH_PASS)
 }
 
 // LoadDotEnv parsea un .env: KEY=VALUE por línea, '#' comentarios (línea
@@ -166,11 +167,27 @@ func Load(env map[string]string, serverRoot string) (*Config, error) {
 		authUser = v
 	}
 
-	// AUTH_PASS: obligatoria (fail-fast) aunque ya existan usuarios
+	// NETPULSE_ONBOX: '0'|'1', opcional — modo on-box (Fase 9, SPEC R4/R5):
+	// la config llega vía UCI (LoadUCIEnv) y AUTH_PASS pasa a ser opcional
+	// (bootstrap con contraseña aleatoria en el primer arranque). Sin la
+	// variable, el binario se comporta exactamente como hoy (CT).
+	onbox := false
+	if v, ok := env["NETPULSE_ONBOX"]; ok && v != "" {
+		switch v {
+		case "0":
+		case "1":
+			onbox = true
+		default:
+			errs.issues = append(errs.issues, issue{"NETPULSE_ONBOX", "Invalid enum value. Expected '0' | '1'"})
+		}
+	}
+
+	// AUTH_PASS: obligatoria (fail-fast) aunque ya existan usuarios — salvo
+	// en on-box, donde el bootstrap R4 genera una si falta (cmd/netpulse).
 	authPass := ""
 	if v, ok := env["AUTH_PASS"]; ok && v != "" {
 		authPass = v
-	} else {
+	} else if !onbox {
 		errs.issues = append(errs.issues, issue{"AUTH_PASS", "Required"})
 	}
 
@@ -373,6 +390,7 @@ func Load(env map[string]string, serverRoot string) (*Config, error) {
 		GithubToken:   githubToken,
 		ServerRoot:    serverRoot,
 		AutoRearm:     autoRearm,
+		Onbox:         onbox,
 	}, nil
 }
 

--- a/server-go/internal/config/config_test.go
+++ b/server-go/internal/config/config_test.go
@@ -1,0 +1,59 @@
+// config_test.go — Fase 9 R4: NETPULSE_ONBOX y la obligatoriedad condicional
+// de AUTH_PASS en Load. Incluye la regresión del comportamiento actual
+// (sin ONBOX, AUTH_PASS sigue siendo fail-fast).
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadAuthPassRequeridaSinOnbox(t *testing.T) {
+	_, err := Load(map[string]string{}, t.TempDir())
+	if err == nil {
+		t.Fatal("Load sin AUTH_PASS debe fallar (fail-fast)")
+	}
+	if !strings.Contains(err.Error(), "AUTH_PASS") {
+		t.Fatalf("el error debe señalar AUTH_PASS: %v", err)
+	}
+}
+
+func TestLoadOnboxAuthPassOpcional(t *testing.T) {
+	cfg, err := Load(map[string]string{"NETPULSE_ONBOX": "1"}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Load con ONBOX=1 y sin AUTH_PASS no debe fallar: %v", err)
+	}
+	if !cfg.Onbox {
+		t.Fatal("cfg.Onbox debe ser true con NETPULSE_ONBOX=1")
+	}
+	if cfg.AuthPass != "" {
+		t.Fatalf("AuthPass = %q, esperaba vacía (el bootstrap la genera después)", cfg.AuthPass)
+	}
+}
+
+func TestLoadOnboxConAuthPass(t *testing.T) {
+	cfg, err := Load(map[string]string{"NETPULSE_ONBOX": "1", "AUTH_PASS": "segura-y-larga"}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.Onbox || cfg.AuthPass != "segura-y-larga" {
+		t.Fatalf("Onbox=%v AuthPass=%q: ONBOX con AUTH_PASS explícita debe conservarla", cfg.Onbox, cfg.AuthPass)
+	}
+}
+
+func TestLoadOnboxEnumInvalido(t *testing.T) {
+	_, err := Load(map[string]string{"NETPULSE_ONBOX": "2", "AUTH_PASS": "x"}, t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "NETPULSE_ONBOX") {
+		t.Fatalf("NETPULSE_ONBOX=2 debe fallar señalando la variable: %v", err)
+	}
+}
+
+func TestLoadOnboxCeroEquivaleAHoy(t *testing.T) {
+	cfg, err := Load(map[string]string{"NETPULSE_ONBOX": "0", "AUTH_PASS": "x"}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Onbox {
+		t.Fatal("NETPULSE_ONBOX=0 debe dejar Onbox=false (comportamiento actual)")
+	}
+}

--- a/server-go/internal/config/uci.go
+++ b/server-go/internal/config/uci.go
@@ -1,0 +1,219 @@
+// uci.go — modo on-box (Fase 9, SPEC R4/R5): puente entre la config UCI del
+// router (/etc/config/netpulse, sección `server`) y el loader de entorno.
+//
+//   - LoadUCIEnv traduce las opciones UCI a variables de entorno con las
+//     mismas claves que .env, SIN pisar las ya presentes. Precedencia final:
+//     entorno real > .env > UCI > defaults (misma semántica que LoadDotEnv).
+//   - PersistUCIAuthPass guarda la contraseña generada en el bootstrap R4
+//     vía la CLI `uci` (transaccional; nunca sed sobre ficheros — regla de
+//     diseño de la Fase 10 aplicada ya aquí).
+//
+// Todo es best-effort/fail-soft: en un entorno sin `uci` (el CT) las
+// funciones devuelven error y el caller decide (log y seguir). El binario
+// nunca deja de arrancar por culpa de UCI.
+package config
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// uciConfigFile es el fichero UCI del servidor on-box (convención OpenWrt;
+// no se soporta `uci -c` con otro directorio).
+const uciConfigFile = "/etc/config/netpulse"
+
+// uciExecTimeout acota cada llamada a la CLI de uci.
+const uciExecTimeout = 5 * time.Second
+
+// uciEnvMap es la allowlist opción UCI → variable de entorno (SPEC R5: "las
+// mismas claves"). Solo lo listado se inyecta: nada de mapear opciones
+// arbitrarias a entorno. Orden estable para logs/tests deterministas.
+var uciEnvMap = []struct{ uci, env string }{
+	{"port", "PORT"},
+	{"static_dir", "STATIC_DIR"},
+	{"data_dir", "DATA_DIR"},
+	{"session_secret", "SESSION_SECRET"},
+	{"auth_user", "AUTH_USER"},
+	{"auth_pass", "AUTH_PASS"},
+	{"demo_mode", "DEMO_MODE"},
+	{"max_sse_clients", "MAX_SSE_CLIENTS"},
+	{"cookie_secure", "COOKIE_SECURE"},
+	{"trust_proxy", "TRUST_PROXY"},
+	{"wg_interface", "WG_INTERFACE"},
+	{"github_repo", "GITHUB_REPO"},
+	{"github_token", "GITHUB_TOKEN"},
+	{"adguard_url", "ADGUARD_URL"},
+	{"adguard_user", "ADGUARD_USER"},
+	{"adguard_pass", "ADGUARD_PASS"},
+	{"webhook_url", "WEBHOOK_URL"},
+	{"webhook_secret", "WEBHOOK_SECRET"},
+	{"agent_max_ts_drift_s", "AGENT_MAX_TS_DRIFT_S"},
+	{"auto_rearm", "NETPULSE_AUTO_REARM"},
+	{"agent_ttl_s", "NETPULSE_AGENT_TTL_S"},
+}
+
+// LoadUCIEnv lee `uci -q show netpulse` y aplica la sección server al
+// entorno del proceso (solo claves de la allowlist ausentes del entorno).
+// Error si uci no existe o el paquete netpulse no está configurado; el
+// caller debe tratarlo como aviso, no como fatal.
+func LoadUCIEnv() error {
+	ctx, cancel := context.WithTimeout(context.Background(), uciExecTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "uci", "-q", "show", "netpulse").Output()
+	if err != nil {
+		return fmt.Errorf("uci -q show netpulse: %w", err)
+	}
+	applyUCIEnv(parseUCIShow(string(out)), os.LookupEnv, os.Setenv)
+	return nil
+}
+
+// applyUCIEnv inyecta en el "entorno" (lookup/set inyectables para test) las
+// opciones de la allowlist que NO estén ya presentes. Los errores de set se
+// ignoran (os.Setenv solo falla con claves inválidas, que aquí son fijas).
+func applyUCIEnv(vals map[string]string, lookup func(string) (string, bool), set func(string, string) error) {
+	for _, m := range uciEnvMap {
+		v, ok := vals[m.uci]
+		if !ok || v == "" {
+			continue
+		}
+		if _, exists := lookup(m.env); exists {
+			continue
+		}
+		_ = set(m.env, v)
+	}
+}
+
+// parseUCIShow parsea la salida de `uci show netpulse`:
+//
+//	netpulse.server=server
+//	netpulse.server.port='3000'
+//	netpulse.@server[0].data_dir='/etc/netpulse'   (sección anónima)
+//
+// Se aceptan la sección nombrada `server` y la anónima `@server[0]`; las
+// líneas de declaración de sección (2 segmentos) y los paquetes ajenos se
+// ignoran. Valores vacíos se descartan (opción sin configurar → defaults).
+// No hay opciones de tipo lista en la allowlist; un valor de lista llegaría
+// con comillas internas y simplemente no coincidiría con ningún enum/parse
+// del loader (fail-fast aguas arriba).
+func parseUCIShow(out string) map[string]string {
+	vals := map[string]string{}
+	for _, raw := range strings.Split(out, "\n") {
+		line := strings.TrimSpace(raw)
+		eq := strings.Index(line, "=")
+		if eq <= 0 {
+			continue
+		}
+		parts := strings.Split(line[:eq], ".")
+		if len(parts) != 3 || parts[0] != "netpulse" {
+			continue
+		}
+		if parts[1] != "server" && parts[1] != "@server[0]" {
+			continue
+		}
+		opt, val := parts[2], uciUnquote(line[eq+1:])
+		if val == "" {
+			continue
+		}
+		if _, dup := vals[opt]; !dup {
+			vals[opt] = val
+		}
+	}
+	return vals
+}
+
+// uciUnquote deshace el entrecomillado de `uci show`: valor entre comillas
+// simples, con la comilla interna escapada al estilo shell (`'\”`).
+func uciUnquote(s string) string {
+	if len(s) >= 2 && s[0] == '\'' && s[len(s)-1] == '\'' {
+		s = s[1 : len(s)-1]
+		s = strings.ReplaceAll(s, `'\''`, `'`)
+	}
+	return s
+}
+
+// PersistUCIAuthPass guarda la contraseña generada por el bootstrap on-box
+// (R4) en netpulse.server.auth_pass y deja /etc/config/netpulse en 0600
+// (contiene un secreto, como hace dropbear con sus claves). La sección la
+// trae el paquete netpulse-server; si falta (instalación manual) se crea.
+func PersistUCIAuthPass(pass string) error {
+	if _, err := exec.LookPath("uci"); err != nil {
+		return fmt.Errorf("uci no disponible: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), uciExecTimeout)
+	defer cancel()
+
+	// `uci set` falla si el paquete/sección no existen todavía: asegurar el
+	// fichero y la sección nombrada antes de escribir la opción.
+	if err := exec.CommandContext(ctx, "uci", "-q", "get", "netpulse.server").Run(); err != nil {
+		f, err := os.OpenFile(uciConfigFile, os.O_CREATE|os.O_WRONLY, 0o600)
+		if err != nil {
+			return fmt.Errorf("creando %s: %w", uciConfigFile, err)
+		}
+		_ = f.Close()
+		if err := uciRun(ctx, "set", "netpulse.server=server"); err != nil {
+			return err
+		}
+	}
+	if err := uciRun(ctx, "set", "netpulse.server.auth_pass="+pass); err != nil {
+		return err
+	}
+	if err := uciRun(ctx, "commit", "netpulse"); err != nil {
+		return err
+	}
+	// Best-effort: uci commit reescribe el fichero (puede resetear permisos).
+	_ = os.Chmod(uciConfigFile, 0o600)
+	return nil
+}
+
+// uciRun ejecuta un subcomando de uci con vector de argumentos (sin shell:
+// inyección imposible) y envuelve el error con la salida para el log.
+func uciRun(ctx context.Context, args ...string) error {
+	out, err := exec.CommandContext(ctx, "uci", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("uci %s: %w (%s)", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap R4 — contraseña inicial del admin on-box
+// ---------------------------------------------------------------------------
+
+// InitialPasswordLen es la longitud de la contraseña generada en el primer
+// arranque on-box (SPEC Fase 9 R4: 26 chars ≈ 154 bits con charset de 62).
+const InitialPasswordLen = 26
+
+// passwordCharset: alfanumérico. Sin símbolos: el valor viaja por UCI, logread
+// e input de login sin necesitar escapado en ninguna de las tres superficies.
+const passwordCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// GenerateInitialPassword genera la contraseña del bootstrap con
+// crypto/rand y muestreo por rechazo (248 = 62*4) para evitar el sesgo del
+// módulo sobre el charset de 62.
+func GenerateInitialPassword() (string, error) {
+	const limit = byte(len(passwordCharset) * (256 / len(passwordCharset))) // 248
+	out := make([]byte, InitialPasswordLen)
+	buf := make([]byte, 64)
+	i := 0
+	for i < len(out) {
+		if _, err := rand.Read(buf); err != nil {
+			return "", fmt.Errorf("crypto/rand: %w", err)
+		}
+		for _, b := range buf {
+			if b >= limit {
+				continue
+			}
+			out[i] = passwordCharset[int(b)%len(passwordCharset)]
+			i++
+			if i == len(out) {
+				break
+			}
+		}
+	}
+	return string(out), nil
+}

--- a/server-go/internal/config/uci_test.go
+++ b/server-go/internal/config/uci_test.go
@@ -1,0 +1,115 @@
+// uci_test.go — Fase 9 R4/R5: parser de `uci show`, precedencia de entorno
+// del loader UCI y generador de contraseña del bootstrap. Todo puro: sin
+// binario uci, sin tocar el entorno real del proceso.
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseUCIShow(t *testing.T) {
+	out := strings.Join([]string{
+		"netpulse.server=server",                      // declaración de sección: ignorar
+		"netpulse.server.port='3100'",                 // normal
+		"netpulse.server.auth_user='nacho'",           // normal
+		"netpulse.server.data_dir='/mnt/netpulse da'", // espacio dentro de comillas
+		"netpulse.server.auth_pass='it'\\''s'",        // comilla escapada al estilo uci
+		"netpulse.server.session_secret=''",           // vacío: descartar
+		"netpulse.@server[0].wg_interface='wg1'",      // sección anónima: aceptar
+		"netpulse.server.port='9999'",                 // duplicado: gana el primero
+		"netpulse.extra.option='x'",                   // otra sección: ignorar
+		"otropaquete.server.port='1'",                 // otro paquete: ignorar
+		"netpulse.server.demo_mode.subniv='1'",        // 4 segmentos: ignorar
+		"linea sin igual",                             // malformada: ignorar
+		"",                                            // vacía
+	}, "\n")
+
+	vals := parseUCIShow(out)
+
+	want := map[string]string{
+		"port":         "3100",
+		"auth_user":    "nacho",
+		"data_dir":     "/mnt/netpulse da",
+		"auth_pass":    "it's",
+		"wg_interface": "wg1",
+	}
+	if len(vals) != len(want) {
+		t.Fatalf("parseUCIShow: %d claves, esperaba %d (%v)", len(vals), len(want), vals)
+	}
+	for k, v := range want {
+		if vals[k] != v {
+			t.Errorf("parseUCIShow[%q] = %q, esperaba %q", k, vals[k], v)
+		}
+	}
+}
+
+func TestUCIUnquote(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"'3000'", "3000"},
+		{"''", ""},
+		{"sin-comillas", "sin-comillas"},
+		{"'it'\\''s'", "it's"},
+		{"'a b c'", "a b c"},
+		{"'", "'"}, // una sola comilla: se deja tal cual
+	}
+	for _, c := range cases {
+		if got := uciUnquote(c.in); got != c.want {
+			t.Errorf("uciUnquote(%q) = %q, esperaba %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestApplyUCIEnvPrecedencia(t *testing.T) {
+	vals := map[string]string{
+		"port":        "3100",
+		"auth_user":   "uci-user",
+		"auto_rearm":  "1",
+		"desconocida": "x", // fuera de la allowlist: nunca se inyecta
+	}
+	env := map[string]string{
+		"AUTH_USER": "env-user", // ya presente: UCI no pisa
+	}
+	lookup := func(k string) (string, bool) { v, ok := env[k]; return v, ok }
+	set := func(k, v string) error { env[k] = v; return nil }
+
+	applyUCIEnv(vals, lookup, set)
+
+	if env["PORT"] != "3100" {
+		t.Errorf("PORT = %q, esperaba 3100 (inyección desde UCI)", env["PORT"])
+	}
+	if env["AUTH_USER"] != "env-user" {
+		t.Errorf("AUTH_USER = %q: el entorno existente debe ganar a UCI", env["AUTH_USER"])
+	}
+	if env["NETPULSE_AUTO_REARM"] != "1" {
+		t.Errorf("NETPULSE_AUTO_REARM = %q, esperaba 1 (mapeo auto_rearm)", env["NETPULSE_AUTO_REARM"])
+	}
+	if _, ok := env["DESCONOCIDA"]; ok {
+		t.Error("una opción fuera de la allowlist no debe llegar al entorno")
+	}
+	if len(env) != 3 {
+		t.Errorf("entorno final con %d claves, esperaba 3: %v", len(env), env)
+	}
+}
+
+func TestGenerateInitialPassword(t *testing.T) {
+	a, err := GenerateInitialPassword()
+	if err != nil {
+		t.Fatalf("GenerateInitialPassword: %v", err)
+	}
+	b, err := GenerateInitialPassword()
+	if err != nil {
+		t.Fatalf("GenerateInitialPassword (2ª): %v", err)
+	}
+	if len(a) != InitialPasswordLen || len(b) != InitialPasswordLen {
+		t.Fatalf("longitudes %d/%d, esperaba %d", len(a), len(b), InitialPasswordLen)
+	}
+	if a == b {
+		t.Fatal("dos contraseñas generadas idénticas: rand roto")
+	}
+	for _, r := range a + b {
+		if !strings.ContainsRune(passwordCharset, r) {
+			t.Fatalf("carácter %q fuera del charset", r)
+		}
+	}
+}

--- a/server-go/internal/db/db.go
+++ b/server-go/internal/db/db.go
@@ -143,15 +143,39 @@ type DB struct {
 	stop  chan struct{}
 	wg    sync.WaitGroup
 	close sync.Once
+	// rollbackJournal: journal DELETE en vez de WAL (modo on-box, Fase 9 R6).
+	// Los wal_checkpoint de mantenimiento se omiten en este modo.
+	rollbackJournal bool
 }
 
 // NowMS devuelve el epoch actual en milisegundos (como Date.now()).
 func NowMS() int64 { return time.Now().UnixMilli() }
 
+// OpenOption configura Open (variádica: los callers existentes no cambian).
+type OpenOption func(*openOptions)
+
+type openOptions struct {
+	rollbackJournal bool
+}
+
+// WithRollbackJournal (Fase 9 R6, modo on-box): `journal_mode=DELETE` +
+// `synchronous=FULL` en vez de WAL+NORMAL, y sin wal_checkpoint en los jobs.
+// Motivo: en la flash de un router el fichero -wal y sus checkpoints son
+// churn de escritura evitable; y en rollback-journal, NORMAL deja una
+// ventana de corrupción ante un corte de luz (frecuente en un router) que
+// WAL+NORMAL no tiene — de ahí FULL (docs de PRAGMA synchronous).
+func WithRollbackJournal() OpenOption {
+	return func(o *openOptions) { o.rollbackJournal = true }
+}
+
 // Open abre (o crea) DATA_DIR/netpulse.db, ejecuta la migración Node→Go si la
 // DB ya existía con esquema Node (backup atómico antes de tocar nada),
 // aplica pragmas, crea el schema y arranca el mantenimiento horario.
-func Open(dataDir string) (*DB, error) {
+func Open(dataDir string, opts ...OpenOption) (*DB, error) {
+	var o openOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
 	if err := os.MkdirAll(dataDir, 0o755); err != nil {
 		return nil, err
 	}
@@ -175,11 +199,21 @@ func Open(dataDir string) (*DB, error) {
 	}
 	sqldb.SetMaxOpenConns(1)
 
-	for _, p := range []string{
+	pragmas := []string{
 		"PRAGMA journal_mode = WAL",
 		"PRAGMA synchronous = NORMAL",
 		"PRAGMA foreign_keys = ON",
-	} {
+	}
+	if o.rollbackJournal {
+		// Una DB previa en WAL se convierte sola: con una única conexión el
+		// cambio de journal_mode hace checkpoint y elimina el -wal.
+		pragmas = []string{
+			"PRAGMA journal_mode = DELETE",
+			"PRAGMA synchronous = FULL",
+			"PRAGMA foreign_keys = ON",
+		}
+	}
+	for _, p := range pragmas {
 		if _, err := sqldb.Exec(p); err != nil {
 			sqldb.Close()
 			return nil, fmt.Errorf("pragma %q: %w", p, err)
@@ -207,7 +241,7 @@ func Open(dataDir string) (*DB, error) {
 		)
 	}
 
-	d := &DB{DB: sqldb, Path: dbPath, stop: make(chan struct{})}
+	d := &DB{DB: sqldb, Path: dbPath, stop: make(chan struct{}), rollbackJournal: o.rollbackJournal}
 	d.wg.Add(1)
 	go d.maintenanceLoop()
 	return d, nil
@@ -257,8 +291,10 @@ func (d *DB) Maintenance() {
 	if _, err := d.Exec("DELETE FROM metrics_buckets WHERE bucket_ts < ?", bucketCutoff); err != nil {
 		log.Printf("[netpulse] error en mantenimiento DB: %v", err)
 	}
-	if _, err := d.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
-		log.Printf("[netpulse] error en mantenimiento DB: %v", err)
+	if !d.rollbackJournal {
+		if _, err := d.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+			log.Printf("[netpulse] error en mantenimiento DB: %v", err)
+		}
 	}
 }
 
@@ -284,8 +320,11 @@ func (d *DB) NightlyJob() {
 		log.Printf("[netpulse] rollup buckets→daily OK (%s)", time.Since(start).Round(time.Millisecond))
 	}
 
-	// 3) checkpoint tras los DELETE/INSERT grandes (concentra el WAL)
-	_, _ = d.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+	// 3) checkpoint tras los DELETE/INSERT grandes (concentra el WAL);
+	// en rollback-journal (on-box) no hay WAL que consolidar.
+	if !d.rollbackJournal {
+		_, _ = d.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+	}
 
 	// 4) optimize + ANALYZE (estadísticas del planner tras la purga)
 	_, _ = d.Exec("PRAGMA optimize")

--- a/server-go/internal/db/db_onbox_test.go
+++ b/server-go/internal/db/db_onbox_test.go
@@ -1,0 +1,88 @@
+// db_onbox_test.go — Fase 9 R6: WithRollbackJournal aplica DELETE+FULL y el
+// Open por defecto conserva WAL+NORMAL (regresión del comportamiento actual).
+package db
+
+import "testing"
+
+// pragmaStr lee un PRAGMA que devuelve texto (journal_mode).
+func pragmaStr(t *testing.T, d *DB, pragma string) string {
+	t.Helper()
+	var v string
+	if err := d.QueryRow("PRAGMA " + pragma).Scan(&v); err != nil {
+		t.Fatalf("PRAGMA %s: %v", pragma, err)
+	}
+	return v
+}
+
+// pragmaInt lee un PRAGMA numérico (synchronous: 1=NORMAL, 2=FULL).
+func pragmaInt(t *testing.T, d *DB, pragma string) int {
+	t.Helper()
+	var v int
+	if err := d.QueryRow("PRAGMA " + pragma).Scan(&v); err != nil {
+		t.Fatalf("PRAGMA %s: %v", pragma, err)
+	}
+	return v
+}
+
+func TestOpenRollbackJournal(t *testing.T) {
+	d, err := Open(t.TempDir(), WithRollbackJournal())
+	if err != nil {
+		t.Fatalf("Open(WithRollbackJournal): %v", err)
+	}
+	defer d.Close()
+
+	if got := pragmaStr(t, d, "journal_mode"); got != "delete" {
+		t.Errorf("journal_mode = %q, esperaba delete", got)
+	}
+	if got := pragmaInt(t, d, "synchronous"); got != 2 {
+		t.Errorf("synchronous = %d, esperaba 2 (FULL)", got)
+	}
+	if !d.rollbackJournal {
+		t.Error("rollbackJournal debe quedar activo en el struct (guardas de checkpoint)")
+	}
+	// Maintenance no debe fallar sin WAL (checkpoint omitido).
+	d.Maintenance()
+}
+
+func TestOpenPorDefectoSigueEnWAL(t *testing.T) {
+	d, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+
+	if got := pragmaStr(t, d, "journal_mode"); got != "wal" {
+		t.Errorf("journal_mode = %q, esperaba wal (regresión)", got)
+	}
+	if got := pragmaInt(t, d, "synchronous"); got != 1 {
+		t.Errorf("synchronous = %d, esperaba 1 (NORMAL, regresión)", got)
+	}
+}
+
+func TestOpenConversionWALaDelete(t *testing.T) {
+	// Una DB creada en WAL (CT) y reabierta on-box debe convertirse sola.
+	dir := t.TempDir()
+	d1, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open WAL: %v", err)
+	}
+	if _, err := d1.Exec("INSERT INTO kv (key, value) VALUES ('t', '1')"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := d1.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	d2, err := Open(dir, WithRollbackJournal())
+	if err != nil {
+		t.Fatalf("reOpen DELETE: %v", err)
+	}
+	defer d2.Close()
+	if got := pragmaStr(t, d2, "journal_mode"); got != "delete" {
+		t.Errorf("journal_mode tras conversión = %q, esperaba delete", got)
+	}
+	var v string
+	if err := d2.QueryRow("SELECT value FROM kv WHERE key = 't'").Scan(&v); err != nil || v != "1" {
+		t.Errorf("dato pre-conversión perdido: v=%q err=%v", v, err)
+	}
+}


### PR DESCRIPTION
Closes #76

## What this does

Phase 9 (SPEC-FASE8) moves the server onto the gateway. This first PR covers the three challenges that do not depend on TLS or hardware and are fully testable in the CT.

### R5 — UCI config (`internal/config/uci.go`)
- Parses `uci show netpulse` output (named `server` and anonymous `@server[0]` sections)
- Translates UCI options to env vars via an explicit allowlist (same keys as `.env`)
- Precedence: real env > `.env` > UCI > defaults (UCI never overrides what is already set)
- Fail-soft: continues with a warning if `uci` is not available
- Parser handles escaped single quotes (`'`), duplicates, foreign packages, and empty values

### R4 — AUTH_PASS bootstrap
- On-box without `AUTH_PASS`: first boot (0 users) generates a random 26-char alphanumeric password (crypto/rand, rejection sampling, ~154 bits)
- Persists it in `netpulse.server.auth_pass` (file set to 0600 after `uci commit`)
- Printed **once** in the log (`logread`); subsequent restarts do not regenerate it
- `auth.CountUsers` extracted and reused by `EnsureUsers` — zero behavior change

### R6 — Flash-friendly persistence
- `db.Open` now accepts variadic `OpenOption` (existing callers unchanged)
- `WithRollbackJournal()` → `journal_mode=DELETE` + `synchronous=FULL` (rollback-journal with NORMAL has a corruption window on power loss — common on routers; WAL+NORMAL stays as-is for the CT)
- Converts preexisting WAL databases while preserving data (tested)
- Skips `wal_checkpoint` in both `Maintenance` and `NightlyJob` when rollback journal is active

### Everything is opt-in
Without `NETPULSE_ONBOX=1`, the binary behaves exactly as today (regression tests included for AUTH_PASS fail-fast and WAL+NORMAL defaults).

### Test results
```
go build ./...   OK
go vet ./...     OK  
go test ./...    14/14 packages green
  internal/config  9/9 PASS
  internal/db      3/3 PASS (rollback journal, WAL regression, conversion)
```

### Out of scope (upcoming PRs)
- PR2: self-signed TLS + `GET /fingerprint` + SPKI pinning in both agent transports
- PR3: pairing token + adoption + "Adopt AP" button in Settings  
- PR4: `deploy/openwrt/netpulse-server/` package + CI matrix