### PR TITLE
feat(pairing): token-based agent adoption (Phase 9 R3)

### DIFF
--- a/agent/cmd/netpulse-agent/main.go
+++ b/agent/cmd/netpulse-agent/main.go
@@ -9,20 +9,24 @@
 //
 // Config (env o /etc/netpulse-agent.env; el env gana):
 //
-//	NETPULSE_SERVER    URL del servidor (https://... o http://...:3000) [obligatoria]
-//	NETPULSE_TOKEN     token del equipo (64 hex; se muestra una vez al crearlo)
-//	NETPULSE_SLUG      slug del equipo (agent.token.<slug> en el servidor)
-//	NETPULSE_SERVER_FP SHA-256 del SPKI del servidor en hex (obligatorio si la URL es https://)
-//	NETPULSE_INTERVAL  intervalo de push (default 30s; "30", "15s", "1m")
-//	NETPULSE_ENV_FILE  fichero env alternativo (default /etc/netpulse-agent.env)
+//	NETPULSE_SERVER        URL del servidor (https://... o http://...:3000) [obligatoria]
+//	NETPULSE_TOKEN         token del equipo (64 hex; se muestra una vez al crearlo)
+//	NETPULSE_SLUG          slug del equipo (agent.token.<slug> en el servidor)
+//	NETPULSE_SERVER_FP     SHA-256 del SPKI del servidor en hex (obligatorio si la URL es https://)
+//	NETPULSE_PAIRING_TOKEN token de pairing (modo bootstrap: contacta /api/agents/pair para
+//	                       obtener el token real, lo escribe al env file y sale — procd reinicia)
+//	NETPULSE_INTERVAL      intervalo de push (default 30s; "30", "15s", "1m")
+//	NETPULSE_ENV_FILE      fichero env alternativo (default /etc/netpulse-agent.env)
 //	NETPULSE_WAN_TARGET    ping WAN con pérdida (gateway; p. ej. 1.1.1.1)
 //	NETPULSE_GW_TARGET     ping corto al gateway (APs; p. ej. 192.168.8.1)
 package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -57,9 +61,11 @@ const (
 type config struct {
 	server, token, slug string
 	serverFP            string // SPKI hash hex (obligatorio si la URL es https://)
+	pairingToken        string // si está puesto: modo bootstrap (pairing)
 	interval            time.Duration
 	wanTarget, gwTarget string
 	heartbeatFile       string
+	envFile             string // ruta del env file (para escribir el token tras pairing)
 }
 
 // loadEnvFile lee KEY=VALUE de un fichero env (líneas # = comentario).
@@ -83,7 +89,7 @@ func loadEnvFile(path string) map[string]string {
 	return out
 }
 
-// loadConfig: env del proceso > fichero env; fail-fast si falta lo obligatorio.
+	// loadConfig: env del proceso > fichero env; fail-fast si falta lo obligatorio.
 func loadConfig() (config, error) {
 	file := os.Getenv("NETPULSE_ENV_FILE")
 	if file == "" {
@@ -101,10 +107,12 @@ func loadConfig() (config, error) {
 		token:         get("NETPULSE_TOKEN"),
 		slug:          get("NETPULSE_SLUG"),
 		serverFP:      tlspin.Normalize(get("NETPULSE_SERVER_FP")),
+		pairingToken:  get("NETPULSE_PAIRING_TOKEN"),
 		interval:      pollInterval,
 		wanTarget:     get("NETPULSE_WAN_TARGET"),
 		gwTarget:      get("NETPULSE_GW_TARGET"),
 		heartbeatFile: get("NETPULSE_HEARTBEAT_FILE"),
+		envFile:       file,
 	}
 	if v := get("NETPULSE_INTERVAL"); v != "" {
 		if sec, err := strconv.Atoi(v); err == nil && sec > 0 {
@@ -115,14 +123,18 @@ func loadConfig() (config, error) {
 			log.Printf("[netpulse-agent] NETPULSE_INTERVAL %q inválido; usando 30s", v)
 		}
 	}
+	// Validación: SERVER y SLUG siempre obligatorios. TOKEN obligatorio salvo
+	// en modo pairing (donde PAIRING_TOKEN sustituye a TOKEN).
 	for _, kv := range [][2]string{
 		{"NETPULSE_SERVER", cfg.server},
-		{"NETPULSE_TOKEN", cfg.token},
 		{"NETPULSE_SLUG", cfg.slug},
 	} {
 		if kv[1] == "" {
 			return config{}, &configError{kv[0]}
 		}
+	}
+	if cfg.token == "" && cfg.pairingToken == "" {
+		return config{}, &configError{"NETPULSE_TOKEN (o NETPULSE_PAIRING_TOKEN para bootstrap)"}
 	}
 	return cfg, nil
 }
@@ -166,6 +178,13 @@ func run() error {
 	cfg, err := loadConfig()
 	if err != nil {
 		return err
+	}
+
+	// Fase 9 R3: modo pairing (bootstrap). Si hay pairing_token en vez de
+	// token, contactar al servidor una vez, obtener el token real, escribirlo
+	// al env file y salir. procd reinicia el agente, que arranca en modo normal.
+	if cfg.pairingToken != "" {
+		return pairWithServer(cfg)
 	}
 
 	transport, err := tlspin.BuildTransport(cfg.server, cfg.serverFP)
@@ -250,4 +269,95 @@ func run() error {
 		case <-time.After(client.Delay(cfg.interval)):
 		}
 	}
+}
+
+// pairWithServer contacta POST /api/agents/pair con el pairing token, recibe
+// el token real del agente, lo escribe al env file y sale (procd reinicia).
+// Usa el server_fp para validar TLS (el admin lo proporciona junto con el
+// pairing token).
+func pairWithServer(cfg config) error {
+	transport, err := tlspin.BuildTransport(cfg.server, cfg.serverFP)
+	if err != nil {
+		return err
+	}
+
+	body := fmt.Sprintf(`{"pairing_token":%q,"slug":%q}`, cfg.pairingToken, cfg.slug)
+	req, err := http.NewRequest("POST", cfg.server+"/api/agents/pair", strings.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	hc := &http.Client{Transport: transport, Timeout: 15 * time.Second}
+	log.Printf("[netpulse-agent] pairing con %s (slug=%s)…", cfg.server, cfg.slug)
+	res, err := hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("pairing: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 201 {
+		respBody, _ := io.ReadAll(io.LimitReader(res.Body, 512))
+		return fmt.Errorf("pairing fallido (HTTP %d): %s", res.StatusCode, respBody)
+	}
+
+	var pr struct {
+		Slug     string `json:"slug"`
+		Token    string `json:"token"`
+		ServerFP string `json:"server_fp"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&pr); err != nil {
+		return fmt.Errorf("parsear respuesta pairing: %w", err)
+	}
+	if pr.Token == "" {
+		return fmt.Errorf("pairing: token vacío en respuesta")
+	}
+
+	// Escribir el token real al env file (reemplaza PAIRING_TOKEN por TOKEN).
+	if err := writePairedToken(cfg.envFile, pr.Token); err != nil {
+		return fmt.Errorf("escribir token al env file: %w", err)
+	}
+
+	log.Printf("[netpulse-agent] pairing OK (slug=%s). Token escrito a %s. Reiniciando…", pr.Slug, cfg.envFile)
+	// Salir limpiamente: procd reinicia el agente, que ahora lee NETPULSE_TOKEN
+	// del env file y arranca en modo normal.
+	return nil
+}
+
+// writePairedToken reescribe el env file: quita NETPULSE_PAIRING_TOKEN y
+// añade/actualiza NETPULSE_TOKEN. Conserva el resto de líneas.
+func writePairedToken(path, token string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// Si no existe, crear uno nuevo con el token.
+		return os.WriteFile(path, []byte("NETPULSE_TOKEN="+token+"\n"), 0o600)
+	}
+	var out []string
+	haveToken := false
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			out = append(out, line)
+			continue
+		}
+		k, _, ok := strings.Cut(trimmed, "=")
+		if !ok {
+			out = append(out, line)
+			continue
+		}
+		key := strings.TrimSpace(k)
+		if key == "NETPULSE_PAIRING_TOKEN" {
+			continue // eliminar
+		}
+		if key == "NETPULSE_TOKEN" {
+			out = append(out, "NETPULSE_TOKEN="+token)
+			haveToken = true
+			continue
+		}
+		out = append(out, line)
+	}
+	if !haveToken {
+		out = append(out, "NETPULSE_TOKEN="+token)
+	}
+	return os.WriteFile(path, []byte(strings.Join(out, "\n")+"\n"), 0o600)
 }

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -551,6 +551,11 @@
     "admin": {
       "title": "Administration"
     },
+    "adoption": {
+      "title": "Agent adoption",
+      "hint": "Use this pairing token and fingerprint to install new agents. After pairing, the agent gets its real token automatically.",
+      "rotate": "Rotate token"
+    },
     "about": {
       "changelog": "Changelog",
       "code": "Source code",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -552,6 +552,11 @@
     "admin": {
       "title": "Administración"
     },
+    "adoption": {
+      "title": "Adopción de agentes",
+      "hint": "Usa este token de pairing y el fingerprint para instalar agentes nuevos. Tras emparejarse, el agente obtiene su token real automáticamente.",
+      "rotate": "Rotar token"
+    },
     "about": {
       "changelog": "Registro de cambios",
       "code": "Código",

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -32,6 +32,7 @@ import {
   UserCog,
   Users,
   Volume2,
+  Wifi,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { HealthRing } from '@/components/HealthRing'
@@ -1607,7 +1608,75 @@ function UpdateCheckInline() {
         <span role="alert" className="text-[10px] font-medium text-rose-500">
           {t('settings.about.updateError')}
         </span>
-      ) : null}
+       ) : null}
+    </div>
+  )
+}
+
+function AdoptionCard() {
+  const { t } = useTranslation()
+  const [data, setData] = useState<{ token: string; server_fp: string } | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [copied, setCopied] = useState<string | null>(null)
+
+  const fetchToken = async () => {
+    setBusy(true)
+    try {
+      const res = await fetch('/api/pairing/token')
+      if (res.ok) setData(await res.json())
+    } catch { /* ignore */ } finally { setBusy(false) }
+  }
+
+  useEffect(() => { void fetchToken() }, [])
+
+  const rotate = async () => {
+    setBusy(true)
+    try {
+      const res = await fetch('/api/pairing/rotate', { method: 'POST' })
+      if (res.ok) setData(await res.json())
+    } catch { /* ignore */ } finally { setBusy(false) }
+  }
+
+  const copy = (val: string, label: string) => {
+    navigator.clipboard?.writeText(val)
+    setCopied(label)
+    setTimeout(() => setCopied(null), 2000)
+  }
+
+  if (!data?.token) return null
+
+  return (
+    <div className="rounded-xl border border-border bg-surface p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <Wifi className="h-4 w-4 text-accent" strokeWidth={1.75} aria-hidden="true" />
+        <h3 className="text-sm font-semibold text-text-primary">{t('settings.adoption.title')}</h3>
+      </div>
+      <p className="mb-3 text-xs text-text-secondary">{t('settings.adoption.hint')}</p>
+
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <code className="flex-1 truncate rounded-lg bg-elevated px-2.5 py-1.5 font-mono text-xs text-text-primary">{data.token}</code>
+          <button type="button" onClick={() => copy(data.token, 'token')} className="rounded-lg border border-border px-2 py-1.5 text-xs text-text-secondary hover:bg-hover" title={t('common.copy')}>
+            <Copy className="h-3.5 w-3.5" strokeWidth={1.75} />
+          </button>
+          {copied === 'token' && <span className="text-[10px] text-ok">✓</span>}
+        </div>
+
+        {data.server_fp && (
+          <div className="flex items-center gap-2">
+            <code className="flex-1 truncate rounded-lg bg-elevated px-2.5 py-1.5 font-mono text-xs text-text-primary">{data.server_fp}</code>
+            <button type="button" onClick={() => copy(data.server_fp, 'fp')} className="rounded-lg border border-border px-2 py-1.5 text-xs text-text-secondary hover:bg-hover" title={t('common.copy')}>
+              <Copy className="h-3.5 w-3.5" strokeWidth={1.75} />
+            </button>
+            {copied === 'fp' && <span className="text-[10px] text-ok">✓</span>}
+          </div>
+        )}
+      </div>
+
+      <button type="button" onClick={() => void rotate()} disabled={busy} className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:bg-hover disabled:opacity-60">
+        <RefreshCw className={`h-3.5 w-3.5 ${busy ? 'animate-spin' : ''}`} strokeWidth={1.75} />
+        {t('settings.adoption.rotate')}
+      </button>
     </div>
   )
 }
@@ -2333,6 +2402,13 @@ export default function Settings() {
         {!isDemo && auth?.role === 'admin' && (
           <div className="lg:col-span-12">
             <RoutersManager reduce={reduce} onSaved={notify} />
+          </div>
+        )}
+
+        {/* Adopción de agentes (pairing token + server fingerprint) */}
+        {!isDemo && auth?.role === 'admin' && (
+          <div className="lg:col-span-12">
+            <AdoptionCard />
           </div>
         )}
 

--- a/install-agent.sh
+++ b/install-agent.sh
@@ -17,7 +17,10 @@
 #   --host X        IP/host del router (obligatorio)
 #   --server X      URL del servidor NetPulse (obligatoria salvo --uninstall)
 #   --slug X        slug del equipo en NetPulse (obligatorio salvo --uninstall)
-#   --token X       token del equipo (obligatorio salvo --uninstall)
+#   --token X       token del equipo (obligatorio salvo --uninstall y --pairing-token)
+#   --pairing-token X  token de pairing (bootstrap: el agente contacta al servidor
+#                   y obtiene el token real automáticamente; Fase 9 R3)
+#   --server-fp X   SHA-256 SPKI del servidor en hex (obligatorio si --server es https://)
 #   --ssh-user X    usuario SSH del router (default: root)
 #   --binary X      binario local a copiar (default: descarga de la release)
 #   --version X.Y.Z versión a descargar (default: latest)
@@ -37,7 +40,7 @@ ENV_FILE="/etc/netpulse-agent.env"
 INIT_NAME="netpulse-agent"
 INIT_DST="/etc/init.d/$INIT_NAME"
 
-HOST=""; SERVER=""; SLUG=""; TOKEN=""; SSH_USER="root"; BINARY=""; NETPULSE_VERSION=""; USE_TMP=0; UNINSTALL=0
+HOST=""; SERVER=""; SLUG=""; TOKEN=""; PAIRING_TOKEN=""; SERVER_FP=""; SSH_USER="root"; BINARY=""; NETPULSE_VERSION=""; USE_TMP=0; UNINSTALL=0
 
 if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
     C_G=$(printf '\033[32m'); C_R=$(printf '\033[31m'); C_Y=$(printf '\033[33m'); C_B=$(printf '\033[1m'); C_0=$(printf '\033[0m')
@@ -55,6 +58,8 @@ for arg in "$@"; do
         --server=*)   SERVER="${arg#*=}" ;;
         --slug=*)     SLUG="${arg#*=}" ;;
         --token=*)    TOKEN="${arg#*=}" ;;
+        --pairing-token=*) PAIRING_TOKEN="${arg#*=}" ;;
+        --server-fp=*) SERVER_FP="${arg#*=}" ;;
         --ssh-user=*) SSH_USER="${arg#*=}" ;;
         --binary=*)   BINARY="${arg#*=}" ;;
         --version=*)  NETPULSE_VERSION="${arg#*=}" ;;
@@ -89,7 +94,10 @@ fi
 
 [ -n "$SERVER" ] || fatal 11 "falta --server (URL de NetPulse)"
 [ -n "$SLUG" ]   || fatal 11 "falta --slug"
-[ -n "$TOKEN" ]  || fatal 11 "falta --token (se muestra una vez al crearlo: POST /api/agents)"
+# Token: obligatorio --token o --pairing-token (no ambos)
+if [ -z "$TOKEN" ] && [ -z "$PAIRING_TOKEN" ]; then
+    fatal 11 "falta --token (o --pairing-token para bootstrap)"
+fi
 SERVER="${SERVER%/}"
 
 ssh -o ConnectTimeout=8 -o BatchMode=yes "$SSH" true \
@@ -158,15 +166,26 @@ ok "binario en $BIN_DST"
 
 # Config (chmod 600: el token solo lo lee root)
 info "escribiendo $ENV_FILE (chmod 600)"
+# Construir la línea de token: PAIRING_TOKEN (bootstrap) o TOKEN (normal)
+if [ -n "$PAIRING_TOKEN" ]; then
+    TOKEN_LINE="NETPULSE_PAIRING_TOKEN=$PAIRING_TOKEN"
+else
+    TOKEN_LINE="NETPULSE_TOKEN=$TOKEN"
+fi
+# Server fingerprint (si se proporciona)
+FP_LINE=""
+if [ -n "$SERVER_FP" ]; then
+    FP_LINE="NETPULSE_SERVER_FP=$SERVER_FP"
+fi
 ssh "$SSH" "cat > $ENV_FILE && chmod 600 $ENV_FILE" <<EOF
 # netpulse-agent — config (generado por install-agent.sh)
 NETPULSE_SERVER=$SERVER
 NETPULSE_SLUG=$SLUG
-NETPULSE_TOKEN=$TOKEN
+$TOKEN_LINE
+$FP_LINE
 # NETPULSE_INTERVAL=15
 # NETPULSE_WAN_TARGET=1.1.1.1      # solo si este equipo es el gateway
 # NETPULSE_GW_TARGET=192.168.8.1   # ping al gateway (APs)
-# NETPULSE_SERVER_FP=<sha256 hex>  # obligatorio si SERVER es https:// (pinning SPKI)
 EOF
 ok "config escrita"
 

--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -267,28 +267,8 @@ func run() error {
 		return checkAgentToken(dbHandle, slug, token)
 	})
 
-	handler := httpapi.NewHandler(httpapi.Deps{
-		Config:   cfg,
-		DB:       dbHandle,
-		Adapter:  adapter,
-		Hub:      hub,
-		Secret:   secret,
-		Static:   static,
-		Updater:  upd,
-		Agents:   agentReg,
-		Pool:     sshPool,
-		Rearmer:  arm,
-		AgentHub: agentHub,
-		LastOverview: func() *adapters.Overview {
-			return p.LastOverview()
-		},
-		PollNow: p.PollNow,
-		Started: time.Now(),
-	})
-
-	// Fase 9 R2: TLS autofirmado on-box. En modo on-box se genera/carga un
-	// cert autofirmado, se registra GET /fingerprint (sin auth, para que el
-	// agente pueda pinear el SPKI) y se sirve HTTPS. Sin ONBOX: HTTP plano.
+	// Fase 9 R2/R3: TLS autofirmado + pairing token (on-box only).
+	// Se generan ANTES del handler para que serverFP esté disponible en Deps.
 	var (
 		serverFP string
 		tlsConf  *tls.Config
@@ -303,11 +283,42 @@ func run() error {
 		}
 		log.Printf("[netpulse] TLS autofirmado on-box: %s", certPath)
 		log.Printf("[netpulse] FINGERPRINT SPKI (sha256): %s", serverFP)
-		// Envolver el handler con el endpoint /fingerprint (sin auth).
+
+		// Pairing token (generado en primer arranque, logueado).
+		pairTok, perr := httpapi.EnsurePairingToken(dbHandle)
+		if perr != nil {
+			return fmt.Errorf("pairing token: %w", perr)
+		}
+		log.Printf("[netpulse] PAIRING TOKEN: %s", pairTok)
+	}
+
+	handler := httpapi.NewHandler(httpapi.Deps{
+		Config:   cfg,
+		DB:       dbHandle,
+		Adapter:  adapter,
+		Hub:      hub,
+		Secret:   secret,
+		Static:   static,
+		Updater:  upd,
+		Agents:   agentReg,
+		Pool:     sshPool,
+		Rearmer:  arm,
+		AgentHub: agentHub,
+		ServerFP: serverFP,
+		LastOverview: func() *adapters.Overview {
+			return p.LastOverview()
+		},
+		PollNow: p.PollNow,
+		Started: time.Now(),
+	})
+
+	// Envolver el handler con GET /fingerprint (sin auth) si on-box.
+	if cfg.Onbox {
+		fp := serverFP
 		fpMux := http.NewServeMux()
 		fpMux.HandleFunc("GET /fingerprint", func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"spki_sha256":%q}`, serverFP)
+			fmt.Fprintf(w, `{"spki_sha256":%q}`, fp)
 		})
 		fpMux.Handle("/", handler)
 		handler = fpMux

--- a/server-go/internal/auth/middleware.go
+++ b/server-go/internal/auth/middleware.go
@@ -45,14 +45,15 @@ func WriteError(w http.ResponseWriter, status int, code string, message ...strin
 
 // RequireAuth es middleware global: todo /api/* exige sesión salvo
 // /api/health, /api/auth/login, /api/ingest/agent (auth Bearer por token
-// de equipo), /api/agents/{slug}/binary (auth Bearer por token de agente,
+// de equipo), /api/agents/pair (pairing token de un solo uso, Fase 9 R3),
+// /api/agents/{slug}/binary (auth Bearer por token de agente,
 // Fase 6.2) y /api/agents/{slug}/stream (SSE bidireccional, Fase 7.3).
 // Fallo → 401 {error:'unauthorized'}.
 func RequireAuth(d *db.DB, secret string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 		if !strings.HasPrefix(path, "/api/") || path == "/api/health" || path == "/api/auth/login" ||
-			path == "/api/ingest/agent" ||
+			path == "/api/ingest/agent" || path == "/api/agents/pair" ||
 			(strings.HasPrefix(path, "/api/agents/") && (strings.HasSuffix(path, "/binary") || strings.HasSuffix(path, "/stream"))) {
 			next.ServeHTTP(w, r)
 			return

--- a/server-go/internal/httpapi/pairing.go
+++ b/server-go/internal/httpapi/pairing.go
@@ -1,0 +1,167 @@
+// pairing.go — Fase 9 R3: pairing/adopción cero-fricción de agentes.
+//
+// El servidor on-box genera un pairing token (UUID) en el primer arranque,
+// visible en la UI de Ajustes > Adopción y en el log. Al instalar un agente
+// nuevo, el admin proporciona el pairing token + el server_fp (ambos visibles
+// en la UI). El agente contacta POST /api/agents/pair con ambos; el servidor
+// valida el pairing token, crea el agente (slug + token) y devuelve el token
+// real del agente + el server_fp para que lo pinee.
+//
+// POST /api/agents/pair NO requiere sesión (el pairing token ES la auth) pero
+// lleva rate limit por IP (mismo que la ingesta, 30/min).
+//
+// GET  /api/pairing/token   (admin) — ver el pairing token actual.
+// POST /api/pairing/rotate  (admin) — rotar el pairing token (invalida el viejo).
+package httpapi
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"fmt"
+	"net/http"
+
+	"github.com/gnacho/netpulse/server-go/internal/auth"
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+const pairingTokenKey = "pairing.token"
+
+// newPairingToken genera un UUID v4 como string (crypto/rand).
+func newPairingToken() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:]), nil
+}
+
+// getPairingToken lee el pairing token actual del kv. Si no existe, lo genera.
+func (s *server) getPairingToken() (string, error) {
+	var existing string
+	err := s.db.QueryRow("SELECT value FROM kv WHERE key = ?", pairingTokenKey).Scan(&existing)
+	if err == nil && existing != "" {
+		return existing, nil
+	}
+	// Generar uno nuevo si no existe (primer arranque o migración).
+	tok, err := newPairingToken()
+	if err != nil {
+		return "", err
+	}
+	if _, err := s.db.Exec(
+		"INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO NOTHING",
+		pairingTokenKey, tok); err != nil {
+		return "", err
+	}
+	return tok, nil
+}
+
+// handlePairingToken (GET /api/pairing/token): devuelve el pairing token
+// actual (admin only — el token permite adoptar agentes).
+func (s *server) handlePairingToken(w http.ResponseWriter, _ *http.Request) {
+	tok, err := s.getPairingToken()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "pairing_error")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"token": tok, "server_fp": s.serverFP})
+}
+
+// handlePairingRotate (POST /api/pairing/rotate): genera un pairing token
+// nuevo, reemplazando el anterior. Los agentes ya paired siguen funcionando
+// (su token de agente es independiente).
+func (s *server) handlePairingRotate(w http.ResponseWriter, _ *http.Request) {
+	tok, err := newPairingToken()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "token_error")
+		return
+	}
+	if _, err := s.db.Exec(
+		"INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+		pairingTokenKey, tok); err != nil {
+		writeError(w, http.StatusInternalServerError, "token_error")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"token": tok})
+}
+
+// pairRequest es el body de POST /api/agents/pair.
+type pairRequest struct {
+	PairingToken string `json:"pairing_token"`
+	Slug         string `json:"slug"`
+}
+
+// pairResponse es lo que recibe el agente tras un pairing exitoso.
+type pairResponse struct {
+	Slug    string `json:"slug"`
+	Token   string `json:"token"`
+	ServerFP string `json:"server_fp"`
+}
+
+// handleAgentPair (POST /api/agents/pair): valida el pairing token y crea un
+// agente nuevo. No requiere sesión (el pairing token es la auth). Rate limited.
+func (s *server) handleAgentPair(w http.ResponseWriter, r *http.Request) {
+	ip := auth.ClientIP(r)
+	if ok, _ := s.ingestLimit.allow(ip); !ok {
+		writeError(w, http.StatusTooManyRequests, "rate_limited")
+		return
+	}
+
+	var body pairRequest
+	if !readJSONBody(r, &body) || !agentSlugRe.MatchString(body.Slug) || body.PairingToken == "" {
+		writeError(w, http.StatusBadRequest, "invalid_body",
+			`Se esperaba { "pairing_token": "...", "slug": "<equipo>" }`)
+		return
+	}
+
+	// Validar pairing token contra el almacenado.
+	stored, err := s.getPairingToken()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "pairing_error")
+		return
+	}
+	if stored == "" || subtle.ConstantTimeCompare([]byte(body.PairingToken), []byte(stored)) != 1 {
+		writeError(w, http.StatusUnauthorized, "invalid_pairing_token")
+		return
+	}
+
+	// Crear el agente (mismo flujo que POST /api/agents).
+	token, err := newAgentToken()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "token_error")
+		return
+	}
+	if _, err := s.db.Exec(
+		"INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+		agentTokenKey(body.Slug), hashAgentToken(token)); err != nil {
+		writeError(w, http.StatusInternalServerError, "token_error")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, pairResponse{
+		Slug:     body.Slug,
+		Token:    token,
+		ServerFP: s.serverFP,
+	})
+}
+
+// EnsurePairingToken es llamado desde main.go en el primer arranque on-box
+// para generar y loguear el pairing token.
+func EnsurePairingToken(database *db.DB) (string, error) {
+	var existing string
+	err := database.QueryRow("SELECT value FROM kv WHERE key = ?", pairingTokenKey).Scan(&existing)
+	if err == nil && existing != "" {
+		return existing, nil
+	}
+	tok, err := newPairingToken()
+	if err != nil {
+		return "", err
+	}
+	if _, err := database.Exec(
+		"INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO NOTHING",
+		pairingTokenKey, tok); err != nil {
+		return "", err
+	}
+	return tok, nil
+}

