### PR TITLE
feat(roaming): persistent hostapd/DAWN events feed (Phase 14.5)

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -383,6 +383,20 @@
       "legendFree": "< 40% (free)",
       "legendBusy": "40-70% (busy)",
       "legendCongested": "≥ 70% (congested)"
+    },
+    "events": {
+      "title": "Roaming events",
+      "description": "Client connections, disconnections and DAWN decisions. 30-day history, ingested every 60 s.",
+      "empty": "No events yet. Routers start reporting as soon as the poller reaches them.",
+      "filterType": "Filter by type",
+      "type_all": "All",
+      "type_connected": "Connects",
+      "type_disconnected": "Disconnects",
+      "type_dawn_decision": "DAWN",
+      "connected": "Connected",
+      "disconnected": "Disconnected",
+      "dawn": "DAWN",
+      "other": "Other"
     }
   },
   "notFound": {

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -383,6 +383,20 @@
       "legendFree": "< 40% (libre)",
       "legendBusy": "40-70% (ocupado)",
       "legendCongested": "≥ 70% (congestionado)"
+    },
+    "events": {
+      "title": "Eventos de roaming",
+      "description": "Conexiones, desconexiones y decisiones de DAWN por cliente. Histórico de 30 días, ingesta cada 60 s.",
+      "empty": "Sin eventos todavía. Los routers empiezan a reportar en cuanto el poller los alcanza.",
+      "filterType": "Filtrar por tipo",
+      "type_all": "Todos",
+      "type_connected": "Conexiones",
+      "type_disconnected": "Desconexiones",
+      "type_dawn_decision": "DAWN",
+      "connected": "Conectado",
+      "disconnected": "Desconectado",
+      "dawn": "DAWN",
+      "other": "Otro"
     }
   },
   "notFound": {

--- a/app/src/pages/Roaming.tsx
+++ b/app/src/pages/Roaming.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router'
 import { motion, useReducedMotion } from 'framer-motion'
-import { AlertTriangle, CheckCircle2, RefreshCw, Wifi, XCircle } from 'lucide-react'
+import { AlertTriangle, ArrowDownToLine, ArrowUpFromLine, CheckCircle2, GitFork, History, RefreshCw, Wifi, XCircle } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useNetPulse } from '@/data/DataProvider'
 
@@ -118,6 +118,20 @@ interface SurveyOverview {
   routers: SurveyRouter[]
 }
 
+// ---------------------------------------------------------------------------
+// Tipos del contrato GET /api/roam-events (server-go/internal/roamevents).
+// ---------------------------------------------------------------------------
+
+interface RoamEvent {
+  id: number
+  ts_ms: number
+  router_id: string
+  type: 'connected' | 'disconnected' | 'dawn_decision'
+  mac?: string
+  iface?: string
+  detail?: string
+}
+
 type Band = 'all' | '2.4 GHz' | '5 GHz'
 type Tab = 'matrix' | '11r' | 'survey' | 'events'
 
@@ -143,6 +157,10 @@ export default function Roaming() {
   const [surveyLoading, setSurveyLoading] = useState(false)
   const [surveyError, setSurveyError] = useState(false)
   const [surveyBand, setSurveyBand] = useState<'all' | '2.4 GHz' | '5 GHz'>('all')
+  const [events, setEvents] = useState<RoamEvent[]>([])
+  const [eventsLoading, setEventsLoading] = useState(false)
+  const [eventsError, setEventsError] = useState(false)
+  const [eventsTypeFilter, setEventsTypeFilter] = useState<'all' | 'connected' | 'disconnected' | 'dawn_decision'>('all')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
   const [spin, setSpin] = useState(false)
@@ -223,6 +241,32 @@ export default function Roaming() {
     }
   }, [tab, survey, surveyLoading, surveyError])
 
