### PR TITLE
fix(topology): tooltip card clipped by overflow-hidden on map container

### DIFF
--- a/app/src/pages/Topology.tsx
+++ b/app/src/pages/Topology.tsx
@@ -182,10 +182,10 @@ export default function Topology() {
 
       {/* ② Map canvas */}
       <section
-        className="relative h-[70dvh] min-h-[420px] overflow-hidden rounded-2xl border border-border bg-canvas lg:h-[600px]"
+        className="relative h-[70dvh] min-h-[420px] rounded-2xl border border-border bg-canvas lg:h-[600px]"
         aria-label={t('topology.interactiveMap')}
       >
-        <div className="mesh-bg pointer-events-none absolute inset-0" aria-hidden />
+        <div className="mesh-bg pointer-events-none absolute inset-0 overflow-hidden rounded-2xl" aria-hidden />
         <TopologyMap
           model={model}
           apiRef={mapApi}


### PR DESCRIPTION
The map section had `overflow-hidden` to clip the mesh background to the rounded corners. The TooltipCard is a child of that section, so hovering a device chip near the top/bottom edge got the tooltip clipped — device info was invisible.

SVG clips its own content by default, so `overflow-hidden` was only needed for the mesh-bg. Moved it to the mesh-bg wrapper (`overflow-hidden rounded-2xl`) and removed it from the section.