### PR TITLE
feat(config): edit router configuration in place (PUT + UI)

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -783,7 +783,13 @@
       "sshKeyTitle": "Server SSH key",
       "sshKeyCaption": "Authorize it on each router (System → Administration → SSH keys, or /etc/dropbear/authorized_keys). NetPulse is read-only: status, clients and traffic.",
       "copy": "Copy",
-      "copied": "Copied"
+      "copied": "Copied",
+      "agentOnly": "Agent only (no SSH)",
+      "agentOnlyBadge": "Agent only",
+      "edit": "Edit",
+      "editTitle": "Edit {{id}}",
+      "save": "Save",
+      "saving": "Saving…"
     },
     "saved": "Preferences saved",
     "services": {

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -783,7 +783,13 @@
       "sshKeyTitle": "Clave SSH del servidor",
       "sshKeyCaption": "Autorízala en cada router (Sistema → Administración → claves SSH, o /etc/dropbear/authorized_keys). NetPulse solo lee: estado, clientes y tráfico.",
       "copy": "Copiar",
-      "copied": "Copiada"
+      "copied": "Copiada",
+      "agentOnly": "Solo agente (sin SSH)",
+      "agentOnlyBadge": "Solo agente",
+      "edit": "Editar",
+      "editTitle": "Editar {{id}}",
+      "save": "Guardar",
+      "saving": "Guardando…"
     },
     "saved": "Preferencias guardadas",
     "services": {

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -22,17 +22,17 @@ import {
   Pencil,
   Plus,
   Lock,
-  Radar,
-  RefreshCw,
-  Router as RouterIcon,
-  Shield,
-  ShieldCheck,
-  Sun,
-  Trash2,
-  UserCog,
-  Users,
-  Volume2,
-  Wifi,
+   Radar,
+   RefreshCw,
+   Router as RouterIcon,
+   Shield,
+   ShieldCheck,
+   Sun,
+   Trash2,
+   UserCog,
+   Users,
+   Volume2,
+   Wifi,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { HealthRing } from '@/components/HealthRing'
@@ -254,6 +254,7 @@ interface ConfigRouter {
   host: string
   type: 'glinet' | 'openwrt'
   is_gateway: boolean
+  agent_only: boolean
 }
 
 interface DiscoverCandidate {
@@ -274,8 +275,16 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
   const [name, setName] = useState('')
   const [type, setType] = useState<'glinet' | 'openwrt'>('openwrt')
   const [gateway, setGateway] = useState(false)
+  const [agentOnly, setAgentOnly] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [confirmDeleteFor, setConfirmDeleteFor] = useState<string | null>(null)
+  const [editing, setEditing] = useState<ConfigRouter | null>(null)
+  const [editHost, setEditHost] = useState('')
+  const [editName, setEditName] = useState('')
+  const [editType, setEditType] = useState<'glinet' | 'openwrt'>('openwrt')
+  const [editGateway, setEditGateway] = useState(false)
+  const [editAgentOnly, setEditAgentOnly] = useState(false)
+  const [editSubmitting, setEditSubmitting] = useState(false)
   const [pubkey, setPubkey] = useState<{ publicKey: string; fingerprint: string } | null>(null)
   const [copied, setCopied] = useState(false)
   const [scanning, setScanning] = useState(false)
@@ -406,6 +415,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
           name: name.trim() || undefined,
           type,
           gateway,
+          agent_only: agentOnly,
         }),
       })
       if (res.status === 409) {
@@ -417,6 +427,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
       setName('')
       setType('openwrt')
       setGateway(false)
+      setAgentOnly(false)
       setShowAddForm(false)
       await load()
       refresh()
@@ -425,6 +436,49 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
       setError(t('settings.routers.errorGeneric'))
     } finally {
       setSubmitting(false)
+    }
+  }
+
+  const openEdit = (r: ConfigRouter) => {
+    setEditing(r)
+    setEditHost(r.host)
+    setEditName(r.name ?? '')
+    setEditType(r.type)
+    setEditGateway(r.is_gateway)
+    setEditAgentOnly(r.agent_only)
+    setError(null)
+  }
+
+  const saveEdit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!editing || editSubmitting) return
+    setEditSubmitting(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/config/routers/${encodeURIComponent(editing.id)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          host: editHost.trim(),
+          name: editName.trim() || undefined,
+          type: editType,
+          gateway: editGateway,
+          agent_only: editAgentOnly,
+        }),
+      })
+      if (res.status === 409) {
+        setError(t('settings.routers.errorDuplicate'))
+        return
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setEditing(null)
+      await load()
+      refresh()
+      onSaved()
+    } catch {
+      setError(t('settings.routers.errorGeneric'))
+    } finally {
+      setEditSubmitting(false)
     }
   }
 