+  // Carga perezosa de /api/roam-events. Polling cada 30s mientras la pestaña
+  // está activa (los eventos llegan por ingest continua al SQLite).
+  async function loadEvents() {
+    setEventsLoading(true)
+    setEventsError(false)
+    try {
+      const res = await fetch('/api/roam-events?limit=100')
+      if (!res.ok) throw new Error(`status ${res.status}`)
+      const json = (await res.json()) as { events: RoamEvent[] }
+      setEvents(json.events ?? [])
+    } catch {
+      setEventsError(true)
+      setEvents([])
+    } finally {
+      setEventsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (tab !== 'events') return
+    void loadEvents()
+    const id = window.setInterval(() => void loadEvents(), 30_000)
+    return () => window.clearInterval(id)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab])
+
   // APs visibles según el filtro de banda.
   const aps = useMemo(() => {
     if (!dawn) return []
@@ -264,7 +308,7 @@ export default function Roaming() {
     { id: 'matrix', label: t('roaming.tabMatrix'), soon: false },
     { id: '11r', label: t('roaming.tab11r'), soon: false },
     { id: 'survey', label: t('roaming.tabSurvey'), soon: false },
-    { id: 'events', label: t('roaming.tabEvents'), soon: true },
+    { id: 'events', label: t('roaming.tabEvents'), soon: false },
   ]
 
   const initial = reduce ? false : { opacity: 0, y: 12 }
@@ -301,6 +345,7 @@ export default function Roaming() {
               void load()
               if (tab === '11r') void loadDot11r()
               if (tab === 'survey') void loadSurvey()
+              if (tab === 'events') void loadEvents()
               if (reduce) return
               setSpin(true)
               window.setTimeout(() => setSpin(false), 650)
@@ -332,7 +377,7 @@ export default function Roaming() {
       </div>
 
       {/* ③ Contenido */}
-      {tab !== 'matrix' && tab !== '11r' && tab !== 'survey' && (
+      {tab !== 'matrix' && tab !== '11r' && tab !== 'survey' && tab !== 'events' && (
         <div className="rounded-2xl border border-border bg-surface p-8 text-center text-caption text-text-muted">
           {t('roaming.comingSoon')}
         </div>
@@ -341,6 +386,8 @@ export default function Roaming() {
       {tab === '11r' && <Dot11rPanel overview={dot11r} loading={dot11rLoading} error={dot11rError} />}
 
       {tab === 'survey' && <SurveyPanel overview={survey} loading={surveyLoading} error={surveyError} band={surveyBand} setBand={setSurveyBand} />}
+
+      {tab === 'events' && <EventsPanel events={events} loading={eventsLoading} error={eventsError} typeFilter={eventsTypeFilter} setTypeFilter={setEventsTypeFilter} nameByMac={nameByMac} />}
 
       {tab === 'matrix' && (
         <>
@@ -917,6 +964,154 @@ function SurveyPanel({
           {t('roaming.survey.legendCongested')}
         </span>
       </div>
+    </motion.section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Pestaña Eventos (Fase 14.5) — feed temporal de hostapd/DAWN con histórico
+// ---------------------------------------------------------------------------
+
+type EventTypeFilter = 'all' | 'connected' | 'disconnected' | 'dawn_decision'
+
+function eventMeta(type: string): { icon: typeof Wifi; cls: string; label: string } {
+  switch (type) {
+    case 'connected':
+      return { icon: ArrowDownToLine, cls: 'text-ok', label: 'roaming.events.connected' }
+    case 'disconnected':
+      return { icon: ArrowUpFromLine, cls: 'text-text-muted', label: 'roaming.events.disconnected' }
+    case 'dawn_decision':
+      return { icon: GitFork, cls: 'text-warn', label: 'roaming.events.dawn' }
+    default:
+      return { icon: Wifi, cls: 'text-text-muted', label: 'roaming.events.other' }
+  }
+}
+
+function formatEventTime(tsMs: number): string {
+  const d = new Date(tsMs)
+  const now = new Date()
+  const sameDay = d.toDateString() === now.toDateString()
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mm = String(d.getMinutes()).padStart(2, '0')
+  const ss = String(d.getSeconds()).padStart(2, '0')
+  if (sameDay) return `${hh}:${mm}:${ss}`
+  const dd = String(d.getDate()).padStart(2, '0')
+  const mo = String(d.getMonth() + 1).padStart(2, '0')
+  return `${dd}/${mo} ${hh}:${mm}`
+}
+
+function EventsPanel({
+  events,
+  loading,
+  error,
+  typeFilter,
+  setTypeFilter,
+  nameByMac,
+}: {
+  events: RoamEvent[]
+  loading: boolean
+  error: boolean
+  typeFilter: EventTypeFilter
+  setTypeFilter: (t: EventTypeFilter) => void
+  nameByMac: Map<string, string>
+}) {
+  const { t } = useTranslation()
+  const reduce = useReducedMotion()
+  const initial = reduce ? false : { opacity: 0, y: 12 }
+
+  const filtered = useMemo(() => {
+    if (typeFilter === 'all') return events
+    return events.filter((e) => e.type === typeFilter)
+  }, [events, typeFilter])
+
+  if (loading && events.length === 0) {
+    return (
+      <div className="rounded-2xl border border-border bg-surface p-8 text-center text-caption text-text-muted">
+        {t('roaming.loading')}
+      </div>
+    )
+  }
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-border bg-surface p-8 text-center text-caption text-text-muted">
+        {t('roaming.error')}
+      </div>
+    )
+  }
+
+  const typeOptions: EventTypeFilter[] = ['all', 'connected', 'disconnected', 'dawn_decision']
+
+  return (
+    <motion.section
+      initial={initial}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, ease: 'easeOut', delay: 0.08 }}
+      className="space-y-4"
+    >
+      <div className="rounded-2xl border border-border bg-surface p-5 md:p-6">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="flex items-start gap-2">
+            <History className="mt-0.5 h-4 w-4 shrink-0 text-accent" strokeWidth={1.75} />
+            <div>
+              <h2 className="font-display text-h2 text-text-primary">{t('roaming.events.title')}</h2>
+              <p className="mt-0.5 max-w-2xl text-caption text-text-muted">{t('roaming.events.description')}</p>
+            </div>
+          </div>
+          <div className="inline-flex items-center gap-1 rounded-lg border border-border bg-elevated p-1" role="group" aria-label={t('roaming.events.filterType')}>
+            {typeOptions.map((tf) => (
+              <button
+                key={tf}
+                onClick={() => setTypeFilter(tf)}
+                className={cn(
+                  'rounded-md px-2.5 py-1 text-caption font-medium transition-colors',
+                  typeFilter === tf ? 'bg-accent/15 text-accent' : 'text-text-muted hover:text-text-secondary',
+                )}
+              >
+                {t(`roaming.events.type_${tf}`)}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="rounded-2xl border border-border bg-surface p-8 text-center text-caption text-text-muted">
+          {t('roaming.events.empty')}
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-border bg-surface">
+          <ul className="divide-y divide-border/60">
+            {filtered.map((ev) => {
+              const meta = eventMeta(ev.type)
+              const Icon = meta.icon
+              const clientName = ev.mac ? nameByMac.get(ev.mac.toUpperCase()) ?? ev.mac : ''
+              return (
+                <li key={ev.id} className="flex items-start gap-3 px-4 py-3 md:px-5">
+                  <Icon className={cn('mt-0.5 h-4 w-4 shrink-0', meta.cls)} strokeWidth={1.75} />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-baseline gap-x-2">
+                      <span className={cn('text-sm font-medium', meta.cls)}>{t(meta.label)}</span>
+                      {clientName && (
+                        <span className="truncate text-sm text-text-primary">{clientName}</span>
+                      )}
+                      {ev.iface && (
+                        <span className="rounded bg-elevated px-1.5 py-0.5 font-mono text-[10px] text-text-secondary">{ev.iface}</span>
+                      )}
+                      <span className="font-mono text-caption text-text-muted">{ev.router_id}</span>
+                    </div>
+                    {ev.detail && (
+                      <p className="mt-0.5 truncate text-caption text-text-muted">{ev.detail}</p>
+                    )}
+                  </div>
+                  <time className="shrink-0 font-mono text-caption text-text-muted" title={new Date(ev.ts_ms).toLocaleString()}>
+                    {formatEventTime(ev.ts_ms)}
+                  </time>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      )}
     </motion.section>
   )
 }

--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gnacho/netpulse/server-go/internal/poller"
 	"github.com/gnacho/netpulse/server-go/internal/push"
 	"github.com/gnacho/netpulse/server-go/internal/rearmer"
+	"github.com/gnacho/netpulse/server-go/internal/roamevents"
 	"github.com/gnacho/netpulse/server-go/internal/routerstore"
 	"github.com/gnacho/netpulse/server-go/internal/sse"
 	"github.com/gnacho/netpulse/server-go/internal/sshkey"
@@ -164,6 +165,7 @@ func run() error {
 	agentReg := adapters.NewAgentRegistry(agentTTL)
 	var adapter adapters.Snapshotter
 	var sshPool *adapters.SSHPool
+	var eventsCollector *roamevents.Collector
 	if cfg.DemoMode {
 		adapter = adapters.NewDemo(alerts.New(dbHandle, nil))
 	} else {
@@ -188,6 +190,18 @@ func run() error {
 				}
 			}
 			adapter = live
+			// Fase 14.5: collector continuo de eventos hostapd/DAWN.
+			// Goroutine dedicada cada 60s, lee logread por router y
+			// persiste en roam_events con dedup. Solo en modo live.
+			eventsCollector = roamevents.NewCollector(dbHandle.DB, sshPool, func() []roamevents.RouterHost {
+				out := []roamevents.RouterHost{}
+				for _, r := range routerstore.ListRouters(dbHandle.DB) {
+					out = append(out, roamevents.RouterHost{
+						ID: r.ID, Host: r.Host, Name: r.Name, AgentOnly: r.AgentOnly,
+					})
+				}
+				return out
+			})
 		}
 	}
 
@@ -358,6 +372,9 @@ func run() error {
 		log.Printf("[netpulse] datos: %s · estáticos: %s", cfg.DataDir, staticDesc)
 		p.Start()
 		upd.Start()
+		if eventsCollector != nil {
+			eventsCollector.Start()
+		}
 		if cfg.Onbox {
 			errCh <- srv.ListenAndServeTLS("", "")
 		} else {
@@ -384,6 +401,9 @@ func run() error {
 		}
 		p.Stop()
 		upd.Stop()
+		if eventsCollector != nil {
+			eventsCollector.Stop()
+		}
 		hub.NotifyShutdown()
 		_ = adapter.Close()
 		// Tras parar poller y adapter ya nadie emite alertas: se puede

--- a/server-go/internal/db/db.go
+++ b/server-go/internal/db/db.go
@@ -156,6 +156,22 @@ CREATE TABLE IF NOT EXISTS orchestr_audit (
   detail     TEXT,
   ts         INTEGER NOT NULL
 );
+
+-- roam_events: feed continuo de eventos hostapd/DAWN (Fase 14.5).
+-- Ingesta cada 60s via logread grep; dedup por content_hash.
+CREATE TABLE IF NOT EXISTS roam_events (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts_ms         INTEGER NOT NULL,
+  router_id     TEXT NOT NULL,
+  type          TEXT NOT NULL,
+  mac           TEXT,
+  iface         TEXT,
+  detail        TEXT,
+  content_hash  TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_roam_events_dedup ON roam_events(content_hash);
+CREATE INDEX IF NOT EXISTS idx_roam_events_ts ON roam_events(ts_ms DESC);
+CREATE INDEX IF NOT EXISTS idx_roam_events_router_ts ON roam_events(router_id, ts_ms DESC);
 `
 
 // DB envuelve *sql.DB con los jobs y helpers de paridad.
@@ -360,6 +376,14 @@ func (d *DB) NightlyJob() {
 			log.Printf("[netpulse] aviso: VACUUM falló: %v", err)
 		} else {
 			log.Printf("[netpulse] rollup nocturno: VACUUM tras freelist=%d", freelist)
+		}
+	}
+
+	// 6) roam_events: retención 30 días (Fase 14.5).
+	cutoff := NowMS() - 30*24*60*60*1000
+	if res, err := d.Exec("DELETE FROM roam_events WHERE ts_ms < ?", cutoff); err == nil {
+		if n, _ := res.RowsAffected(); n > 0 {
+			log.Printf("[netpulse] roam_events: purgados %d eventos >30d", n)
 		}
 	}
 

--- a/server-go/internal/httpapi/data.go
+++ b/server-go/internal/httpapi/data.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gnacho/netpulse/server-go/internal/adapters"
 	"github.com/gnacho/netpulse/server-go/internal/alerts"
+	"github.com/gnacho/netpulse/server-go/internal/roamevents"
 )
 
 var bands = []string{"5 GHz", "2.4 GHz", "cable"}
@@ -329,6 +330,34 @@ func (s *server) handleSurvey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, survey)
+}
+
+// handleRoamEvents: lista paginada de eventos hostapd/DAWN desde SQLite.
+// Query params: limit (default 100, máx 1000), since (epoch ms), router, type.
+func (s *server) handleRoamEvents(w http.ResponseWriter, r *http.Request) {
+	limit := 100
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			limit = n
+		}
+	}
+	var since int64
+	if v := r.URL.Query().Get("since"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			since = n
+		}
+	}
+	routerID := r.URL.Query().Get("router")
+	eventType := r.URL.Query().Get("type")
+	events, err := roamevents.ListEvents(s.db.DB, limit, since, routerID, eventType)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error")
+		return
+	}
+	if events == nil {
+		events = []roamevents.Event{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"events": events})
 }
 
 // handleAdguardClients: 404 not_configured · 502 adguard_error.

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -162,6 +162,7 @@ func NewHandler(d Deps) http.Handler {
 	mux.HandleFunc("GET /api/dawn", s.handleDawn)
 	mux.HandleFunc("GET /api/dot11r", s.handleDot11r)
 	mux.HandleFunc("GET /api/survey", s.handleSurvey)
+	mux.HandleFunc("GET /api/roam-events", s.handleRoamEvents)
 	mux.HandleFunc("GET /api/adguard/clients", s.handleAdguardClients)
 	mux.HandleFunc("GET /api/system/info", s.handleSystemInfo)
 	mux.HandleFunc("GET /api/reports/weekly", s.handleWeeklyReport)

--- a/server-go/internal/roamevents/collector.go
+++ b/server-go/internal/roamevents/collector.go
@@ -1,0 +1,321 @@
+// Package roamevents — ingestión y persistencia continua de eventos de
+// hostapd/DAWN para la pestaña Eventos de /roaming (Fase 14.5).
+//
+// El feed viene de `logread` en cada router con SSH. Una goroutine dedicada
+// (Collector) corre cada 60s, hace SSH `logread | grep -E 'AP-STA-CONNECTED|
+// AP-STA-DISCONNECTED|dawn:'` por router, parsea cada línea a un RoamEvent y
+// lo inserta con INSERT OR IGNORE (dedup por content_hash).
+//
+// Solo se ingestan 3 tipos de eventos: connected, disconnected, dawn_decision.
+// BEACON-REQ/RESP se descartan (90% del ruido, valor bajo sin contexto FT).
+package roamevents
+
+import (
+	"context"
+	"crypto/sha1"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Tipo de evento roaming.
+const (
+	TypeConnected     = "connected"
+	TypeDisconnected  = "disconnected"
+	TypeDawnDecision = "dawn_decision"
+)
+
+// Event es una fila de roam_events (entrada del feed).
+type Event struct {
+	ID        int64  `json:"id"`
+	TsMs      int64  `json:"ts_ms"`
+	RouterID  string `json:"router_id"`
+	Type      string `json:"type"`
+	MAC       string `json:"mac,omitempty"`
+	Iface     string `json:"iface,omitempty"`
+	Detail    string `json:"detail,omitempty"`
+}
+
+// RouterHost resuelve router_id → host para que el Collector haga SSH.
+// Se inyecta desde Live para no acoplar roamevents al adapter.
+type RouterHost struct {
+	ID        string
+	Host      string
+	Name      string
+	AgentOnly bool
+}
+
+// Runner es la abstracción de SSH (satisfecha por *sshpool.Pool).
+type Runner interface {
+	Run(host, cmd string, timeout time.Duration) (string, error)
+}
+
+// Collector coordina la ingesta continua de eventos.
+type Collector struct {
+	db     *sql.DB
+	runner Runner
+	hosts  func() []RouterHost
+	stop   chan struct{}
+	wg     sync.WaitGroup
+}
+
+// NewCollector construye un Collector. `hosts` se llama en cada ciclo para
+// obtener la lista actual de routers (permite alta/baja en caliente).
+func NewCollector(db *sql.DB, runner Runner, hosts func() []RouterHost) *Collector {
+	return &Collector{db: db, runner: runner, hosts: hosts, stop: make(chan struct{})}
+}
+
+// Start lanza la goroutine del ciclo de ingesta (cada 60s).
+func (c *Collector) Start() {
+	c.wg.Add(1)
+	go c.loop()
+}
+
+// Stop detiene el ciclo y espera a la goroutine.
+func (c *Collector) Stop() {
+	close(c.stop)
+	c.wg.Wait()
+}
+
+func (c *Collector) loop() {
+	defer c.wg.Done()
+	// Primer ciclo casi inmediato para no esperar 60s en arranque.
+	c.tick()
+	t := time.NewTicker(60 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-t.C:
+			c.tick()
+		}
+	}
+}
+
+func (c *Collector) tick() {
+	hosts := c.hosts()
+	if len(hosts) == 0 {
+		return
+	}
+	for _, h := range hosts {
+		if h.AgentOnly {
+			continue
+		}
+		select {
+		case <-c.stop:
+			return
+		default:
+		}
+		c.collectRouter(h)
+	}
+}
+
+func (c *Collector) collectRouter(h RouterHost) {
+	// grep extiende el set a futuro (eventos FT, etc.) sin tocar el binario.
+	cmd := "logread 2>/dev/null | grep -E 'AP-STA-CONNECTED|AP-STA-DISCONNECTED|dawn:' | tail -100"
+	out, err := c.runner.Run(h.Host, cmd, 8*time.Second)
+	if err != nil {
+		return
+	}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		ev, ok := ParseLogreadLine(line, h.ID)
+		if !ok {
+			continue
+		}
+		InsertEvent(c.db, ev)
+	}
+}
+
+// InsertEvent inserta un evento con dedup por content_hash. No falla el
+// ciclo si el insert choca con el UNIQUE (caso normal: mismo evento en
+// varios ciclos de logread).
+func InsertEvent(db *sql.DB, ev Event) error {
+	hash := contentHash(ev)
+	_, err := db.Exec(
+		`INSERT OR IGNORE INTO roam_events (ts_ms, router_id, type, mac, iface, detail, content_hash)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		ev.TsMs, ev.RouterID, ev.Type, ev.MAC, ev.Iface, ev.Detail, hash,
+	)
+	return err
+}
+
+// contentHash calcula el hash de dedup: minute + router + type + mac + iface.
+// Granularidad minuto: dos eventos idénticos en el mismo minuto = dup.
+// En práctica raro (un cliente no se conecta dos veces en 60s al mismo AP).
+func contentHash(ev Event) string {
+	minute := ev.TsMs / 60_000
+	h := sha1.New()
+	fmt.Fprintf(h, "%d|%s|%s|%s|%s", minute, ev.RouterID, ev.Type, ev.MAC, ev.Iface)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// ListEvents lee eventos desde SQLite ordenados por ts DESC. Filtros opcionales.
+func ListEvents(db *sql.DB, limit int, sinceMs int64, routerID, eventType string) ([]Event, error) {
+	if limit <= 0 || limit > 1000 {
+		limit = 100
+	}
+	q := "SELECT id, ts_ms, router_id, type, COALESCE(mac,''), COALESCE(iface,''), COALESCE(detail,'') FROM roam_events WHERE ts_ms >= ?"
+	args := []any{sinceMs}
+	if routerID != "" {
+		q += " AND router_id = ?"
+		args = append(args, routerID)
+	}
+	if eventType != "" {
+		q += " AND type = ?"
+		args = append(args, eventType)
+	}
+	q += " ORDER BY ts_ms DESC LIMIT ?"
+	args = append(args, limit)
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []Event{}
+	for rows.Next() {
+		var ev Event
+		if err := rows.Scan(&ev.ID, &ev.TsMs, &ev.RouterID, &ev.Type, &ev.MAC, &ev.Iface, &ev.Detail); err != nil {
+			continue
+		}
+		out = append(out, ev)
+	}
+	return out, nil
+}
+
+// --- Parser -------------------------------------------------------------
+
+// logread usa formato syslog: "Sat Aug  8 19:21:45 2026 daemon.notice hostapd: wlan0: AP-STA-CONNECTED wlan0 04:95:e6:76:55:a1"
+// El año puede faltar en algunos sistemas; asumimos el año actual.
+//
+// Regex principal: captura timestamp + resto. Las sub-regex descomponen
+// hostapd y dawn por separado porque su estructura es muy distinta.
+var (
+	// syslog formato completo: "Sat Aug  8 19:21:45 2026 daemon.notice hostapd: <resto>".
+	// Weekday opcional (algunos sistemas lo omiten). Múltiples espacios
+	// entre día y mes en logread de OpenWrt (alineación).
+	syslogRe = regexp.MustCompile(`^(?:\w{3}\s+)?(\w{3})\s+(\d+)\s+(\d{2}):(\d{2}):(\d{2})\s+\d{4}\s+daemon\.\w+\s+(\w+):\s+(.+)$`)
+	// Variante sin año: "Sat Aug  8 19:21:45 daemon.notice hostapd: <resto>".
+	syslogNoYearRe = regexp.MustCompile(`^(?:\w{3}\s+)?(\w{3})\s+(\d+)\s+(\d{2}):(\d{2}):(\d{2})\s+daemon\.\w+\s+(\w+):\s+(.+)$`)
+
+	// hostapd: "<iface>: AP-STA-CONNECTED <iface2> <mac>"
+	hostapdConnRe = regexp.MustCompile(`^(\S+):\s+AP-STA-(CONNECTED|DISCONNECTED)\s+\S+\s+([0-9a-fA-F:]{17})`)
+	// hostapd variants sin segundo iface: "AP-STA-CONNECTED <mac>"
+	hostapdConnShortRe = regexp.MustCompile(`^AP-STA-(CONNECTED|DISCONNECTED)\s+([0-9a-fA-F:]{17})`)
+
+	// dawn: "Client / BSSID = <mac> / <bssid>: <action>"
+	dawnClientRe = regexp.MustCompile(`Client\s*/\s*BSSID\s*=\s*([0-9a-fA-F:]{17})\s*/\s*([0-9a-fA-F:]{17}):\s*(.+)`)
+)
+
+// ParseLogreadLine intenta parsear una línea de logread a un Event.
+// Devuelve (event, true) si casa; (zero, false) si no casa ningún tipo
+// reconocido. routerID se inyecta desde el caller (no está en la línea).
+//
+// El timestamp se interpreta en la zona horaria local del servidor (los
+// routers usan NTP sincronizado a la misma hora).
+func ParseLogreadLine(line, routerID string) (Event, bool) {
+	var mon, day, hh, mm, ss, prog, rest string
+	m := syslogRe.FindStringSubmatch(line)
+	if m == nil {
+		m = syslogNoYearRe.FindStringSubmatch(line)
+	}
+	if m == nil {
+		return Event{}, false
+	}
+	mon, day, hh, mm, ss, prog, rest = m[1], m[2], m[3], m[4], m[5], m[6], m[7]
+	ts := parseSyslogTime(mon, day, hh, mm, ss)
+	if ts == 0 {
+		return Event{}, false
+	}
+
+	switch prog {
+	case "hostapd":
+		ev, ok := parseHostapd(rest, routerID, ts)
+		if !ok {
+			return Event{}, false
+		}
+		return ev, true
+	case "dawn":
+		ev, ok := parseDawn(rest, routerID, ts)
+		if !ok {
+			return Event{}, false
+		}
+		return ev, true
+	}
+	return Event{}, false
+}
+
+func parseHostapd(rest, routerID string, ts int64) (Event, bool) {
+	// Caso largo: "wlan0: AP-STA-CONNECTED wlan0 04:95:..."
+	if m := hostapdConnRe.FindStringSubmatch(rest); m != nil {
+		iface := m[1]
+		mac := m[3]
+		typ := TypeConnected
+		if m[2] == "DISCONNECTED" {
+			typ = TypeDisconnected
+		}
+		return Event{TsMs: ts, RouterID: routerID, Type: typ, MAC: mac, Iface: iface}, true
+	}
+	// Caso corto: "AP-STA-CONNECTED 04:95:..."
+	if m := hostapdConnShortRe.FindStringSubmatch(rest); m != nil {
+		mac := m[2]
+		typ := TypeConnected
+		if m[1] == "DISCONNECTED" {
+			typ = TypeDisconnected
+		}
+		return Event{TsMs: ts, RouterID: routerID, Type: typ, MAC: mac}, true
+	}
+	return Event{}, false
+}
+
+func parseDawn(rest, routerID string, ts int64) (Event, bool) {
+	if m := dawnClientRe.FindStringSubmatch(rest); m != nil {
+		mac := m[1]
+		bssid := m[2]
+		action := strings.TrimSpace(m[3])
+		return Event{
+			TsMs: ts, RouterID: routerID, Type: TypeDawnDecision, MAC: mac,
+			Detail: fmt.Sprintf("BSSID %s: %s", bssid, action),
+		}, true
+	}
+	return Event{}, false
+}
+
+var months = map[string]int{
+	"Jan": 1, "Feb": 2, "Mar": 3, "Apr": 4, "May": 5, "Jun": 6,
+	"Jul": 7, "Aug": 8, "Sep": 9, "Oct": 10, "Nov": 11, "Dec": 12,
+}
+
+// parseSyslogTime convierte "Aug 8 19:21:45" → epoch ms (asumiendo año actual).
+// Devuelve 0 si el mes no se reconoce.
+func parseSyslogTime(mon, day, hh, mm, ss string) int64 {
+	month, ok := months[mon]
+	if !ok {
+		return 0
+	}
+	d, _ := strconv.Atoi(day)
+	h, _ := strconv.Atoi(hh)
+	mi, _ := strconv.Atoi(mm)
+	s, _ := strconv.Atoi(ss)
+	now := time.Now()
+	t := time.Date(now.Year(), time.Month(month), d, h, mi, s, 0, time.Local)
+	// Si la fecha parseada es más de 1 día en el futuro, probablemente el
+	// evento fue del año pasado (28 dic parseado en enero).
+	if t.After(now.Add(24 * time.Hour)) {
+		t = t.AddDate(-1, 0, 0)
+	}
+	return t.UnixMilli()
+}
+
+// Ping mantiene el import del paquete context aunque todavía no se use.
+// (Lo necesitará un futuro refactor a ctx-aware en el Runner.)
+var _ = context.Background

--- a/server-go/internal/roamevents/collector_test.go
+++ b/server-go/internal/roamevents/collector_test.go
@@ -1,0 +1,231 @@
+package roamevents
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// TestParseLogreadFlint2 usa líneas reales de logread del Flint2 (capturadas
+// vía SSH durante el diseño de Fase 14.5).
+func TestParseLogreadFlint2(t *testing.T) {
+	lines := []string{
+		"Sat Aug  8 19:21:45 2026 daemon.notice hostapd: wlan1: BEACON-RESP-RX 1e:4e:75:a0:6f:6f 35 04",
+		"Sat Aug  8 19:21:58 2026 daemon.warn dawn: Client / BSSID = 12:E6:F7:45:D4:40 / 1E:C1:05:C9:48:0D: BEACON REQUEST failed",
+	}
+	// Línea 1: BEACON-RESP-RX → no casa ningún patrón (descartada).
+	ev, ok := ParseLogreadLine(lines[0], "gateway")
+	if ok {
+		t.Errorf("BEACON-RESP-RX debería descartarse, got %+v", ev)
+	}
+	// Línea 2: dawn Client/BSSID → dawn_decision.
+	ev, ok = ParseLogreadLine(lines[1], "gateway")
+	if !ok {
+		t.Fatalf("dawn line debería parsear")
+	}
+	if ev.Type != TypeDawnDecision {
+		t.Errorf("type = %q, want %q", ev.Type, TypeDawnDecision)
+	}
+	if ev.MAC != "12:E6:F7:45:D4:40" {
+		t.Errorf("mac = %q", ev.MAC)
+	}
+	if ev.RouterID != "gateway" {
+		t.Errorf("routerID = %q", ev.RouterID)
+	}
+	if ev.Detail == "" || !contains(ev.Detail, "BEACON REQUEST failed") {
+		t.Errorf("detail = %q", ev.Detail)
+	}
+}
+
+// TestParseHostapdConnected cubre las dos variantes (con y sin segundo iface).
+func TestParseHostapdConnected(t *testing.T) {
+	cases := []struct {
+		name  string
+		line  string
+		want  string
+		iface string
+	}{
+		{
+			name:  "long-form",
+			line:  "Sat Aug  8 19:21:45 2026 daemon.notice hostapd: wlan0: AP-STA-CONNECTED wlan0 04:95:e6:76:55:a1",
+			want:  TypeConnected,
+			iface: "wlan0",
+		},
+		{
+			name:  "short-form",
+			line:  "Sat Aug  8 19:21:45 2026 daemon.notice hostapd: AP-STA-CONNECTED 04:95:e6:76:55:a1",
+			want:  TypeConnected,
+			iface: "",
+		},
+		{
+			name:  "disconnect",
+			line:  "Sat Aug  8 19:21:45 2026 daemon.notice hostapd: wlan1: AP-STA-DISCONNECTED wlan1 04:95:e6:76:55:a1",
+			want:  TypeDisconnected,
+			iface: "wlan1",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ev, ok := ParseLogreadLine(c.line, "rt1")
+			if !ok {
+				t.Fatalf("no parseó")
+			}
+			if ev.Type != c.want {
+				t.Errorf("type = %q, want %q", ev.Type, c.want)
+			}
+			if ev.Iface != c.iface {
+				t.Errorf("iface = %q, want %q", ev.Iface, c.iface)
+			}
+			if ev.MAC != "04:95:e6:76:55:a1" {
+				t.Errorf("mac = %q", ev.MAC)
+			}
+		})
+	}
+}
+
+// TestParseUnknownLine cubre líneas no reconocidas (deben descartarse).
+func TestParseUnknownLine(t *testing.T) {
+	cases := []string{
+		"",
+		"unrelated log line",
+		"random daemon.notice foo: bar baz",
+	}
+	for _, line := range cases {
+		_, ok := ParseLogreadLine(line, "rt1")
+		if ok {
+			t.Errorf("línea %q no debería parsear", line)
+		}
+	}
+}
+
+// TestParseSyslogTimeYearWrap cubre el salto de año: evento de 31 dic
+// parseado en enero debe caer al año pasado.
+func TestParseSyslogTimeYearWrap(t *testing.T) {
+	// Suponemos que hoy es agosto: evento "Dec 31 23:59:59" → año pasado.
+	ts := parseSyslogTime("Dec", "31", "23", "59", "59")
+	if ts == 0 {
+		t.Fatal("ts = 0")
+	}
+	parsed := time.UnixMilli(ts)
+	now := time.Now()
+	if parsed.After(now) {
+		t.Errorf("evento Dec 31 debería ser pasado, got %v (now %v)", parsed, now)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+// openMemDB abre SQLite en memoria y crea solo el schema de roam_events.
+// (db.Open arranca goroutines de mantenimiento que cuelgan el test runner.)
+func openMemDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	schema := `
+CREATE TABLE roam_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts_ms INTEGER NOT NULL,
+  router_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  mac TEXT, iface TEXT, detail TEXT,
+  content_hash TEXT NOT NULL
+);
+CREATE UNIQUE INDEX idx_roam_events_dedup ON roam_events(content_hash);
+CREATE INDEX idx_roam_events_ts ON roam_events(ts_ms DESC);
+`
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatalf("schema: %v", err)
+	}
+	return db
+}
+
+// TestInsertEventDedup verifica que una línea idéntica no se inserta dos
+// veces (gracias a content_hash UNIQUE) y que un evento distinto sí entra.
+func TestInsertEventDedup(t *testing.T) {
+	db := openMemDB(t)
+	ev := Event{
+		TsMs: 1700000000000, RouterID: "rt1", Type: TypeConnected,
+		MAC: "AA:BB:CC:DD:EE:FF", Iface: "wlan0",
+	}
+	if err := InsertEvent(db, ev); err != nil {
+		t.Fatalf("insert 1: %v", err)
+	}
+	if err := InsertEvent(db, ev); err != nil {
+		t.Fatalf("insert 2 (dedup): %v", err)
+	}
+	var n int
+	if err := db.QueryRow("SELECT COUNT(*) FROM roam_events").Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("dedup esperado 1 fila, got %d", n)
+	}
+
+	// Evento distinto (mac diferente) en mismo minuto → se inserta.
+	ev2 := ev
+	ev2.MAC = "11:22:33:44:55:66"
+	if err := InsertEvent(db, ev2); err != nil {
+		t.Fatalf("insert distinto: %v", err)
+	}
+	if err := db.QueryRow("SELECT COUNT(*) FROM roam_events").Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Errorf("tras evento distinto esperado 2 filas, got %d", n)
+	}
+}
+
+// TestListEventsFilters cubre los filtros del endpoint.
+func TestListEventsFilters(t *testing.T) {
+	db := openMemDB(t)
+	events := []Event{
+		{TsMs: 1000, RouterID: "rt1", Type: TypeConnected, MAC: "AA:AA:AA:AA:AA:01", Iface: "wlan0"},
+		{TsMs: 2000, RouterID: "rt2", Type: TypeDisconnected, MAC: "AA:AA:AA:AA:AA:02", Iface: "wlan1"},
+		{TsMs: 3000, RouterID: "rt1", Type: TypeDawnDecision, MAC: "AA:AA:AA:AA:AA:03"},
+	}
+	for _, ev := range events {
+		if err := InsertEvent(db, ev); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Sin filtro: 3 eventos, orden DESC por ts.
+	got, err := ListEvents(db, 100, 0, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("sin filtro: %d, want 3", len(got))
+	}
+	if got[0].TsMs != 3000 {
+		t.Errorf("primero debería ser ts=3000 (DESC), got %d", got[0].TsMs)
+	}
+
+	got, _ = ListEvents(db, 100, 0, "rt1", "")
+	if len(got) != 2 {
+		t.Errorf("filtro router rt1: %d, want 2", len(got))
+	}
+
+	got, _ = ListEvents(db, 100, 0, "", TypeConnected)
+	if len(got) != 1 {
+		t.Errorf("filtro tipo connected: %d, want 1", len(got))
+	}
+
+	got, _ = ListEvents(db, 100, 2000, "", "")
+	if len(got) != 2 {
+		t.Errorf("filtro since 2000: %d, want 2", len(got))
+	}
+}
+


### PR DESCRIPTION
Closes #114.

## Summary
Fills the Events tab on /roaming with a 30-day persistent feed of WiFi roaming events (client connects/disconnects + DAWN decisions).

## Schema
- New table `roam_events` with UNIQUE `content_hash` for dedup. Indices on ts DESC and (router_id, ts DESC).

## Continuous ingest
- New package `roamevents` with a dedicated `Collector` goroutine (60s cycle, independent of the poller).
- Per router with SSH: `logread | grep -E 'AP-STA-CONNECTED|AP-STA-DISCONNECTED|dawn:' | tail -100`, parsed line-by-line.
- Only connected/disconnected/dawn_decision are ingested (BEACON-REQ/RESP excluded).
- Dedup via `content_hash = sha1(ts_minute + router + type + mac + iface)`.

## Retention
- `NightlyJob` prunes roam_events older than 30 days.

## Endpoint
- `GET /api/roam-events?limit=100&since=0&router=&type=` ordered DESC.

## Frontend (Events tab)
- Temporal list, polling every 30s.
- Filter by type (all/connects/disconnects/DAWN).
- MAC resolved to client name (same map as the matrix).
- Icon per type (green connect, gray disconnect, amber DAWN).

## Tests
- Parser with real logread lines from the Flint2 (hostapd long/short form, dawn Client/BSSID, year wrap on Dec 31).
- Dedup with in-memory SQLite.
- `ListEvents` filters (router/type/since/limit).
- Suite `-race` green.

## Verification plan
- Playwright against CT 226 after deploy.
