### PR TITLE
fix(ci): inject BuildCommit in go.yml so updater reports real SHA

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -79,7 +79,10 @@ jobs:
           CGO_ENABLED: 0
           GOOS: linux
           GOARCH: ${{ matrix.arch }}
-        run: go build -trimpath -ldflags "-s -w" -o netpulse ./cmd/netpulse
+        # -X updater.BuildCommit: sin esto el updater del CT cae a git rev-parse
+        # (repo stale dubious-ownership) y reporta un SHA viejo → falso "update
+        # available" permanente aunque el binario sea el de main HEAD.
+        run: go build -trimpath -ldflags "-s -w -X github.com/gnacho/netpulse/server-go/internal/updater.BuildCommit=${GITHUB_SHA::7}" -o netpulse ./cmd/netpulse
 
       - name: Empaqueta binario + despliegue
         run: tar czf netpulse-server-${{ github.sha }}-linux-${{ matrix.arch }}.tar.gz -C server-go netpulse .env.example -C .. deploy


### PR DESCRIPTION
Without `-X updater.BuildCommit` in go.yml, rolling binaries (go-latest) had `BuildCommit=""` and fell back to `git rev-parse` — which on the CT 226 hits a stale repo with dubious ownership and reports a commit from days ago. This produced a permanent false 'update available' even when the binary was already at main HEAD.

Injects the short SHA (first 7 chars of `GITHUB_SHA`), matching goreleaser's `{{.ShortCommit}}` for stable releases and the 7-char truncation that `fetchLatestCommit` applies to the `latest` field.