### PR TITLE
feat(roaming): hide /roaming nav entry when no DAWN active

### DIFF
--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -172,10 +172,21 @@ function GatewayStatus() {
 // Sidebar desktop (≥1024px) — 232px
 // ---------------------------------------------------------------------------
 
+/** Items de nav visibles según el overview. /roaming solo si hay DAWN. */
+function useVisibleNavItems(): NavItem[] {
+  const { dawn } = useNetPulse()
+  const dawnAvailable = !!dawn?.available
+  return useMemo(
+    () => NAV_ITEMS.filter((it) => it.to !== '/roaming' || dawnAvailable),
+    [dawnAvailable],
+  )
+}
+
 function Sidebar({ collapsed, onToggleCollapse }: { collapsed: boolean; onToggleCollapse: () => void }) {
   const { t } = useTranslation()
-  const main = NAV_ITEMS.filter((i) => i.to !== '/settings')
-  const settings = NAV_ITEMS[NAV_ITEMS.length - 1]
+  const items = useVisibleNavItems()
+  const main = items.filter((i) => i.to !== '/settings')
+  const settings = items[items.length - 1]
 
   if (collapsed) {
     // Sidebar colapsado = raíl de iconos en lg (persiste en localStorage)
@@ -185,7 +196,7 @@ function Sidebar({ collapsed, onToggleCollapse }: { collapsed: boolean; onToggle
           <Logo compact />
         </div>
         <nav className="flex-1 space-y-1 py-2" aria-label={t('nav.mainNav')}>
-          {NAV_ITEMS.map((item) => (
+          {items.map((item) => (
             <NavLink
               key={item.to}
               to={item.to}
@@ -291,13 +302,14 @@ function Sidebar({ collapsed, onToggleCollapse }: { collapsed: boolean; onToggle
 
 function Rail() {
   const { t } = useTranslation()
+  const items = useVisibleNavItems()
   return (
     <aside className="fixed inset-y-0 left-0 z-40 hidden w-16 flex-col items-center border-r border-border bg-surface md:flex lg:hidden">
       <div className="flex h-16 items-center pt-safe">
         <Logo compact />
       </div>
       <nav className="flex-1 space-y-1 py-2" aria-label={t('nav.mainNav')}>
-        {NAV_ITEMS.map((item) => (
+        {items.map((item) => (
           <NavLink
             key={item.to}
             to={item.to}

--- a/app/src/data/DataProvider.tsx
+++ b/app/src/data/DataProvider.tsx
@@ -96,6 +96,8 @@ export interface NetPulseData {
    * Ausente en demo y con servidores viejos → model.ts usa su cálculo local.
    */
   topology?: TopoSemantics
+  /** Disponibilidad de DAWN (roaming); ausente = no mostrar /roaming. */
+  dawn?: { available: boolean }
 }
 
 export interface NetPulseApi extends NetPulseData {
@@ -371,6 +373,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
       unreadAlerts: o.unreadAlerts,
       vm,
       topology: o.topology,
+      dawn: o.dawn,
     }))
   }, [])
 

--- a/app/src/data/types.ts
+++ b/app/src/data/types.ts
@@ -307,6 +307,8 @@ export interface OverviewBundle {
   vm?: number
   /** Semántica de topología precalculada (SPEC-65 D65-3); ausente = fallback local. */
   topology?: TopoSemantics
+  /** Disponibilidad de DAWN (roaming/band-steering); ausente = no mostrar /roaming. */
+  dawn?: { available: boolean }
   ts: number
 }
 

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -135,6 +135,12 @@ type Live struct {
 	wgActive       map[string]bool
 	weakAlerted    map[string]int64
 	onlineMacs     map[string]bool
+	// dawnAvailable: cache de "¿hay DAWN en algún router?" para el flag del
+	// overview (entrada /roaming). Refrescado asíncronamente (TTL 30s, 1 SSH
+	// al gateway) por dawnAvailableCached para no bloquear buildOverview.
+	dawnAvailable bool
+	dawnCheckedAt time.Time
+	dawnChecking  bool
 	seenOnlineMacs bool
 	wanDown        map[string]int
 	backhaulCache  map[string]backhaulCacheEntry
@@ -1360,9 +1366,42 @@ func (l *Live) buildOverview(ctx context.Context) (*Overview, error) {
 		TopDevices: top, Alerts: alertsCopy, UnreadAlerts: unread,
 		DistributionNodes: distNodes,
 		Topology:          BuildTopoSemantics(routerList, devices, wgStats, distNodes), // SPEC-65 D65-3
+		Dawn:              &DawnOverview{Available: l.dawnAvailableCached()},
 		VM:                ViewModelVersion,                                            // SPEC-65 D65-4
 		Ts:                time.Now().Unix(),
 	}, nil
+}
+
+// dawnAvailableCached devuelve si hay DAWN en la red (cacheado). Lanza un
+// refresco asíncrono (1 SSH al gateway, TTL 30s) cuando el cache está stale,
+// sin bloquear el overview: la primera llamada devuelve false y el flag llega
+// en el overview siguiente una vez refrescado.
+func (l *Live) dawnAvailableCached() bool {
+	l.mu.Lock()
+	avail := l.dawnAvailable
+	checked := l.dawnCheckedAt
+	checking := l.dawnChecking
+	gw := l.gatewayCfg
+	l.mu.Unlock()
+	if gw == nil {
+		return false
+	}
+	if checking || time.Since(checked) < 30*time.Second {
+		return avail
+	}
+	l.mu.Lock()
+	l.dawnChecking = true
+	host := gw.Host
+	l.mu.Unlock()
+	go func() {
+		out, err := l.pool.Run(host, "ubus call dawn get_network", 4*time.Second)
+		l.mu.Lock()
+		l.dawnChecking = false
+		l.dawnCheckedAt = time.Now()
+		l.dawnAvailable = err == nil && len(out) > 10
+		l.mu.Unlock()
+	}()
+	return avail
 }
 
 // GetRouters: tarjetas desde la caché del último tick (index.js:600-610).

--- a/server-go/internal/adapters/types.go
+++ b/server-go/internal/adapters/types.go
@@ -273,12 +273,21 @@ type Overview struct {
 	// Topology: semántica de topología precalculada (SPEC-65 D65-3). Puntero:
 	// ausente en snapshots viejos → la app usa su cálculo actual como fallback.
 	Topology *TopoSemantics `json:"topology,omitempty"`
+	// Dawn: disponibilidad de DAWN (roaming/band-steering) para decidir si la
+	// app muestra la entrada /roaming. Puntero: ausente en snapshots viejos y
+	// cuando ningún router tiene DAWN → nil = no mostrar la página.
+	Dawn *DawnOverview `json:"dawn,omitempty"`
 	// VM: versión del view-model (SPEC-65 D65-4). SIEMPRE presente.
 	VM int   `json:"vm"`
 	Ts int64 `json:"ts"` // floor(now/1000) — SEGUNDOS
 }
 
-// ---------------------------------------------------------------------------
+// DawnOverview indica si la red tiene DAWN (roaming/band-steering) disponible.
+// Lo usa el frontend para mostrar/ocultar la entrada /roaming del menú.
+type DawnOverview struct {
+	Available bool `json:"available"`
+}
+
 // RouterDetail (GET /api/routers/:id; SPEC §7.8 y demo §7.1)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #102.

## What

The \`/roaming\` nav entry now only appears when at least one router has DAWN (band-steering) active, so third-party installs without DAWN do not get a dead menu item.

- **Server**: the overview carries a new \`dawn.available\` flag, computed cheaply via a cached probe on the \`Live\` adapter: one SSH \`ubus call dawn get_network\` to the gateway every 30s, refreshed asynchronously so \`buildOverview\` never blocks.
- **Frontend**: the \`Layout\` filters the \`NAV_ITEMS\` (sidebar + rail) on that flag via a \`useVisibleNavItems\` hook. The mobile tabbar never included \`/roaming\`, so it is untouched. While the overview has not arrived (initial load) the entry is hidden by default.

## Verified

- Server: \`go build\` + \`go test ./internal/adapters/ ./internal/httpapi/ -race\` green.
- Frontend: tsc + lint + vite build clean.

## Notes

For installs with DAWN (the reference setup), the entry shows up a few seconds after the first overview, once the async probe confirms DAWN.