@@ -465,6 +519,11 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
                       {t('settings.routers.gatewayBadge')}
                     </span>
                   )}
+                  {r.agent_only && (
+                    <span className="rounded-full bg-elevated px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted ring-1 ring-inset ring-border">
+                      {t('settings.routers.agentOnlyBadge')}
+                    </span>
+                  )}
                 </div>
                 {r.name && r.name !== r.host && (
                   <div className="truncate text-caption text-text-muted">{r.name}</div>
@@ -488,14 +547,24 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
                   </button>
                 </span>
               ) : (
-                <button
-                  type="button"
-                  onClick={() => setConfirmDeleteFor(r.id)}
-                  aria-label={t('settings.routers.delete')}
-                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border text-text-muted transition-colors duration-150 hover:border-danger/40 hover:text-danger"
-                >
-                  <Trash2 className="h-4 w-4" strokeWidth={1.75} />
-                </button>
+                <span className="flex shrink-0 items-center gap-1.5">
+                  <button
+                    type="button"
+                    onClick={() => openEdit(r)}
+                    aria-label={t('settings.routers.edit')}
+                    className="flex h-8 w-8 items-center justify-center rounded-lg border border-border text-text-muted transition-colors duration-150 hover:border-accent/40 hover:text-accent"
+                  >
+                    <Pencil className="h-3.5 w-3.5" strokeWidth={1.75} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setConfirmDeleteFor(r.id)}
+                    aria-label={t('settings.routers.delete')}
+                    className="flex h-8 w-8 items-center justify-center rounded-lg border border-border text-text-muted transition-colors duration-150 hover:border-danger/40 hover:text-danger"
+                  >
+                    <Trash2 className="h-4 w-4" strokeWidth={1.75} />
+                  </button>
+                </span>
               )}
             </li>
           ))}
@@ -611,6 +680,10 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
             <Switch checked={gateway} onCheckedChange={setGateway} />
             {t('settings.routers.gateway')}
           </label>
+          <label className="flex cursor-pointer items-center gap-2 text-sm text-text-secondary">
+            <Switch checked={agentOnly} onCheckedChange={setAgentOnly} />
+            {t('settings.routers.agentOnly')}
+          </label>
           <button
             type="submit"
             disabled={submitting || !host.trim()}
@@ -625,6 +698,73 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
         </form>
         )}
       </div>
+
+      {/* Edición inline: aparece al pulsar Editar en una fila */}
+      {editing && (
+        <form onSubmit={(e) => void saveEdit(e)} className="mt-4 border-t border-border pt-4">
+          <div className="mb-2 flex items-center gap-2">
+            <Pencil className="h-4 w-4 text-accent" strokeWidth={1.75} />
+            <span className="text-sm font-medium text-text-primary">
+              {t('settings.routers.editTitle', { id: editing.id })}
+            </span>
+          </div>
+          <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
+            <input
+              type="text"
+              required
+              value={editHost}
+              onChange={(e) => setEditHost(e.target.value)}
+              placeholder={t('settings.routers.host')}
+              aria-label={t('settings.routers.host')}
+              className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+            />
+            <input
+              type="text"
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              placeholder={t('settings.routers.name')}
+              aria-label={t('settings.routers.name')}
+              className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+            />
+          </div>
+          <div className="mt-2.5 flex flex-wrap items-center gap-3">
+            <SegmentedControl
+              options={[
+                { value: 'openwrt', label: 'OpenWrt' },
+                { value: 'glinet', label: 'GL.iNet' },
+              ]}
+              value={editType}
+              onChange={(v) => setEditType(v as 'glinet' | 'openwrt')}
+              ariaLabel={t('settings.routers.type')}
+            />
+            <label className="flex cursor-pointer items-center gap-2 text-sm text-text-secondary">
+              <Switch checked={editGateway} onCheckedChange={setEditGateway} />
+              {t('settings.routers.gateway')}
+            </label>
+            <label className="flex cursor-pointer items-center gap-2 text-sm text-text-secondary">
+              <Switch checked={editAgentOnly} onCheckedChange={setEditAgentOnly} />
+              {t('settings.routers.agentOnly')}
+            </label>
+            <span className="ml-auto flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setEditing(null)}
+                className="rounded-lg border border-border px-3 py-2 text-sm font-medium text-text-secondary transition-colors duration-150 hover:text-text-primary"
+              >
+                {t('settings.users.cancel')}
+              </button>
+              <button
+                type="submit"
+                disabled={editSubmitting || !editHost.trim()}
+                className="flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-canvas transition-opacity duration-150 hover:opacity-90 disabled:opacity-40"
+              >
+                <Pencil className="h-4 w-4" strokeWidth={2} />
+                {editSubmitting ? t('settings.routers.saving') : t('settings.routers.save')}
+              </button>
+            </span>
+          </div>
+        </form>
+      )}
 
       {/* Clave pública SSH del servidor */}
       <div className="mt-4 border-t border-border pt-4">

