### PR TITLE
feat(tls): self-signed TLS + SPKI pinning + GET /fingerprint (Phase 9 R2)

### DIFF
--- a/agent/cmd/netpulse-agent/main.go
+++ b/agent/cmd/netpulse-agent/main.go
@@ -12,16 +12,15 @@
 //	NETPULSE_SERVER    URL del servidor (https://... o http://...:3000) [obligatoria]
 //	NETPULSE_TOKEN     token del equipo (64 hex; se muestra una vez al crearlo)
 //	NETPULSE_SLUG      slug del equipo (agent.token.<slug> en el servidor)
+//	NETPULSE_SERVER_FP SHA-256 del SPKI del servidor en hex (obligatorio si la URL es https://)
 //	NETPULSE_INTERVAL  intervalo de push (default 30s; "30", "15s", "1m")
 //	NETPULSE_ENV_FILE  fichero env alternativo (default /etc/netpulse-agent.env)
 //	NETPULSE_WAN_TARGET    ping WAN con pérdida (gateway; p. ej. 1.1.1.1)
 //	NETPULSE_GW_TARGET     ping corto al gateway (APs; p. ej. 192.168.8.1)
-//	NETPULSE_INSECURE_TLS  "1" → no verificar el certificado (LAN autofirmado)
 package main
 
 import (
 	"context"
-	"crypto/tls"
 	"flag"
 	"fmt"
 	"log"
@@ -38,6 +37,7 @@ import (
 	"github.com/gnacho/netpulse/agent/internal/iwevents"
 	"github.com/gnacho/netpulse/agent/internal/push"
 	"github.com/gnacho/netpulse/agent/internal/sseclient"
+	"github.com/gnacho/netpulse/agent/internal/tlspin"
 	"github.com/gnacho/netpulse/agent/probe"
 )
 
@@ -56,9 +56,9 @@ const (
 
 type config struct {
 	server, token, slug string
+	serverFP            string // SPKI hash hex (obligatorio si la URL es https://)
 	interval            time.Duration
 	wanTarget, gwTarget string
-	insecureTLS         bool
 	heartbeatFile       string
 }
 
@@ -100,10 +100,10 @@ func loadConfig() (config, error) {
 		server:        strings.TrimRight(get("NETPULSE_SERVER"), "/"),
 		token:         get("NETPULSE_TOKEN"),
 		slug:          get("NETPULSE_SLUG"),
+		serverFP:      tlspin.Normalize(get("NETPULSE_SERVER_FP")),
 		interval:      pollInterval,
 		wanTarget:     get("NETPULSE_WAN_TARGET"),
 		gwTarget:      get("NETPULSE_GW_TARGET"),
-		insecureTLS:   get("NETPULSE_INSECURE_TLS") == "1",
 		heartbeatFile: get("NETPULSE_HEARTBEAT_FILE"),
 	}
 	if v := get("NETPULSE_INTERVAL"); v != "" {
@@ -168,9 +168,9 @@ func run() error {
 		return err
 	}
 
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	if cfg.insecureTLS {
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // opt-in documentado (LAN autofirmada)
+	transport, err := tlspin.BuildTransport(cfg.server, cfg.serverFP)
+	if err != nil {
+		return err
 	}
 	client := push.New(cfg.server, cfg.token, &http.Client{Timeout: 10 * time.Second, Transport: transport})
 	client.SetLogger(func(format string, args ...any) { log.Printf(format, args...) })
@@ -219,9 +219,12 @@ func run() error {
 	}
 
 	// Fase 7.3: SSE bidireccional — el servidor envía comandos al agente.
+	// El SSE reutiliza el mismo transporte (mismo pinning SPKI que el push).
 	refreshCh := make(chan struct{}, 1)
 	go func() {
-		sse := sseclient.New(cfg.server, cfg.slug, cfg.token, func(ev sseclient.Event) {
+		sse := sseclient.New(cfg.server, cfg.slug, cfg.token,
+			&http.Client{Timeout: 0, Transport: transport},
+			func(ev sseclient.Event) {
 			if ev.Name == "refresh" {
 				select {
 				case refreshCh <- struct{}{}:

--- a/agent/internal/sseclient/sseclient.go
+++ b/agent/internal/sseclient/sseclient.go
@@ -30,12 +30,16 @@ type Client struct {
 }
 
 // New crea un cliente SSE. serverURL es la URL base del servidor
-// (p. ej. "http://192.168.1.226:3000").
-func New(serverURL, slug, token string, onEvent func(Event)) *Client {
+// (p. ej. "http://192.168.1.226:3000"). hc permite compartir el transporte
+// (incluido el pinning SPKI del agente); nil → http.Client por defecto.
+func New(serverURL, slug, token string, hc *http.Client, onEvent func(Event)) *Client {
+	if hc == nil {
+		hc = &http.Client{Timeout: 0}
+	}
 	return &Client{
 		url:      serverURL + "/api/agents/" + slug + "/stream",
 		token:    token,
-		hc:       &http.Client{Timeout: 0}, // sin timeout: conexión persistente
+		hc:       hc,
 		onEvent:  onEvent,
 		minRetry: 5 * time.Second,
 		maxRetry: 5 * time.Minute,

--- a/agent/internal/tlspin/tlspin.go
+++ b/agent/internal/tlspin/tlspin.go
@@ -1,0 +1,68 @@
+// Package tlspin — validación TLS del agente por pinning SPKI (Fase 9 R2).
+//
+// Sustituye a NETPULSE_INSECURE_TLS: en vez de saltar la verificación del
+// certificado, el agente pinea el hash SHA-256 del SubjectPublicKeyInfo del
+// servidor. Fail-closed: HTTPS sin fingerprint → error (nunca degrada a
+// insecure).
+package tlspin
+
+import (
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Normalize limpia un fingerprint: quita prefijo "sha256/", dos-puntos y
+// espacios, y lo pasa a minúsculas. Formato esperado: 64 hex chars.
+func Normalize(s string) string {
+	s = strings.NewReplacer("sha256/", "", ":", "", " ", "").Replace(s)
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// BuildTransport crea un *http.Transport con la validación TLS adecuada:
+//   - HTTP: transporte por defecto (sin TLS).
+//   - HTTPS con fp: TLS con pinning SPKI (VerifyPeerCertificate).
+//   - HTTPS sin fp: error (fail-closed).
+func BuildTransport(serverURL, fp string) (*http.Transport, error) {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	if !strings.HasPrefix(serverURL, "https://") {
+		return t, nil // HTTP plano: sin TLS
+	}
+	fp = Normalize(fp)
+	if fp == "" {
+		return nil, fmt.Errorf("HTTPS requiere NETPULSE_SERVER_FP (pinning SPKI, sin InsecureSkipVerify)")
+	}
+	want := fp
+	t.TLSClientConfig = &tls.Config{
+		// InsecureSkipVerify salta la verificación normal de CA; la decisión
+		// final la toma VerifyPeerCertificate contra el SPKI pineado.
+		InsecureSkipVerify: true, //nolint:gosec // pinning deliberado por SPKI
+		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+			return VerifySPKI(rawCerts, want)
+		},
+		MinVersion: tls.VersionTLS12,
+	}
+	return t, nil
+}
+
+// VerifySPKI comprueba que el SPKI hash del leaf cert coincida con el
+// fingerprint esperado (SHA-256 hex del DER del SubjectPublicKeyInfo).
+func VerifySPKI(rawCerts [][]byte, wantHex string) error {
+	if len(rawCerts) == 0 {
+		return fmt.Errorf("sin certificados del peer")
+	}
+	leaf, err := x509.ParseCertificate(rawCerts[0])
+	if err != nil {
+		return fmt.Errorf("parsear leaf: %w", err)
+	}
+	sum := sha256.Sum256(leaf.RawSubjectPublicKeyInfo)
+	got := hex.EncodeToString(sum[:])
+	if got != wantHex {
+		return fmt.Errorf("SPKI mismatch: got %s, want %s", got, wantHex)
+	}
+	return nil
+}

--- a/agent/internal/tlspin/tlspin_test.go
+++ b/agent/internal/tlspin/tlspin_test.go
@@ -1,0 +1,127 @@
+package tlspin
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// selfSignedCert genera un cert autofirmado ECDSA P-256 y devuelve el
+// tls.Config del servidor + el fingerprint SPKI esperado (mismo algoritmo
+// que server-go/internal/tlscert.Fingerprint: SHA-256 del
+// RawSubjectPublicKeyInfo en hex).
+func selfSignedCert(t *testing.T) (tlsConf *tls.Config, fp string) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serial, _ := rand.Int(rand.Reader, big.NewInt(1<<62))
+	template := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, _ := x509.ParseCertificate(der)
+	tlsConf = &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: priv}},
+		MinVersion:   tls.VersionTLS12,
+	}
+	sum := sha256.Sum256(leaf.RawSubjectPublicKeyInfo)
+	fp = hex.EncodeToString(sum[:])
+	return
+}
+
+func TestPinAcceptsMatchingSPKI(t *testing.T) {
+	srvTLS, fp := selfSignedCert(t)
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "ok")
+	}))
+	ts.TLS = srvTLS
+	ts.StartTLS()
+	defer ts.Close()
+
+	transport, err := BuildTransport(ts.URL, fp)
+	if err != nil {
+		t.Fatalf("BuildTransport: %v", err)
+	}
+	hc := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+	res, err := hc.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("GET con SPKI correcto falló: %v", err)
+	}
+	body, _ := io.ReadAll(res.Body)
+	res.Body.Close()
+	if string(body) != "ok" {
+		t.Fatalf("body = %q", body)
+	}
+}
+
+func TestPinRejectsWrongSPKI(t *testing.T) {
+	srvTLS, _ := selfSignedCert(t)
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	ts.TLS = srvTLS
+	ts.StartTLS()
+	defer ts.Close()
+
+	// Fingerprint deliberadamente incorrecto (64 hex chars).
+	transport, err := BuildTransport(ts.URL, "de"+strings.Repeat("ad", 31))
+	if err != nil {
+		t.Fatalf("BuildTransport: %v", err)
+	}
+	hc := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+	_, err = hc.Get(ts.URL)
+	if err == nil {
+		t.Fatal("GET con SPKI incorrecto debería fallar")
+	}
+}
+
+func TestFailClosedHTTPSWithoutFP(t *testing.T) {
+	_, err := BuildTransport("https://192.168.1.1:3000", "")
+	if err == nil {
+		t.Fatal("HTTPS sin serverFP debería dar error (fail-closed)")
+	}
+}
+
+func TestHTTPSkipsTLS(t *testing.T) {
+	transport, err := BuildTransport("http://192.168.1.226:3000", "")
+	if err != nil {
+		t.Fatalf("HTTP sin FP no debería fallar: %v", err)
+	}
+	// El transporte por defecto puede tener TLSClientConfig (Go lo inicializa),
+	// pero NO debe llevar VerifyPeerCertificate (eso es nuestro pinning).
+	if transport.TLSClientConfig != nil && transport.TLSClientConfig.VerifyPeerCertificate != nil {
+		t.Fatal("HTTP no debería configurar pinning SPKI")
+	}
+}
+
+func TestNormalizeStripsPrefixes(t *testing.T) {
+	got := Normalize("sha256/AB:CD:EF:01")
+	want := "abcdef01"
+	if got != want {
+		t.Fatalf("Normalize = %q, want %q", got, want)
+	}
+}

--- a/deploy/openwrt/luci-app-netpulse/files/www/luci-static/resources/view/netpulse/settings.js
+++ b/deploy/openwrt/luci-app-netpulse/files/www/luci-static/resources/view/netpulse/settings.js
@@ -49,8 +49,8 @@ return view.extend({
 		o.datatype = 'host';
 		o.rmempty = true;
 
-		o = s.option(form.Flag, 'insecure_tls', _('Accept self-signed TLS'),
-			_('Skips server certificate verification. Only for LANs without a CA; scheduled for removal once fingerprint pinning lands (Fase 9).'));
+		o = s.option(form.Value, 'server_fp', _('Server fingerprint (SPKI)'),
+			_('SHA-256 of the server SubjectPublicKeyInfo in hex. Required when the server URL is https. Get it with: curl http://server/fingerprint'));
 		o.rmempty = true;
 
 		return m.render();

--- a/deploy/openwrt/netpulse-agent/files/netpulse-agent.config
+++ b/deploy/openwrt/netpulse-agent/files/netpulse-agent.config
@@ -22,5 +22,7 @@ config main 'main'
 	# Ping al gateway (solo APs; p. ej. 192.168.1.1)
 	# option gw_target '192.168.1.1'
 
-	# Aceptar TLS autofirmado (LAN sin CA; default 0)
-	# option insecure_tls '0'
+	# Fingerprint SPKI del servidor (obligatorio si server es https://)
+	# SHA-256 hex del SubjectPublicKeyInfo; se obtiene con:
+	#   curl http://<server>:<port>/fingerprint
+	# option server_fp ''

--- a/deploy/openwrt/netpulse-agent/files/netpulse-agent.init
+++ b/deploy/openwrt/netpulse-agent/files/netpulse-agent.init
@@ -48,10 +48,10 @@ load_config() {
 	[ -n "$wan_target" ] && export NETPULSE_WAN_TARGET="$wan_target"
 	[ -n "$gw_target" ]  && export NETPULSE_GW_TARGET="$gw_target"
 
-	# TLS inseguro (LAN con cert autofirmado)
-	local insecure_tls
-	config_get insecure_tls main insecure_tls "0"
-	[ "$insecure_tls" = "1" ] && export NETPULSE_INSECURE_TLS=1
+	# Fingerprint SPKI del servidor (obligatorio si server es https://)
+	local server_fp
+	config_get server_fp main server_fp ""
+	[ -n "$server_fp" ] && export NETPULSE_SERVER_FP="$server_fp"
 }
 
 start_service() {

--- a/install-agent.sh
+++ b/install-agent.sh
@@ -166,7 +166,7 @@ NETPULSE_TOKEN=$TOKEN
 # NETPULSE_INTERVAL=15
 # NETPULSE_WAN_TARGET=1.1.1.1      # solo si este equipo es el gateway
 # NETPULSE_GW_TARGET=192.168.8.1   # ping al gateway (APs)
-# NETPULSE_INSECURE_TLS=1          # solo si el servidor usa cert autofirmado
+# NETPULSE_SERVER_FP=<sha256 hex>  # obligatorio si SERVER es https:// (pinning SPKI)
 EOF
 ok "config escrita"
 

--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/subtle"
+	"crypto/tls"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -40,6 +41,7 @@ import (
 	"github.com/gnacho/netpulse/server-go/internal/sse"
 	"github.com/gnacho/netpulse/server-go/internal/sshkey"
 	"github.com/gnacho/netpulse/server-go/internal/staticspa"
+	"github.com/gnacho/netpulse/server-go/internal/tlscert"
 	"github.com/gnacho/netpulse/server-go/internal/updater"
 	"github.com/gnacho/netpulse/server-go/internal/webhook"
 )
@@ -284,6 +286,33 @@ func run() error {
 		Started: time.Now(),
 	})
 
+	// Fase 9 R2: TLS autofirmado on-box. En modo on-box se genera/carga un
+	// cert autofirmado, se registra GET /fingerprint (sin auth, para que el
+	// agente pueda pinear el SPKI) y se sirve HTTPS. Sin ONBOX: HTTP plano.
+	var (
+		serverFP string
+		tlsConf  *tls.Config
+	)
+	if cfg.Onbox {
+		certPath := filepath.Join(cfg.DataDir, "cert.pem")
+		keyPath := filepath.Join(cfg.DataDir, "key.pem")
+		var err2 error
+		tlsConf, serverFP, err2 = tlscert.Ensure(certPath, keyPath)
+		if err2 != nil {
+			return fmt.Errorf("cert on-box: %w", err2)
+		}
+		log.Printf("[netpulse] TLS autofirmado on-box: %s", certPath)
+		log.Printf("[netpulse] FINGERPRINT SPKI (sha256): %s", serverFP)
+		// Envolver el handler con el endpoint /fingerprint (sin auth).
+		fpMux := http.NewServeMux()
+		fpMux.HandleFunc("GET /fingerprint", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"spki_sha256":%q}`, serverFP)
+		})
+		fpMux.Handle("/", handler)
+		handler = fpMux
+	}
+
 	srv := &http.Server{
 		Addr:              fmt.Sprintf(":%d", cfg.Port),
 		Handler:           handler,
@@ -293,7 +322,12 @@ func run() error {
 
 	errCh := make(chan error, 1)
 	go func() {
-		log.Printf("[netpulse] v%s · modo %s · http://localhost:%d", httpapi.Version, adapter.Mode(), cfg.Port)
+		scheme := "http"
+		if cfg.Onbox {
+			scheme = "https"
+			srv.TLSConfig = tlsConf
+		}
+		log.Printf("[netpulse] v%s · modo %s · %s://localhost:%d", httpapi.Version, adapter.Mode(), scheme, cfg.Port)
 		staticDesc := staticDir
 		if staticDesc == "" {
 			staticDesc = "(embed)"
@@ -301,7 +335,11 @@ func run() error {
 		log.Printf("[netpulse] datos: %s · estáticos: %s", cfg.DataDir, staticDesc)
 		p.Start()
 		upd.Start()
-		errCh <- srv.ListenAndServe()
+		if cfg.Onbox {
+			errCh <- srv.ListenAndServeTLS("", "")
+		} else {
+			errCh <- srv.ListenAndServe()
+		}
 	}()
 
 	sigCh := make(chan os.Signal, 1)

--- a/server-go/internal/tlscert/tlscert.go
+++ b/server-go/internal/tlscert/tlscert.go
@@ -1,0 +1,113 @@
+// Package tlscert — gestión del certificado autofirmado on-box (Fase 9 R2).
+//
+// En modo on-box el servidor escucha HTTPS con un cert autofirmado generado
+// en el primer arranque. El agente valida la conexión por pinning del SPKI
+// (SubjectPublicKeyInfo) hash, configurado durante el pairing — sin
+// InsecureSkipVerify.
+//
+// El fingerprint expuesto por GET /fingerprint es SHA-256 del DER del SPKI en
+// hex minúsculas (formato estándar de pinning, mismo que usa el agente en
+// VerifyPeerCertificate).
+package tlscert
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"time"
+)
+
+// Ensure garantiza que existe un cert autofirmado en certPath/keyPath.
+// Si ya existe, lo carga; si no, lo genera. Devuelve el *tls.Config para el
+// listener y el fingerprint SPKI hex (SHA-256 del DER del SubjectPublicKeyInfo).
+func Ensure(certPath, keyPath string) (*tls.Config, string, error) {
+	if fileExists(certPath) && fileExists(keyPath) {
+		return loadExisting(certPath, keyPath)
+	}
+	return generate(certPath, keyPath)
+}
+
+// Fingerprint calcula el SPKI hash hex de un certificado parsed.
+func Fingerprint(cert *x509.Certificate) string {
+	sum := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	return hex.EncodeToString(sum[:])
+}
+
+func loadExisting(certPath, keyPath string) (*tls.Config, string, error) {
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("cargar cert existente: %w", err)
+	}
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return nil, "", fmt.Errorf("parsear leaf: %w", err)
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}, Fingerprint(leaf), nil
+}
+
+func generate(certPath, keyPath string) (*tls.Config, string, error) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, "", fmt.Errorf("generar clave ECDSA: %w", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, "", fmt.Errorf("serial: %w", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "netpulse"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, "", fmt.Errorf("crear cert: %w", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal clave: %w", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	if err := os.WriteFile(certPath, certPEM, 0o644); err != nil {
+		return nil, "", fmt.Errorf("escribir cert: %w", err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		return nil, "", fmt.Errorf("escribir key: %w", err)
+	}
+
+	leaf, _ := x509.ParseCertificate(der)
+	tlsCert := tls.Certificate{Certificate: [][]byte{der}, PrivateKey: priv}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+		MinVersion:   tls.VersionTLS12,
+	}, Fingerprint(leaf), nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/server-go/internal/tlscert/tlscert_test.go
+++ b/server-go/internal/tlscert/tlscert_test.go
@@ -1,0 +1,70 @@
+package tlscert
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureGeneratesAndPersists(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+
+	// Primera llamada: genera.
+	tlsConf1, fp1, err := Ensure(certPath, keyPath)
+	if err != nil {
+		t.Fatalf("Ensure (generate): %v", err)
+	}
+	if tlsConf1 == nil || len(tlsConf1.Certificates) != 1 {
+		t.Fatal("tls.Config sin certificados")
+	}
+	if fp1 == "" {
+		t.Fatal("fingerprint vacío")
+	}
+
+	// Segunda llamada: carga el existente. El fingerprint debe ser idéntico.
+	tlsConf2, fp2, err := Ensure(certPath, keyPath)
+	if err != nil {
+		t.Fatalf("Ensure (load): %v", err)
+	}
+	if fp1 != fp2 {
+		t.Fatalf("fingerprint cambió entre generate y load: %s ≠ %s", fp1, fp2)
+	}
+	if len(tlsConf2.Certificates) != 1 {
+		t.Fatal("tls.Config (load) sin certificados")
+	}
+}
+
+func TestFingerprintIs64HexChars(t *testing.T) {
+	dir := t.TempDir()
+	_, fp, err := Ensure(filepath.Join(dir, "cert.pem"), filepath.Join(dir, "key.pem"))
+	if err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	if len(fp) != 64 {
+		t.Fatalf("fingerprint length = %d, want 64 (SHA-256 hex)", len(fp))
+	}
+	for _, c := range fp {
+		isHex := (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')
+		if !isHex {
+			t.Fatalf("fingerprint contiene char no-hex: %q en %s", c, fp)
+		}
+	}
+}
+
+func TestGeneratedCertUsableByTLS(t *testing.T) {
+	dir := t.TempDir()
+	tlsConf, _, err := Ensure(filepath.Join(dir, "cert.pem"), filepath.Join(dir, "key.pem"))
+	if err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	// Verificar que el tls.Config es válido para un handshake (sin levantar
+	// servidor: basta con que el leaf parseable y la clave casen).
+	cert := tlsConf.Certificates[0]
+	if len(cert.Certificate) == 0 {
+		t.Fatal("cert sin DER")
+	}
+	if cert.PrivateKey == nil {
+		t.Fatal("cert sin PrivateKey")
+	}
+}


### PR DESCRIPTION
Closes #84.

Implements R2 of the on-box SPEC: the server generates a self-signed cert on first start and the agent validates it via SPKI pinning, replacing the opt-in `NETPULSE_INSECURE_TLS`.

**Server** (on-box only): `internal/tlscert` generates ECDSA P-256 self-signed (10y), `GET /fingerprint` returns the SPKI hash, serves HTTPS. Without `Onbox`: HTTP as before (zero regression).

**Agent**: `internal/tlspin` does `VerifyPeerCertificate` against `NETPULSE_SERVER_FP`. Fail-closed: HTTPS without FP is an error. HTTP skips TLS (CT layout unchanged). The pinned transport is shared by push + SSE.

**Deploy**: `server_fp` replaces `insecure_tls` in UCI config, init script, and LuCI.

**Tests**: `tlscert` (generate→load consistency, 64-hex fingerprint), `tlspin` (accepts match, rejects mismatch, fail-closed, HTTP skips TLS, Normalize). Full suite `-race` green, `go vet` clean.