### PR TITLE
feat(agent): DAWN probe — roaming visibility (Fase 14.1)

### DIFF
--- a/agent/probe/local.go
+++ b/agent/probe/local.go
@@ -90,6 +90,7 @@ func (p *Prober) Build(ctx context.Context, router, version string) *Payload {
 	pl.Data.Wireless = p.probeWireless(ctx)
 	pl.Data.DHCP = p.probeDHCP(ctx)
 	pl.Data.FDB = p.probeFDB(ctx)
+	pl.Data.Dawn = p.probeDawn(ctx)
 	return pl
 }
 
@@ -271,4 +272,93 @@ func (p *Prober) probeFDB(ctx context.Context) *FDBData {
 		fd.Ports = []EthPort{}
 	}
 	return fd
+}
+
+// probeDawn: lee el estado de DAWN (roaming/band-steering, Fase 14) vía
+// `ubus call dawn get_network`. Devuelve nil si DAWN no está instalado
+// (fail-soft silencioso — la sección queda ausente en el payload).
+//
+// El output de ubus mezcla campos del AP (channel, freq, etc.) con clientes
+// anidados (MAC → {signal, ht, ...}) en el mismo objeto por BSSID. Los
+// distinguimos por tipo: escalares = metadata del AP, objetos = clientes.
+func (p *Prober) probeDawn(ctx context.Context) *DawnData {
+	out := p.runBest(ctx, "ubus call dawn get_network", 5*time.Second)
+	if out == "" {
+		return nil
+	}
+
+	// SSID → BSSID → {campos mixtos}
+	var raw map[string]map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(out), &raw); err != nil {
+		return nil
+	}
+
+	ssids := make(map[string]DawnSSID, len(raw))
+	for ssid, bssids := range raw {
+		var aps []DawnAP
+		clients := make(map[string]DawnClient)
+
+		for bssidKey, bssidRaw := range bssids {
+			// Parsear todos los campos del BSSID como mapa flexible.
+			var fields map[string]json.RawMessage
+			if err := json.Unmarshal(bssidRaw, &fields); err != nil {
+				continue
+			}
+
+			// ¿Tiene "channel"? → es un AP.
+			chRaw, hasChannel := fields["channel"]
+			if !hasChannel {
+				continue
+			}
+			var channel int
+			json.Unmarshal(chRaw, &channel)
+			if channel == 0 {
+				continue
+			}
+
+			ap := DawnAP{BSSID: bssidKey, Channel: channel}
+			json.Unmarshal(fields["freq"], &ap.Freq)
+			json.Unmarshal(fields["channel_utilization"], &ap.Utilization)
+			json.Unmarshal(fields["num_sta"], &ap.Clients)
+			json.Unmarshal(fields["ht_support"], &ap.HT)
+			json.Unmarshal(fields["vht_support"], &ap.VHT)
+			json.Unmarshal(fields["local"], &ap.Local)
+			json.Unmarshal(fields["hostname"], &ap.Hostname)
+			aps = append(aps, ap)
+
+			// Buscar clientes anidados: cualquier key cuyo valor sea un
+			// objeto (empieza con '{') y tenga "signal".
+			for mac, valRaw := range fields {
+				if mac == "channel" || mac == "freq" || mac == "channel_utilization" ||
+					mac == "num_sta" || mac == "ht_support" || mac == "vht_support" ||
+					mac == "local" || mac == "hostname" || mac == "iface" ||
+					mac == "neighbor_report" || mac == "op_class" {
+					continue
+				}
+				s := strings.TrimSpace(string(valRaw))
+				if !strings.HasPrefix(s, "{") {
+					continue
+				}
+				var c struct {
+					Signal int  `json:"signal"`
+					HT     bool `json:"ht"`
+					VHT    bool `json:"vht"`
+				}
+				if json.Unmarshal(valRaw, &c) == nil && c.Signal < 0 {
+					clients[strings.ToUpper(mac)] = DawnClient{
+						BSSID: bssidKey, Signal: c.Signal, HT: c.HT, VHT: c.VHT,
+					}
+				}
+			}
+		}
+
+		if len(aps) > 0 {
+			ssids[ssid] = DawnSSID{APs: aps, Clients: clients}
+		}
+	}
+
+	if len(ssids) == 0 {
+		return nil
+	}
+	return &DawnData{SSIDs: ssids}
 }

--- a/agent/probe/payload.go
+++ b/agent/probe/payload.go
@@ -12,7 +12,7 @@ type Payload struct {
 	Data    PayloadData `json:"data"`
 }
 
-// PayloadData agrupa las 4 secciones del tier rápido. Punteros/mapas nil =
+// PayloadData agrupa las secciones del tier rápido. Punteros/mapas nil =
 // sonda fallida en este push (el servidor conserva el último dato bueno,
 // mismo anti-parpadeo que el pipeline SSH).
 type PayloadData struct {
@@ -20,6 +20,7 @@ type PayloadData struct {
 	Wireless *WirelessData `json:"wireless,omitempty"`
 	DHCP     *DHCPData     `json:"dhcp,omitempty"`
 	FDB      *FDBData      `json:"fdb,omitempty"`
+	Dawn     *DawnData     `json:"dawn,omitempty"` // Fase 14: DAWN roaming (solo si instalado)
 }
 
 // SystemData: salud del equipo + tráfico + latencias.
@@ -55,4 +56,38 @@ type DHCPData struct {
 type FDBData struct {
 	MACs  map[string]string `json:"macs"` // {} = sin entradas; ausente = sonda fallida
 	Ports []EthPort         `json:"ports"`
+}
+
+// DawnData: estado de DAWN (roaming/band-steering, Fase 14). Solo si DAWN
+// está instalado en el router. Trimmed del output de `ubus call dawn
+// get_network` — solo lo que la UI necesita (APs + señal por cliente).
+type DawnData struct {
+	SSIDs map[string]DawnSSID `json:"ssids"`
+}
+
+// DawnSSID: por red WiFi (p. ej. "temiscira").
+type DawnSSID struct {
+	APs     []DawnAP              `json:"aps"`
+	Clients map[string]DawnClient `json:"clients"` // MAC upper → cliente
+}
+
+// DawnAP: un punto de acceso (BSSID) visto por DAWN en este SSID.
+type DawnAP struct {
+	BSSID       string `json:"bssid"`
+	Hostname    string `json:"hostname,omitempty"`
+	Channel     int    `json:"channel"`
+	Freq        int    `json:"freq"`
+	Utilization int    `json:"utilization"` // %
+	Clients     int    `json:"clients"`
+	Local       bool   `json:"local"` // true si es este router
+	HT          bool   `json:"ht"`
+	VHT         bool   `json:"vht"`
+}
+
+// DawnClient: un cliente WiFi visto por DAWN con señal al AP asociado.
+type DawnClient struct {
+	BSSID  string `json:"bssid"`
+	Signal int    `json:"signal"` // dBm (negativo)
+	HT     bool   `json:"ht"`
+	VHT    bool   `json:"vht"`
 }


### PR DESCRIPTION
Agent probes DAWN via `ubus call dawn get_network` every 30s. Trimmed payload with AP metadata + per-client signal. Fail-soft if DAWN not installed.

Foundation for Fase 14 (WiFi/roaming visibility). Server forwarding + UI next.