### PR TITLE
fix(a11y): sr-only table caption was visible over the card header (#63)

### DIFF
--- a/app/src/components/routers/RouterPerformance.tsx
+++ b/app/src/components/routers/RouterPerformance.tsx
@@ -145,9 +145,10 @@ export function RouterPerformance({ router }: { router: Router }) {
         ))}
       </div>
 
-      {/* Tabla accesible */}
+      {/* Descripción + tabla accesible (visually-hidden). El texto va en un
+          span sr-only: <caption> escapa del clip del table sr-only (#63). */}
+      <span className="sr-only">{t('routerDetail.perf.tableCaption', { range })}</span>
       <table className="sr-only">
-        <caption>{t('routerDetail.perf.tableCaption', { range })}</caption>
         <thead>
           <tr><th>{t('home.traffic.time')}</th><th>CPU (%)</th><th>{t('common.memory')} (%)</th><th>{t('common.temperature')} (°C)</th></tr>
         </thead>

--- a/app/src/sections/WanTraffic.tsx
+++ b/app/src/sections/WanTraffic.tsx
@@ -165,9 +165,11 @@ export function WanTraffic() {
         </ResponsiveContainer>
       </motion.div>
 
-      {/* Tabla accesible (visually-hidden) */}
+      {/* Descripción + tabla accesible (visually-hidden). El texto va en un
+          span sr-only porque <caption> escapa del clip del table sr-only
+          (display: table-caption) y quedaría visible encima del header (#63). */}
+      <span className="sr-only">{t('home.traffic.tableCaption', { range })}</span>
       <table className="sr-only">
-        <caption>{t('home.traffic.tableCaption', { range })}</caption>
         <thead>
           <tr><th>{t('home.traffic.time')}</th><th>{t('home.traffic.downloadMbps')}</th><th>{t('home.traffic.uploadMbps')}</th></tr>
         </thead>


### PR DESCRIPTION
Closes #63.

## Root cause

The \`<caption>\` of a \`<table class="sr-only">\` escapes the table's clip: \`display: table-caption\` gives the caption its own box that does not respect the parent's \`position: absolute; clip: rect(0,0,0,0)\`. As a result the caption was actually **visible** and rendered over the card header.

Measured on the Overview with the 24h range selected: the caption \`"Datos de tráfico (24h)"\` painted at **252×21 px** on top of the \`"Tráfico de red"\` title + \`"En vivo"\` pill — the exact overlap reported in #63. The earlier fix #90 (range selector \`shrink-0\`) was unrelated; the real culprit was this caption.

The same pattern existed in \`RouterPerformance\`.

## Fix

Move the caption text to a \`<span class="sr-only">\` placed before the table. Spans with \`sr-only\` hide reliably; the accessible data table is preserved for screen readers.

## Verified

- Before: caption rect 252×21 px (visible). After: caption (now a span) rect **1×1 px** (hidden).
- tsc + lint + vite build clean. Deployed to CT 226, NRestarts 0, 0 JS errors.