### PR TITLE
docs: acknowledge OpenWrt in README (EN/ES)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -200,6 +200,13 @@ base de datos ocurre automáticamente en el primer arranque Go.
 cd server-go && go test ./...
 ```
 
+## Gracias enormes
+
+NetPulse no existiría sin [OpenWrt](https://openwrt.org/). Toda la premisa
+del proyecto, que el hardware de tu red sea realmente tuyo y no dependa del
+firmware cerrado de un fabricante, solo es posible porque OpenWrt existe. Si
+NetPulse te sirve, el mérito real es de la comunidad de OpenWrt.
+
 ## Licencia
 
 [AGPL-3.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ its database happens automatically on the first Go boot.
 cd server-go && go test ./...
 ```
 
+## Big thanks
+
+NetPulse wouldn't exist without [OpenWrt](https://openwrt.org/). The whole
+premise of the project, that you can own and control your network hardware
+instead of depending on a vendor's closed firmware, only works because
+OpenWrt exists. If NetPulse is useful to you, the real credit goes to the
+OpenWrt community.
+
 ## License
 
 [AGPL-3.0](LICENSE)


### PR DESCRIPTION
Adds a short acknowledgements section thanking the OpenWrt project, before the License section in both README.md and README.es.md.

NetPulse monitors OpenWrt-based routers, so the project exists because OpenWrt does.

Closes #126