--- a/server-go/internal/httpapi/config.go
+++ b/server-go/internal/httpapi/config.go
@@ -28,6 +28,7 @@ func (s *server) registerConfigRoutes(mux *http.ServeMux) {
 	mux.Handle("GET /api/config/discover", auth.RequireAdmin(http.HandlerFunc(s.handleDiscover)))
 	mux.HandleFunc("GET /api/config/routers", s.handleListConfigRouters)
 	mux.Handle("POST /api/config/routers", auth.RequireAdmin(http.HandlerFunc(s.handleAddConfigRouter)))
+	mux.Handle("PUT /api/config/routers/{id}", auth.RequireAdmin(http.HandlerFunc(s.handleUpdateConfigRouter)))
 	mux.Handle("DELETE /api/config/routers/{id}", auth.RequireAdmin(http.HandlerFunc(s.handleDeleteConfigRouter)))
 	mux.Handle("GET /api/config/adguard", auth.RequireAdmin(http.HandlerFunc(s.handleGetAdguardConfig)))
 	mux.Handle("PUT /api/config/adguard", auth.RequireAdmin(http.HandlerFunc(s.handlePutAdguardConfig)))
@@ -147,6 +148,67 @@ func (s *server) handleDeleteConfigRouter(w http.ResponseWriter, r *http.Request
 	}
 	s.syncRouters()
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// PUT /api/config/routers/:id — edita host/name/type/gateway/agent_only.
+// Campos omitidos (nil) no se tocan. 404 si el router no existe.
+func (s *server) handleUpdateConfigRouter(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	var in routerInput
+	if !readJSONBody(r, &in) {
+		writeError(w, http.StatusBadRequest, "invalid_json")
+		return
+	}
+	var name *string
+	if in.Name != nil {
+		n := strings.TrimSpace(*in.Name)
+		if len(n) < 1 {
+			writeError(w, http.StatusBadRequest, "invalid_input", "String must contain at least 1 character(s)")
+			return
+		}
+		if len(n) > 60 {
+			writeError(w, http.StatusBadRequest, "invalid_input", "String must contain at most 60 character(s)")
+			return
+		}
+		name = &n
+	}
+	var host *string
+	if in.Host != nil {
+		h, msg := validateHost(*in.Host)
+		if msg != "" {
+			writeError(w, http.StatusBadRequest, "invalid_input", msg)
+			return
+		}
+		// Duplicado: otro router con ese host (excluyendo el propio id).
+		for _, rt := range routerstore.ListRouters(s.db.DB) {
+			if rt.Host == h && rt.ID != id {
+				writeError(w, http.StatusConflict, "duplicate_host", "Ya hay un router con "+h)
+				return
+			}
+		}
+		host = &h
+	}
+	var typ *string
+	if in.Type != "" {
+		t := in.Type
+		if t != "glinet" && t != "openwrt" {
+			writeError(w, http.StatusBadRequest, "invalid_input", "Invalid enum value. Expected 'glinet' | 'openwrt'")
+			return
+		}
+		typ = &t
+	}
+	gw := in.Gateway
+	ao := in.AgentOnly
+	updated, ok := routerstore.UpdateRouter(s.db.DB, id, routerstore.UpdateInput{
+		Name: name, Host: host, Type: typ,
+		IsGateway: &gw, AgentOnly: &ao,
+	})
+	if !ok {
+		writeError(w, http.StatusNotFound, "not_found")
+		return
+	}
+	s.syncRouters()
+	writeJSON(w, http.StatusOK, map[string]any{"router": updated})
 }
 
 // --- AdGuard Home (GL.iNet) — solo admin; la contraseña NO se devuelve ---

--- a/server-go/internal/httpapi/config_test.go
+++ b/server-go/internal/httpapi/config_test.go
@@ -140,3 +140,96 @@ func TestConfigRoutersCRUD(t *testing.T) {
 		t.Fatalf("sshkey: %d", res.StatusCode)
 	}
 }
