### PR TITLE
feat(reports): daily/monthly availability + range tabs (Phase 15.1)

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -442,18 +442,21 @@
     "trafficAria": "{{name}} traffic over the last 24 hours"
   },
   "reports": {
-    "availability": "Weekly availability",
+    "availability": "Availability",
     "colAvg": "Average",
     "colRouter": "Router",
     "empty": "No data for this period yet. The nightly rollup populates the report each day.",
     "error": "Could not load the report. Check the connection and try again.",
-    "footnote": "Availability = minutes with data over the total of recorded days. The current week is shown as partial.",
+    "footnote": "Availability = minutes with data over the period total. The current period is shown as partial.",
     "latency": "Average latency",
     "loading": "Loading report…",
-    "subtitle": "Availability and performance per router, in ISO weeks (Monday–Sunday).",
+    "rangeLabel": "Range to show",
+    "subtitle": "Availability and performance per router.",
+    "tabDay": "Daily",
+    "tabWeek": "Weekly",
+    "tabMonth": "Monthly",
     "traffic": "Total traffic (↓+↑)",
-    "upMin": "Minutes with data",
-    "weeksLabel": "Weeks to show"
+    "upMin": "Minutes with data"
   },
   "topology": {
     "animateFlow": "Animate packet flow",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -443,18 +443,21 @@
     "trafficAria": "Tráfico de {{name}} en las últimas 24 horas"
   },
   "reports": {
-    "availability": "Disponibilidad semanal",
+    "availability": "Disponibilidad",
     "colAvg": "Media",
     "colRouter": "Router",
     "empty": "Todavía no hay datos para este período. El rollup nocturno rellena el informe cada día.",
     "error": "No se pudo cargar el informe. Comprueba la conexión e inténtalo de nuevo.",
-    "footnote": "Disponibilidad = minutos con datos sobre el total de los días con registro. La semana en curso se muestra parcial.",
+    "footnote": "Disponibilidad = minutos con datos sobre el total del período. El período en curso se muestra parcial.",
     "latency": "Latencia media",
     "loading": "Cargando informe…",
-    "subtitle": "Disponibilidad y rendimiento por router, en semanas ISO (lunes-domingo).",
+    "rangeLabel": "Rango a mostrar",
+    "subtitle": "Disponibilidad y rendimiento por router.",
+    "tabDay": "Diario",
+    "tabWeek": "Semanal",
+    "tabMonth": "Mensual",
     "traffic": "Tráfico total (↓+↑)",
-    "upMin": "Minutos con datos",
-    "weeksLabel": "Semanas a mostrar"
+    "upMin": "Minutos con datos"
   },
   "topology": {
     "animateFlow": "Animar flujo de paquetes",

--- a/app/src/pages/Reports.tsx
+++ b/app/src/pages/Reports.tsx
@@ -6,15 +6,15 @@ import { CalendarDays, RefreshCw } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 // ---------------------------------------------------------------------------
-// Tipos del contrato GET /api/reports/weekly (server-go/internal/httpapi/reports.go)
+// Tipos del contrato GET /api/reports/availability (server-go/internal/httpapi/reports.go)
 // ---------------------------------------------------------------------------
 
-interface WeeklyEntry {
+interface AvailabilityEntry {
   routerId: string
-  week: string // "2026-W31" (semana ISO, lunes-domingo)
+  bucket: string // day "2026-08-07" | week "2026-W31" | month "2026-07"
   days: number
-  upMin: number // minutos de recolección en la semana
-  upPct: number // % de disponibilidad sobre los días con datos
+  upMin: number
+  upPct: number
   latAvg: number | null
   rxTotal: number
   txTotal: number
@@ -22,7 +22,16 @@ interface WeeklyEntry {
   ramAvg: number
 }
 
-const WEEK_OPTIONS = [2, 4, 8, 12]
+type Range = 'day' | 'week' | 'month'
+
+const N_OPTIONS: Record<Range, number[]> = {
+  day: [7, 14, 30, 60],
+  week: [2, 4, 8, 12],
+  month: [3, 6, 12, 24],
+}
+const DEFAULT_N: Record<Range, number> = { day: 30, week: 8, month: 12 }
+const SUFFIX: Record<Range, string> = { day: 'd', week: 'w', month: 'm' }
+const RANGE_TABS: Range[] = ['day', 'week', 'month']
 
 /** Formatea bytes a unidad legible (mismo estilo que fmtEs de tráfico). */
 function fmtBytes(b: number): string {
@@ -51,23 +60,24 @@ function AvailabilityBar({ pct }: { pct: number }) {
   )
 }
 
-/** Página `/reports` — Informe semanal de disponibilidad (reports.md) */
+/** Página `/reports` — Informe de disponibilidad (reports.md). */
 export default function Reports() {
   const { t } = useTranslation()
   const reduce = useReducedMotion()
-  const [weeks, setWeeks] = useState(4)
-  const [items, setItems] = useState<WeeklyEntry[]>([])
+  const [range, setRange] = useState<Range>('week')
+  const [n, setN] = useState<number>(DEFAULT_N.week)
+  const [items, setItems] = useState<AvailabilityEntry[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
   const [spin, setSpin] = useState(false)
 
-  async function load(n: number) {
+  async function load(r: Range, count: number) {
     setLoading(true)
     setError(false)
     try {
-      const res = await fetch(`/api/reports/weekly?weeks=${n}`)
+      const res = await fetch(`/api/reports/availability?range=${r}&n=${count}`)
       if (!res.ok) throw new Error(`status ${res.status}`)
-      const env = (await res.json()) as { items: WeeklyEntry[] }
+      const env = (await res.json()) as { items: AvailabilityEntry[] }
       setItems(env.items)
     } catch {
       setError(true)
@@ -78,20 +88,28 @@ export default function Reports() {
   }
 
   useEffect(() => {
-    void load(weeks)
-  }, [weeks])
+    void load(range, n)
+  }, [range, n])
 
-  // Agrupa por router y coloca las semanas en columnas (fila = router).
+  function changeRange(r: Range) {
+    if (r === range) return
+    setRange(r)
+    setN(DEFAULT_N[r])
+  }
+
+  // Agrupa por router y coloca los buckets en columnas (fila = router).
   const routerIds = [...new Set(items.map((i) => i.routerId))].sort()
-  const weeksPresent = [...new Set(items.map((i) => i.week))].sort().reverse()
+  const buckets = [...new Set(items.map((i) => i.bucket))].sort().reverse()
   const byRouter = (id: string) => items.filter((i) => i.routerId === id)
+
+  const initial = reduce ? false : { opacity: 0, y: 12 }
 
   return (
     <div className="space-y-4 md:space-y-5">
       {/* ① Page header */}
       <header>
         <motion.nav
-          initial={reduce ? false : { opacity: 0, y: 12 }}
+          initial={initial}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.25, ease: 'easeOut' }}
           aria-label={t('common.breadcrumb')}
@@ -103,7 +121,7 @@ export default function Reports() {
         </motion.nav>
         <div className="mt-1.5 flex flex-wrap items-end justify-between gap-x-4 gap-y-3">
           <motion.div
-            initial={reduce ? false : { opacity: 0, y: 12 }}
+            initial={initial}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.25, ease: 'easeOut', delay: 0.06 }}
           >
@@ -111,28 +129,28 @@ export default function Reports() {
             <p className="text-caption text-text-muted">{t('reports.subtitle')}</p>
           </motion.div>
           <motion.div
-            initial={reduce ? false : { opacity: 0, y: 12 }}
+            initial={initial}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.25, ease: 'easeOut', delay: 0.12 }}
             className="flex items-center gap-3"
           >
-            <div className="inline-flex items-center gap-1 rounded-lg border border-border bg-surface p-1" role="group" aria-label={t('reports.weeksLabel')}>
-              {WEEK_OPTIONS.map((n) => (
+            <div className="inline-flex items-center gap-1 rounded-lg border border-border bg-surface p-1" role="group" aria-label={t('reports.rangeLabel')}>
+              {N_OPTIONS[range].map((opt) => (
                 <button
-                  key={n}
-                  onClick={() => setWeeks(n)}
+                  key={opt}
+                  onClick={() => setN(opt)}
                   className={cn(
                     'rounded-md px-2.5 py-1 text-caption font-medium transition-colors',
-                    weeks === n ? 'bg-accent/15 text-accent' : 'text-text-muted hover:text-text-secondary',
+                    n === opt ? 'bg-accent/15 text-accent' : 'text-text-muted hover:text-text-secondary',
                   )}
                 >
-                  {n}w
+                  {opt}{SUFFIX[range]}
                 </button>
               ))}
             </div>
             <button
               onClick={() => {
-                void load(weeks)
+                void load(range, n)
                 if (reduce) return
                 setSpin(true)
                 window.setTimeout(() => setSpin(false), 650)
@@ -146,7 +164,25 @@ export default function Reports() {
         </div>
       </header>
 
-      {/* ② Contenido */}
+      {/* ② Pestañas de rango */}
+      <div className="inline-flex items-center gap-1 rounded-lg border border-border bg-surface p-1" role="tablist">
+        {RANGE_TABS.map((r) => (
+          <button
+            key={r}
+            role="tab"
+            aria-selected={range === r}
+            onClick={() => changeRange(r)}
+            className={cn(
+              'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+              range === r ? 'bg-accent/15 text-accent' : 'text-text-muted hover:text-text-secondary',
+            )}
+          >
+            {r === 'day' ? t('reports.tabDay') : r === 'week' ? t('reports.tabWeek') : t('reports.tabMonth')}
+          </button>
+        ))}
+      </div>
+
+      {/* ③ Contenido */}
       {loading && items.length === 0 && (
         <div className="rounded-2xl border border-border bg-surface p-8 text-center text-caption text-text-muted">
           {t('reports.loading')}
@@ -174,8 +210,8 @@ export default function Reports() {
               <thead>
                 <tr className="border-b border-border">
                   <th className="pb-2.5 pr-3 text-label font-medium uppercase text-text-muted">{t('reports.colRouter')}</th>
-                  {weeksPresent.map((w) => (
-                    <th key={w} className="pb-2.5 pr-3 text-label font-medium uppercase text-text-muted">{w}</th>
+                  {buckets.map((b) => (
+                    <th key={b} className="pb-2.5 pr-3 font-mono text-caption font-medium normal-case text-text-muted">{b}</th>
                   ))}
                   <th className="pb-2.5 text-label font-medium uppercase text-text-muted">{t('reports.colAvg')}</th>
                 </tr>
@@ -187,10 +223,10 @@ export default function Reports() {
                   return (
                     <tr key={id} className="border-b border-border/60 last:border-0 hover:bg-hover">
                       <td className="py-3 pr-3 font-medium text-text-primary">{id}</td>
-                      {weeksPresent.map((w) => {
-                        const e = rows.find((r) => r.week === w)
+                      {buckets.map((b) => {
+                        const e = rows.find((r) => r.bucket === b)
                         return (
-                          <td key={w} className="py-3 pr-3">
+                          <td key={b} className="py-3 pr-3">
                             {e ? <AvailabilityBar pct={e.upPct} /> : <span className="text-caption text-text-muted">—</span>}
                           </td>
                         )
@@ -205,17 +241,17 @@ export default function Reports() {
             </table>
           </div>
 
-          {/* ③ Detalle por router: últimas semanas con tráfico/latencia */}
+          {/* ④ Detalle por router: últimos buckets con tráfico/latencia */}
           <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2">
             {routerIds.map((id) => {
-              const rows = [...byRouter(id)].sort((a, b) => b.week.localeCompare(a.week))
+              const rows = [...byRouter(id)].sort((a, b) => b.bucket.localeCompare(a.bucket))
               return (
                 <div key={id} className="rounded-xl border border-border bg-elevated p-4">
                   <h3 className="mb-3 font-display text-h3 text-text-primary">{id}</h3>
                   <div className="space-y-2">
                     {rows.map((r) => (
-                      <div key={r.week} className="flex items-center justify-between gap-2 text-caption">
-                        <span className="font-mono text-text-muted">{r.week}</span>
+                      <div key={r.bucket} className="flex items-center justify-between gap-2 text-caption">
+                        <span className="font-mono text-text-muted">{r.bucket}</span>
                         <span className="flex items-center gap-3 font-mono text-mono-sm text-text-secondary">
                           <span title={t('reports.latency')}>
                             {r.latAvg !== null ? `${r.latAvg.toFixed(1)} ms` : '—'}

--- a/server-go/internal/httpapi/availability_test.go
+++ b/server-go/internal/httpapi/availability_test.go
@@ -1,0 +1,169 @@
+// availability_test.go — contrato de GET /api/reports/availability (Fase 15.1):
+// agregación por día, semana ISO y mes desde metrics_daily, y normalización
+// del día actual parcial por minutos transcurridos.
+package httpapi_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// availabilityEntry espeja la respuesta (campos que usa el test).
+type availabilityEntry struct {
+	RouterID string   `json:"routerId"`
+	Bucket   string   `json:"bucket"`
+	Days     int      `json:"days"`
+	UpMin    int64    `json:"upMin"`
+	UpPct    float64  `json:"upPct"`
+	LatAvg   *float64 `json:"latAvg"`
+}
+
+func getAvailability(t *testing.T, ts *testServer, query string) (int, []availabilityEntry) {
+	t.Helper()
+	_, cookie, _ := loginCookie(t, ts.URL, "admin", "test1234")
+	url := ts.URL + "/api/reports/availability" + query
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Cookie", "session="+cookie)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET availability: %v", err)
+	}
+	defer res.Body.Close()
+	body, _ := io.ReadAll(res.Body)
+	var env struct {
+		Items []availabilityEntry `json:"items"`
+	}
+	if res.StatusCode == http.StatusOK {
+		if err := json.Unmarshal(body, &env); err != nil {
+			t.Fatalf("decode: %v (%s)", err, body)
+		}
+	}
+	return res.StatusCode, env.Items
+}
+
+// TestAvailabilityDayAgrupaPorDia: una fila por router y día; upPct = upMin/1440.
+func TestAvailabilityDayAgrupaPorDia(t *testing.T) {
+	ts := makeTestServer(t)
+	insertDaily(t, ts, "gw", "2026-08-06", 17280, sqlNull{true, 1.0}, 1e8, 5e7, 20, 60) // día completo
+	insertDaily(t, ts, "gw", "2026-08-05", 8640, sqlNull{true, 2.0}, 1e8, 5e7, 20, 60)  // medio día
+
+	status, items := getAvailability(t, ts, "?range=day&n=30")
+	if status != http.StatusOK {
+		t.Fatalf("status %d, esperaba 200", status)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %d, esperaba 2 (un daily por día): %+v", len(items), items)
+	}
+	// Orden: bucket DESC → 2026-08-06 primero.
+	if items[0].Bucket != "2026-08-06" {
+		t.Fatalf("items[0].bucket = %q, esperaba 2026-08-06", items[0].Bucket)
+	}
+	byDate := map[string]availabilityEntry{}
+	for _, it := range items {
+		byDate[it.Bucket] = it
+	}
+	if byDate["2026-08-06"].UpPct < 99.9 {
+		t.Fatalf("día completo upPct=%v, esperaba ~100", byDate["2026-08-06"].UpPct)
+	}
+	// 2026-08-05 es un día pasado completo → 8640 muestras = 720 min de 1440 → 50%.
+	if byDate["2026-08-05"].UpPct < 49.9 || byDate["2026-08-05"].UpPct > 50.1 {
+		t.Fatalf("medio día pasado upPct=%v, esperaba ~50", byDate["2026-08-05"].UpPct)
+	}
+}
+
+// TestAvailabilityMonthAgrupaPorMes: agrupa dailies del mismo mes en una fila.
+func TestAvailabilityMonthAgrupaPorMes(t *testing.T) {
+	ts := makeTestServer(t)
+	// Tres días de 2026-07 para el mismo router → un bucket "2026-07".
+	insertDaily(t, ts, "gw", "2026-07-10", 17280, sqlNull{false, 0}, 0, 0, 20, 60)
+	insertDaily(t, ts, "gw", "2026-07-11", 17280, sqlNull{false, 0}, 0, 0, 20, 60)
+	insertDaily(t, ts, "gw", "2026-07-12", 17280, sqlNull{false, 0}, 0, 0, 20, 60)
+
+	status, items := getAvailability(t, ts, "?range=month&n=12")
+	if status != http.StatusOK {
+		t.Fatalf("status %d, esperaba 200", status)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items = %d, esperaba 1 (un bucket 2026-07): %+v", len(items), items)
+	}
+	if items[0].Bucket != "2026-07" {
+		t.Fatalf("bucket = %q, esperaba 2026-07", items[0].Bucket)
+	}
+	if items[0].Days != 3 {
+		t.Fatalf("days = %d, esperaba 3", items[0].Days)
+	}
+	// 3 días completos = 4320 min / (3*1440) = 100%.
+	if items[0].UpPct < 99.9 {
+		t.Fatalf("3 días completos upPct=%v, esperaba ~100", items[0].UpPct)
+	}
+}
+
+// TestAvailabilityWeekIgualQueWeekly: range=week devuelve los mismos buckets
+// que /api/reports/weekly para los mismos datos.
+func TestAvailabilityWeekIgualQueWeekly(t *testing.T) {
+	ts := makeTestServer(t)
+	insertDaily(t, ts, "gw", "2026-08-03", 17280, sqlNull{true, 1.2}, 1e8, 5e7, 20, 60)
+
+	_, wItems := getWeekly(t, ts, "4")
+	_, aItems := getAvailability(t, ts, "?range=week&n=4")
+
+	if len(wItems) != len(aItems) {
+		t.Fatalf("weekly=%d filas, availability week=%d filas (deberían coincidir)", len(wItems), len(aItems))
+	}
+	if len(aItems) == 0 || aItems[0].Bucket != wItems[0].Week {
+		t.Fatalf("weekly week=%q vs availability bucket=%q", wItems[0].Week, aItems[0].Bucket)
+	}
+}
+
+// TestAvailabilityDayActualNoPenaliza: el día de hoy con datos parciales se
+// normaliza por los minutos transcurridos, no por 1440.
+func TestAvailabilityDayActualNoPenaliza(t *testing.T) {
+	ts := makeTestServer(t)
+	today := time.Now().UTC().Format("2006-01-02")
+	// 360 min de recolección hoy (medio día "de trabajo"). Si el divisor fuera
+	// 1440, daría 25% (parece caído). Con minutos transcurridos, refleja la
+	// cobertura real hasta ahora.
+	insertDaily(t, ts, "gw", today, 360*12, sqlNull{false, 0}, 0, 0, 20, 60) // 360 min = 4320 muestras
+
+	_, items := getAvailability(t, ts, "?range=day&n=5")
+	var today_ *availabilityEntry
+	for i := range items {
+		if items[i].Bucket == today {
+			today_ = &items[i]
+		}
+	}
+	if today_ == nil {
+		t.Fatalf("no se devolvió fila para hoy %q: %+v", today, items)
+	}
+	nowMin := time.Now().UTC().Hour()*60 + time.Now().UTC().Minute()
+	want := float64(today_.UpMin) / float64(nowMin) * 100
+	if nowMin == 0 {
+		want = 100 // evitar div/0 a medianoche
+	}
+	if today_.UpPct < want-0.5 || today_.UpPct > want+0.5 {
+		t.Fatalf("día actual upPct=%v, esperaba ~%.1f (upMin=%d / nowMin=%d)", today_.UpPct, want, today_.UpMin, nowMin)
+	}
+	// Y no debe verse como "caído": si ahora mismo hay cobertura, upPct cerca del 100%.
+	if today_.UpPct > 100.1 {
+		t.Fatalf("upPct > 100 sin tope: %v", today_.UpPct)
+	}
+}
+
+// TestAvailabilityValidaParametros: range inválido y n fuera de rango → 400.
+func TestAvailabilityValidaParametros(t *testing.T) {
+	ts := makeTestServer(t)
+	for _, q := range []string{"?range=bogus", "?range=day&n=0", "?range=day&n=999", "?range=month&n=abc", "?range=week&n=-1"} {
+		status, _ := getAvailability(t, ts, q)
+		if status != http.StatusBadRequest {
+			t.Fatalf("query %q → status %d, esperaba 400", q, status)
+		}
+	}
+	// range válido sin n → 200 (default).
+	status, _ := getAvailability(t, ts, "?range=day")
+	if status != http.StatusOK {
+		t.Fatalf("range=day sin n → status %d, esperaba 200", status)
+	}
+}

--- a/server-go/internal/httpapi/reports.go
+++ b/server-go/internal/httpapi/reports.go
@@ -17,6 +17,7 @@ package httpapi
 
 import (
 	"database/sql"
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -97,4 +98,140 @@ func (s *server) handleWeeklyReport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"items": out, "weeks": weeks})
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/reports/availability?range=day|week|month&n=N — Fase 15.1
+//
+// Disponibilidad por router agregada por día, semana ISO o mes, sobre los
+// últimos N buckets (day: 30, week: 8, month: 12 por defecto). Reutiliza la
+// semántica de upMin/upPct del weekly. El día actual parcial se normaliza por
+// los minutos transcurridos (no penaliza); el mes en curso, por días con datos.
+// ---------------------------------------------------------------------------
+
+type availabilityEntry struct {
+	RouterID string   `json:"routerId"`
+	Bucket   string   `json:"bucket"` // day "2026-08-07" | week "2026-W31" | month "2026-07"
+	Days     int      `json:"days"`   // días con datos en el bucket
+	UpMin    int64    `json:"upMin"`  // minutos de recolección en el bucket
+	UpPct    float64  `json:"upPct"`  // % de disponibilidad
+	LatAvg   *float64 `json:"latAvg"`
+	RxTotal  float64  `json:"rxTotal"`
+	TxTotal  float64  `json:"txTotal"`
+	CPUAvg   float64  `json:"cpuAvg"`
+	RAMAvg   float64  `json:"ramAvg"`
+}
+
+// handleAvailabilityReport sirve GET /api/reports/availability.
+func (s *server) handleAvailabilityReport(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	rangeParam := q.Get("range")
+	if rangeParam == "" {
+		rangeParam = "week"
+	}
+
+	// Expresión SQL de agrupación + ventana por defecto según el rango.
+	var groupExpr string
+	nDef, nMax := 8, 52
+	switch rangeParam {
+	case "day":
+		groupExpr = "strftime('%Y-%m-%d', date)"
+		nDef, nMax = 30, 90
+	case "week":
+		groupExpr = "strftime('%G-W%V', date)"
+		nDef, nMax = 8, 52
+	case "month":
+		groupExpr = "strftime('%Y-%m', date)"
+		nDef, nMax = 12, 24
+	default:
+		writeError(w, http.StatusBadRequest, "invalid_query", "range must be day, week or month")
+		return
+	}
+
+	n := nDef
+	if raw := q.Get("n"); raw != "" {
+		v, err := strconv.Atoi(raw)
+		if err != nil || v < 1 || v > nMax {
+			writeError(w, http.StatusBadRequest, "invalid_query",
+				fmt.Sprintf("n must be an integer between 1 and %d", nMax))
+			return
+		}
+		n = v
+	}
+
+	// Ventana hacia atrás desde hoy (UTC).
+	now := time.Now().UTC()
+	var since string
+	switch rangeParam {
+	case "day":
+		since = now.AddDate(0, 0, -n).Format("2006-01-02")
+	case "week":
+		since = now.AddDate(0, 0, -7*n).Format("2006-01-02")
+	case "month":
+		since = now.AddDate(0, -n, 0).Format("2006-01-02")
+	}
+
+	query := fmt.Sprintf(`
+		SELECT
+			router_id,
+			%s AS bucket,
+			COUNT(*),
+			SUM(n) * 5 / 60,
+			AVG(lat_avg),
+			SUM(rx_total),
+			SUM(tx_total),
+			AVG(cpu_avg),
+			AVG(ram_avg)
+		FROM metrics_daily
+		WHERE date >= ?
+		GROUP BY router_id, %s
+		ORDER BY bucket DESC, router_id`, groupExpr, groupExpr)
+
+	rows, err := s.db.Query(query, since)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "db_error")
+		return
+	}
+	defer rows.Close()
+
+	// Para el día actual parcial: divisor = minutos transcurridos del día UTC.
+	today := now.Format("2006-01-02")
+	nowMin := now.Hour()*60 + now.Minute()
+
+	out := []availabilityEntry{}
+	for rows.Next() {
+		var e availabilityEntry
+		var upMin int64
+		var lat sql.NullFloat64
+		if err := rows.Scan(&e.RouterID, &e.Bucket, &e.Days, &upMin,
+			&lat, &e.RxTotal, &e.TxTotal, &e.CPUAvg, &e.RAMAvg); err != nil {
+			continue
+		}
+		e.UpMin = upMin
+		if lat.Valid {
+			e.LatAvg = &lat.Float64
+		}
+		var divisor float64
+		if rangeParam == "day" {
+			if e.Bucket == today && nowMin > 0 {
+				divisor = float64(nowMin)
+			} else {
+				divisor = 1440
+			}
+		} else {
+			divisor = float64(e.Days) * 1440
+		}
+		if divisor > 0 {
+			e.UpPct = float64(upMin) / divisor * 100
+			if e.UpPct > 100 {
+				e.UpPct = 100
+			}
+		}
+		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		writeError(w, http.StatusInternalServerError, "db_error")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": out, "range": rangeParam, "n": n})
 }

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -163,6 +163,7 @@ func NewHandler(d Deps) http.Handler {
 	mux.HandleFunc("GET /api/adguard/clients", s.handleAdguardClients)
 	mux.HandleFunc("GET /api/system/info", s.handleSystemInfo)
 	mux.HandleFunc("GET /api/reports/weekly", s.handleWeeklyReport)
+	mux.HandleFunc("GET /api/reports/availability", s.handleAvailabilityReport)
 
 	// --- Sondeo manual (botón "Refrescar" de Topología; 202 + SSE empuja) ---
 	mux.HandleFunc("POST /api/refresh", s.handleRefresh)


### PR DESCRIPTION
Closes #98.

## What

- **Server**: `GET /api/reports/availability?range=day|week|month&n=N` over `metrics_daily`, reusing the weekly upMin/upPct semantics. The current day normalizes by elapsed minutes (no penalty); the current month by days with data. `/weekly` kept for backwards compatibility.
- **Frontend**: the `/reports` page gains Day / Week / Month tabs and an N selector that adapts per range (days, weeks, months). The existing weekly table generalizes to a routers x buckets grid.

## Verified

- Server: \`go test ./internal/httpapi/ -race\` green; new tests cover day/month grouping, week parity with `/weekly`, the current-day-no-penalty case and parameter validation.
- Frontend: tsc + lint + vite build clean.

## Out of scope

Traffic trends, device activity and alert summaries (15.2 to 15.5).