--- a/server-go/internal/httpapi/pairing_test.go
+++ b/server-go/internal/httpapi/pairing_test.go
@@ -1,0 +1,148 @@
+// pairing_test.go — Fase 9 R3: tests del protocolo de pairing.
+package httpapi_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// pairResult es la respuesta de POST /api/agents/pair.
+type pairResult struct {
+	Slug     string `json:"slug"`
+	Token    string `json:"token"`
+	ServerFP string `json:"server_fp"`
+}
+
+func getPairingToken(t *testing.T, ts *agentTestServer) string {
+	t.Helper()
+	req, _ := http.NewRequest("GET", ts.URL+"/api/pairing/token", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: ts.cookie})
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET pairing/token: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		t.Fatalf("pairing token status: %d", res.StatusCode)
+	}
+	var body struct{ Token string `json:"token"` }
+	json.NewDecoder(res.Body).Decode(&body)
+	if body.Token == "" {
+		t.Fatal("pairing token vacío")
+	}
+	return body.Token
+}
+
+func pair(t *testing.T, ts *agentTestServer, pairingToken, slug string) (int, *pairResult) {
+	t.Helper()
+	body := fmt.Sprintf(`{"pairing_token":%q,"slug":%q}`, pairingToken, slug)
+	res, err := http.Post(ts.URL+"/api/agents/pair", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("pair: %v", err)
+	}
+	defer res.Body.Close()
+	var pr pairResult
+	json.NewDecoder(res.Body).Decode(&pr)
+	return res.StatusCode, &pr
+}
+
+func TestPairCreatesAgentAndReturnsToken(t *testing.T) {
+	ts := makeAgentTestServer(t)
+	pairTok := getPairingToken(t, ts)
+
+	status, pr := pair(t, ts, pairTok, "patio")
+	if status != 201 {
+		t.Fatalf("pair status: %d", status)
+	}
+	if pr.Slug != "patio" || pr.Token == "" {
+		t.Fatalf("pair response: %+v", pr)
+	}
+
+	// El token devuelto debe funcionar para ingesta.
+	res := ingest(t, ts, pr.Token, "10.0.0.1", validPayload())
+	defer res.Body.Close()
+	if res.StatusCode != 202 && res.StatusCode != 204 {
+		t.Fatalf("ingest tras pair falló: %d", res.StatusCode)
+	}
+}
+
+func TestPairRejectsInvalidToken(t *testing.T) {
+	ts := makeAgentTestServer(t)
+	status, _ := pair(t, ts, "token-falso-no-existe", "bad-ap")
+	if status != 401 {
+		t.Fatalf("expected 401, got %d", status)
+	}
+}
+
+func TestPairRejectsInvalidSlug(t *testing.T) {
+	ts := makeAgentTestServer(t)
+	pairTok := getPairingToken(t, ts)
+	// Slug con mayúsculas (inválido: regex ^[a-z0-9][a-z0-9-]{0,63}$).
+	status, _ := pair(t, ts, pairTok, "BAD")
+	if status != 400 {
+		t.Fatalf("expected 400 for bad slug, got %d", status)
+	}
+}
+
+func TestPairRequiresTokenField(t *testing.T) {
+	ts := makeAgentTestServer(t)
+	body := `{"slug":"test-ap"}`
+	res, err := http.Post(ts.URL+"/api/agents/pair", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("pair: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 400 {
+		t.Fatalf("expected 400 without pairing_token, got %d", res.StatusCode)
+	}
+}
+
+func TestPairingRotateChangesToken(t *testing.T) {
+	ts := makeAgentTestServer(t)
+	old := getPairingToken(t, ts)
+
+	// Rotar.
+	req, _ := http.NewRequest("POST", ts.URL+"/api/pairing/rotate", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: ts.cookie})
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		t.Fatalf("rotate status: %d", res.StatusCode)
+	}
+	var body struct{ Token string `json:"token"` }
+	json.NewDecoder(res.Body).Decode(&body)
+	if body.Token == "" || body.Token == old {
+		t.Fatalf("rotate should generate a new token: old=%s new=%s", old, body.Token)
+	}
+
+	// El token viejo ya no debe funcionar para pairing.
+	status, _ := pair(t, ts, old, "post-rotate")
+	if status != 401 {
+		t.Fatalf("old pairing token should be invalid after rotate, got %d", status)
+	}
+
+	// El token nuevo sí funciona.
+	status2, _ := pair(t, ts, body.Token, "post-rotate")
+	if status2 != 201 {
+		t.Fatalf("new pairing token should work, got %d", status2)
+	}
+}
+
+func TestPairingTokenRequiresAdmin(t *testing.T) {
+	ts := makeAgentTestServer(t)
+	// Sin cookie de sesión.
+	res, err := http.Get(ts.URL + "/api/pairing/token")
+	if err != nil {
+		t.Fatalf("GET sin sesión: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode == 200 {
+		t.Fatal("GET /api/pairing/token sin sesión debería fallar")
+	}
+}

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -65,6 +65,9 @@ type Deps struct {
 	// AgentHub: SSE bidireccional para agentes (Fase 7.3). nil → endpoint
 	// de stream devuelve 503.
 	AgentHub *sse.AgentHub
+	// ServerFP: fingerprint SPKI del servidor (hex). Vacío si no es on-box.
+	// Se devuelve en /api/agents/pair para que el agentepine el TLS.
+	ServerFP string
 }
 
 type server struct {
@@ -82,6 +85,9 @@ type server struct {
 
 	// SSE bidireccional para agentes (Fase 7.3).
 	agentHub *sse.AgentHub
+
+	// Fingerprint SPKI del servidor (vacío si no es on-box).
+	serverFP string
 
 	// Anti-martilleo de POST /api/refresh (global, min 5 s entre sondeos).
 	refreshMu   sync.Mutex
@@ -101,6 +107,7 @@ func NewHandler(d Deps) http.Handler {
 		secret: d.Secret, agents: d.Agents, pool: d.Pool,
 		lastOv: d.LastOverview, pollNow: d.PollNow, started: d.Started,
 		agentHub:    d.AgentHub,
+		serverFP:    d.ServerFP,
 		ingestLimit: newIPRateLimit(ingestRateLimit, ingestRateWindow),
 	}
 	// Rearmer compartido entre el endpoint manual y el supervisor de
@@ -181,6 +188,13 @@ func NewHandler(d Deps) http.Handler {
 		// Forzar refresh del agente vía SSE (admin; útil para depuración y futuro UI)
 		mux.Handle("POST /api/agents/{slug}/refresh", auth.RequireAdmin(http.HandlerFunc(s.handleAgentRefresh)))
 	}
+
+	// --- Fase 9 R3: Pairing / adopción de agentes ---
+	// POST /api/agents/pair: sin sesión (el pairing token ES la auth), rate limited.
+	mux.HandleFunc("POST /api/agents/pair", s.handleAgentPair)
+	// Gestión del pairing token (admin).
+	mux.Handle("GET /api/pairing/token", auth.RequireAdmin(http.HandlerFunc(s.handlePairingToken)))
+	mux.Handle("POST /api/pairing/rotate", auth.RequireAdmin(http.HandlerFunc(s.handlePairingRotate)))
 
 	// --- Web Push (Fase 3 Bloque C; tras sesión como el resto del API) ---
 	mux.HandleFunc("GET /api/push/vapid-key", s.handlePushVapidKey)


### PR DESCRIPTION
Closes #86.

Implements the zero-friction pairing protocol from the on-box SPEC (R3). The server generates a pairing token (UUID v4) on first start; the admin provides it alongside the server fingerprint when installing a new agent. The agent contacts `POST /api/agents/pair`, gets its real token + server_fp, writes them to its config, and restarts in normal mode.

**Server** (`pairing.go`): pairing token in kv (UUID v4), `POST /api/agents/pair` (unauthenticated, rate-limited, constant-time compare), `GET /api/pairing/token` + `POST /api/pairing/rotate` (admin). `EnsurePairingToken` generates + logs on first start (on-box).

**Agent**: `NETPULSE_PAIRING_TOKEN` triggers bootstrap mode — contacts server, gets real token, writes env file, exits (procd restarts in normal mode).

**Frontend**: `AdoptionCard` in Settings shows token + server_fp with copy buttons and rotate.

**install-agent.sh**: `--pairing-token` and `--server-fp` flags.

**Tests**: 6 pairing tests. Full suite `-race` green.