+
+// TestConfigRoutersUpdate cubre PUT /api/config/routers/{id}:
+//   - 404 si no existe
+//   - editar name (200, campo cambiado)
+//   - editar host inválido (400)
+//   - editar host duplicado con otro router (409)
+//   - promover a gateway (200, solo uno con el flag)
+//   - marcar agent_only (200, flag cambiado)
+//   - PUT no-admin → 401/403 (lo cubre admin_gate_test.go)
+func TestConfigRoutersUpdate(t *testing.T) {
+	srv := makeTestServer(t)
+	_, cookie, _ := loginCookie(t, srv.URL, "admin", "test1234")
+
+	// Setup: dos routers (rt1 no-gateway, gw gateway).
+	res := doReq(t, "POST", srv.URL+"/api/config/routers", cookie,
+		`{"name":"rt1","host":"192.168.8.10","type":"openwrt"}`)
+	if res.StatusCode != 201 {
+		t.Fatalf("POST rt1: %d", res.StatusCode)
+	}
+	res = doReq(t, "POST", srv.URL+"/api/config/routers", cookie,
+		`{"name":"gw","host":"192.168.8.1","type":"glinet","gateway":true}`)
+	if res.StatusCode != 201 {
+		t.Fatalf("POST gw: %d", res.StatusCode)
+	}
+
+	// PUT inexistente → 404
+	res = doReq(t, "PUT", srv.URL+"/api/config/routers/no-existe", cookie,
+		`{"name":"foo"}`)
+	if res.StatusCode != 404 {
+		t.Fatalf("PUT 404: %d", res.StatusCode)
+	}
+
+	// PUT name → 200, name cambiado
+	res = doReq(t, "PUT", srv.URL+"/api/config/routers/rt1", cookie,
+		`{"name":"Salón Editado","host":"192.168.8.10","type":"openwrt","gateway":false,"agent_only":false}`)
+	if res.StatusCode != 200 {
+		t.Fatalf("PUT name: %d", res.StatusCode)
+	}
+	body := readJSON(t, res)
+	rt := body["router"].(map[string]any)
+	if rt["name"] != "Salón Editado" {
+		t.Errorf("name: %v", rt["name"])
+	}
+
+	// PUT host inválido → 400
+	res = doReq(t, "PUT", srv.URL+"/api/config/routers/rt1", cookie,
+		`{"host":"no es un host"}`)
+	if res.StatusCode != 400 {
+		t.Fatalf("PUT host inválido: %d", res.StatusCode)
+	}
+
+	// PUT host duplicado con gw → 409
+	res = doReq(t, "PUT", srv.URL+"/api/config/routers/rt1", cookie,
+		`{"host":"192.168.8.1"}`)
+	if res.StatusCode != 409 {
+		t.Fatalf("PUT host duplicado: %d", res.StatusCode)
+	}
+
+	// PUT promover rt1 a gateway → 200, ahora rt1 es el único gateway
+	res = doReq(t, "PUT", srv.URL+"/api/config/routers/rt1", cookie,
+		`{"host":"192.168.8.10","gateway":true}`)
+	if res.StatusCode != 200 {
+		t.Fatalf("PUT gateway: %d", res.StatusCode)
+	}
+	res = doReq(t, "GET", srv.URL+"/api/config/routers", cookie, "")
+	body = readJSON(t, res)
+	gwCount := 0
+	rt1Gw := false
+	for _, r := range body["routers"].([]any) {
+		rm := r.(map[string]any)
+		if rm["is_gateway"] == true {
+			gwCount++
+			if rm["id"] == "rt1" {
+				rt1Gw = true
+			}
+		}
+	}
+	if gwCount != 1 || !rt1Gw {
+		t.Fatalf("gateway mutado: gwCount=%d rt1Gw=%v", gwCount, rt1Gw)
+	}
+
+	// PUT agent_only=true → 200, agent_only cambiado
+	res = doReq(t, "PUT", srv.URL+"/api/config/routers/rt1", cookie,
+		`{"host":"192.168.8.10","agent_only":true}`)
+	if res.StatusCode != 200 {
+		t.Fatalf("PUT agent_only: %d", res.StatusCode)
+	}
+	body = readJSON(t, res)
+	rt = body["router"].(map[string]any)
+	if rt["agent_only"] != true {
+		t.Errorf("agent_only: %v", rt["agent_only"])
+	}
+}

--- a/server-go/internal/routerstore/routerstore.go
+++ b/server-go/internal/routerstore/routerstore.go
@@ -178,6 +178,85 @@ func RemoveRouter(db *sql.DB, id string) bool {
 	return n > 0
 }
 
+// UpdateInput son los campos editables de un router. Todos opcionales:
+// nil = no tocar el campo. Se usa desde PUT /api/config/routers/{id}.
+type UpdateInput struct {
+	Name      *string // "" = limpiar (usar host)
+	Host      *string
+	Type      *string
+	IsGateway *bool
+	AgentOnly *bool
+}
+
+// UpdateRouter actualiza un router existente por id. Si IsGateway pasa a true,
+// el flag se quita del resto (un solo gateway, transacción). Si el router no
+// existe devuelve false (caller responde 404).
+func UpdateRouter(db *sql.DB, id string, in UpdateInput) (adapters.RouterConfig, bool) {
+	tx, err := db.Begin()
+	if err != nil {
+		return adapters.RouterConfig{}, false
+	}
+	defer tx.Rollback()
+
+	var exists int
+	if err := tx.QueryRow("SELECT 1 FROM routers WHERE id = ?", id).Scan(&exists); err != nil {
+		return adapters.RouterConfig{}, false
+	}
+
+	if in.IsGateway != nil && *in.IsGateway {
+		if _, err := tx.Exec("UPDATE routers SET is_gateway = 0 WHERE id != ?", id); err != nil {
+			return adapters.RouterConfig{}, false
+		}
+	}
+
+	sets := []string{}
+	args := []any{}
+	if in.Name != nil {
+		sets = append(sets, "name = ?")
+		args = append(args, *in.Name)
+	}
+	if in.Host != nil {
+		sets = append(sets, "host = ?")
+		args = append(args, *in.Host)
+	}
+	if in.Type != nil {
+		sets = append(sets, "type = ?")
+		args = append(args, *in.Type)
+	}
+	if in.IsGateway != nil {
+		gw := 0
+		if *in.IsGateway {
+			gw = 1
+		}
+		sets = append(sets, "is_gateway = ?")
+		args = append(args, gw)
+	}
+	if in.AgentOnly != nil {
+		ao := 0
+		if *in.AgentOnly {
+			ao = 1
+		}
+		sets = append(sets, "agent_only = ?")
+		args = append(args, ao)
+	}
+	if len(sets) > 0 {
+		args = append(args, id)
+		if _, err := tx.Exec("UPDATE routers SET "+strings.Join(sets, ", ")+" WHERE id = ?", args...); err != nil {
+			return adapters.RouterConfig{}, false
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return adapters.RouterConfig{}, false
+	}
+	for _, r := range ListRouters(db) {
+		if r.ID == id {
+			return r, true
+		}
+	}
+	return adapters.RouterConfig{}, false
+}
+
 // ---------------------------------------------------------------------------
 // Autodetección de la puerta de enlace
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #109.

## Summary
PUT /api/config/routers/{id} for editing existing routers without delete+recreate. Also exposes the agent_only toggle in the UI (was the original debt behind this issue).

## Backend
- `routerstore.UpdateRouter` with `UpdateInput` (optional pointers).
- Gateway mutation clears the flag on every other router (single gateway, transactional).
- `handleUpdateConfigRouter` on PUT, admin-only. Reuses routerInput.
- 5 new tests in config_test.go.

## Frontend (Settings.tsx RoutersManager)
- Edit button per row opens inline form prefilled.
- agent_only toggle exposed on both Add and Edit forms.
- agent_only badge on each row.

## Verification
- `go test ./... -race` green.
- `npx tsc --noEmit` clean, `npm run build` ok.
- Playwright 3/3 against local demo (Add form visible, 2 toggles, 0 JS errors). Edit flow tested in production CT 226 after deploy.
