### PR TITLE
feat(orchestr): QoS/SQM module (Phase 17.4)

### DIFF
--- a/agent/executor/executor.go
+++ b/agent/executor/executor.go
@@ -59,12 +59,13 @@ func (shellRunner) Run(name string, args ...string) (string, int) {
 
 // patrones de validación por campo (sin shell metachars).
 var (
-	reConfig  = regexp.MustCompile(`^[a-z_]+$`)
-	// section: nombre de sección (wifi-iface, interface) o referencia
-	// `@tipo[idx]` / `@tipo[-1]`. `[-1]` referencia la ÚLTIMA sección del
-	// tipo — usado tras un uci_add para setear los campos de la sección recién
+	reConfig = regexp.MustCompile(`^[a-z_]+$`)
+	// section: nombre de sección (wifi-iface, interface, eth1) o referencia
+	// `@tipo[idx]` / `@tipo[-1]`. Los dígitos cubren interfaces UCI reales
+	// (eth1, wlan0, br-lan). `[-1]` referencia la ÚLTIMA sección del tipo —
+	// usado tras un uci_add para setear los campos de la sección recién
 	// creada (patrón OpenWrt estándar).
-	reSection = regexp.MustCompile(`^(@[a-z_-]+(\[\d+\]|\[-1\])|[a-z_-]+)$`)
+	reSection = regexp.MustCompile(`^(@[a-z0-9_-]+(\[\d+\]|\[-1\])|[a-z0-9_-]+)$`)
 	reOption  = regexp.MustCompile(`^[a-z_]+$`)
 	// value: alfanumérico + puntos, dos-puntos, barras, hashes, guiones.
 	// Cubre IPs (192.168.1.1), DNS (1.1.1.1#3001), rutas, MACs, puertos.
@@ -296,10 +297,10 @@ var (
 
 // Executor aplica Ops allowlistedas con snapshot + healthcheck + rollback.
 type Executor struct {
-	run        Runner
-	now        func() time.Time
-	gwTarget   string // IP del gateway para healthcheck (APs)
-	wanTarget  string // IP WAN para healthcheck (gateway)
+	run       Runner
+	now       func() time.Time
+	gwTarget  string // IP del gateway para healthcheck (APs)
+	wanTarget string // IP WAN para healthcheck (gateway)
 }
 
 // New crea un ejecutor. gwTarget/wanTarget se usan para el healthcheck

--- a/agent/executor/executor_test.go
+++ b/agent/executor/executor_test.go
@@ -11,7 +11,7 @@ import (
 
 // fakeRunner registra los comandos ejecutados y devuelve respuestas canned.
 type fakeRunner struct {
-	calls    []string
+	calls     []string
 	responses map[string]int // prefix → exitCode (0 si no está)
 }
 
@@ -139,6 +139,22 @@ func TestValidateSectionLastIndex(t *testing.T) {
 	op3 := Op{Kind: "uci_set", Args: map[string]string{"config": "wireless", "section": "@wifi-iface[-2]", "option": "ssid", "value": "X"}}
 	if err := Validate(op3); err == nil {
 		t.Fatal("@wifi-iface[-2] debería rechazarse (solo -1)")
+	}
+}
+
+// TestValidateSectionWithDigits (17.4): las secciones UCI de interfaces reales
+// llevan dígitos (eth1, wlan0, br-lan) — el nombre de sección debe aceptarlos.
+func TestValidateSectionWithDigits(t *testing.T) {
+	for _, sec := range []string{"eth1", "wlan0", "br-lan", "wan6"} {
+		op := Op{Kind: "uci_set", Args: map[string]string{"config": "sqm", "section": sec, "option": "enabled", "value": "1"}}
+		if err := Validate(op); err != nil {
+			t.Errorf("section %q debería aceptarse (interfaz UCI): %v", sec, err)
+		}
+	}
+	// @tipo[-1] con tipo que lleva dígito
+	op := Op{Kind: "uci_set", Args: map[string]string{"config": "sqm", "section": "@queue[-1]", "option": "interface", "value": "eth1"}}
+	if err := Validate(op); err != nil {
+		t.Errorf("@queue[-1] debería aceptarse: %v", err)
 	}
 }
 
@@ -304,7 +320,7 @@ func TestApplyPlanConDownloadWriteChmod(t *testing.T) {
 			"dest": tmpFile,
 		}, Desc: "Download AdGuard tarball"},
 		{Kind: "write_file", Args: map[string]string{
-			"path":       "/tmp/netpulse-plan-test-cfg.yaml",
+			"path":        "/tmp/netpulse-plan-test-cfg.yaml",
 			"content_b64": "YmluZF9wb3J0OiAzMDAwCg==",
 		}, Desc: "Write AdGuard config"},
 		{Kind: "chmod", Args: map[string]string{"mode": "755", "path": tmpFile}, Desc: "Make executable"},

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -929,7 +929,8 @@
     "module": {
       "adguard": "AdGuard Home",
       "guestwifi": "Guest WiFi",
-      "ddns": "DDNS"
+      "ddns": "DDNS",
+      "sqm": "QoS (SQM)"
     },
     "warn": {
       "managed_by_firmware": "This router ships a vendor AdGuard Home (GL.iNet). NetPulse won't manage it to avoid breaking its UI: configure it from the router's own interface.",
@@ -971,6 +972,27 @@
       "domain": "Domain",
       "username": "Username",
       "password": "Password",
+      "method": {
+        "enabled": "Enabled",
+        "disabled": "Disabled"
+      }
+    },
+    "sqm": {
+      "enable": "Enable QoS (SQM)",
+      "allowNonGateway": "Allow QoS on non-gateway routers",
+      "nonGatewayWarning": "SQM prioritizes traffic and reduces latency under congestion on the selected interface. On a non-gateway router it only applies to its own link.",
+      "interface": "Interface",
+      "download": "Download (kbit/s)",
+      "upload": "Upload (kbit/s)",
+      "qdisc": "Discipline",
+      "qdiscCake": "CAKE",
+      "qdiscFqCodel": "fq_codel",
+      "script": "Script",
+      "linklayer": "Link layer",
+      "linkEthernet": "Ethernet",
+      "linkNone": "None",
+      "linkAtm": "ATM",
+      "overhead": "Overhead (bytes)",
       "method": {
         "enabled": "Enabled",
         "disabled": "Disabled"

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -929,7 +929,8 @@
     "module": {
       "adguard": "AdGuard Home",
       "guestwifi": "WiFi invitados",
-      "ddns": "DDNS"
+      "ddns": "DDNS",
+      "sqm": "QoS (SQM)"
     },
     "warn": {
       "managed_by_firmware": "Este router trae un AdGuard Home del fabricante (GL.iNet). NetPulse no lo gestiona para no romper su UI: configúralo desde la interfaz del router.",
@@ -971,6 +972,27 @@
       "domain": "Dominio",
       "username": "Usuario",
       "password": "Contraseña",
+      "method": {
+        "enabled": "Activado",
+        "disabled": "Desactivado"
+      }
+    },
+    "sqm": {
+      "enable": "Activar QoS (SQM)",
+      "allowNonGateway": "Permitir QoS en routers no-gateway",
+      "nonGatewayWarning": "El SQM prioriza el tráfico y reduce la latencia bajo congestión en la interfaz elegida. En un no-gateway solo aplica a su propio enlace.",
+      "interface": "Interfaz",
+      "download": "Descarga (kbit/s)",
+      "upload": "Subida (kbit/s)",
+      "qdisc": "Disciplina",
+      "qdiscCake": "CAKE",
+      "qdiscFqCodel": "fq_codel",
+      "script": "Script",
+      "linklayer": "Capa de enlace",
+      "linkEthernet": "Ethernet",
+      "linkNone": "Ninguna",
+      "linkAtm": "ATM",
+      "overhead": "Overhead (bytes)",
       "method": {
         "enabled": "Activado",
         "disabled": "Desactivado"

--- a/app/src/pages/Orchestration.tsx
+++ b/app/src/pages/Orchestration.tsx
@@ -6,7 +6,7 @@ import { ChevronRight, CheckCircle2, AlertCircle, Loader2, Wand2, ShieldAlert } 
 import { useNetPulse } from '@/data/DataProvider'
 import { useAuth } from '@/data/AuthContext'
 
-type Module = 'adguard' | 'guestwifi' | 'ddns'
+type Module = 'adguard' | 'guestwifi' | 'ddns' | 'sqm'
 
 interface Op {
   kind: string
@@ -61,6 +61,15 @@ export default function Orchestration() {
   const [ddDomain, setDdDomain] = useState('')
   const [ddUser, setDdUser] = useState('')
   const [ddPass, setDdPass] = useState('')
+  // QoS / SQM (17.4): interfaz + ancho de banda + qdisc.
+  const [sqEnabled, setSqEnabled] = useState(true)
+  const [sqInterface, setSqInterface] = useState('eth1')
+  const [sqDownload, setSqDownload] = useState('100000')
+  const [sqUpload, setSqUpload] = useState('20000')
+  const [sqQdisc, setSqQdisc] = useState('cake')
+  const [sqScript, setSqScript] = useState('piece_of_cake.qos')
+  const [sqLinklayer, setSqLinklayer] = useState('ethernet')
+  const [sqOverhead, setSqOverhead] = useState('44')
 
   // issue #120: todos los módulos son gateway-only por defecto. El toggle
   // "advanced" permite un router no-gateway (con warning + checks).
@@ -97,6 +106,12 @@ export default function Orchestration() {
         return { enabled: gwEnabled, ssid: gwSsid, password: gwPassword, band: gwBand, allowNonGateway }
       case 'ddns':
         return { enabled: ddEnabled, serviceName: ddService, domain: ddDomain, username: ddUser, password: ddPass, allowNonGateway }
+      case 'sqm':
+        return {
+          enabled: sqEnabled, interface: sqInterface, download: sqDownload, upload: sqUpload,
+          qdisc: sqQdisc, script: sqScript, linklayer: sqLinklayer, overhead: sqOverhead,
+          allowNonGateway,
+        }
       default:
         return { enabled: agEnabled, port: agPort, upstreamDns: agDns, allowNonGateway }
     }
@@ -189,7 +204,7 @@ export default function Orchestration() {
 
       {/* Selector de módulo */}
       <div className="flex flex-wrap gap-2">
-        {(['adguard', 'guestwifi', 'ddns'] as Module[]).map((m) => (
+        {(['adguard', 'guestwifi', 'ddns', 'sqm'] as Module[]).map((m) => (
           <button
             key={m}
             type="button"
@@ -382,6 +397,93 @@ export default function Orchestration() {
                       type="password"
                       value={ddPass}
                       onChange={(e) => setDdPass(e.target.value)}
+                      className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary"
+                    />
+                  </label>
+                </>
+              )}
+            </>
+          )}
+
+          {module === 'sqm' && (
+            <>
+              <label className="flex items-center gap-2 pt-6">
+                <input
+                  type="checkbox"
+                  checked={sqEnabled}
+                  onChange={(e) => setSqEnabled(e.target.checked)}
+                  className="h-4 w-4 rounded border-border"
+                />
+                <span className="text-sm text-text-primary">{t('orchestration.sqm.enable')}</span>
+              </label>
+
+              {sqEnabled && (
+                <>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-caption font-medium text-text-secondary">{t('orchestration.sqm.interface')}</span>
+                    <input
+                      type="text"
+                      value={sqInterface}
+                      onChange={(e) => setSqInterface(e.target.value)}
+                      className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary"
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-caption font-medium text-text-secondary">{t('orchestration.sqm.download')}</span>
+                    <input
+                      type="text"
+                      value={sqDownload}
+                      onChange={(e) => setSqDownload(e.target.value)}
+                      className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary"
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-caption font-medium text-text-secondary">{t('orchestration.sqm.upload')}</span>
+                    <input
+                      type="text"
+                      value={sqUpload}
+                      onChange={(e) => setSqUpload(e.target.value)}
+                      className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary"
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-caption font-medium text-text-secondary">{t('orchestration.sqm.qdisc')}</span>
+                    <select
+                      value={sqQdisc}
+                      onChange={(e) => setSqQdisc(e.target.value)}
+                      className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary"
+                    >
+                      <option value="cake">{t('orchestration.sqm.qdiscCake')}</option>
+                      <option value="fq_codel">{t('orchestration.sqm.qdiscFqCodel')}</option>
+                    </select>
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-caption font-medium text-text-secondary">{t('orchestration.sqm.script')}</span>
+                    <input
+                      type="text"
+                      value={sqScript}
+                      onChange={(e) => setSqScript(e.target.value)}
+                      className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary"
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-caption font-medium text-text-secondary">{t('orchestration.sqm.linklayer')}</span>
+                    <select
+                      value={sqLinklayer}
+                      onChange={(e) => setSqLinklayer(e.target.value)}
+                      className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary"
+                    >
+                      <option value="ethernet">{t('orchestration.sqm.linkEthernet')}</option>
+                      <option value="none">{t('orchestration.sqm.linkNone')}</option>
+                      <option value="atm">{t('orchestration.sqm.linkAtm')}</option>
+                    </select>
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-caption font-medium text-text-secondary">{t('orchestration.sqm.overhead')}</span>
+                    <input
+                      type="text"
+                      value={sqOverhead}
+                      onChange={(e) => setSqOverhead(e.target.value)}
                       className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary"
                     />
                   </label>

--- a/server-go/internal/httpapi/orchestr.go
+++ b/server-go/internal/httpapi/orchestr.go
@@ -27,10 +27,10 @@ func (s *server) registerOrchestrRoutes(mux *http.ServeMux, mgr *orchestr.Manage
 
 	mux.Handle("POST /api/plans", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body struct {
-			RouterID string             `json:"routerId"`
-			Resource string             `json:"resource"`
-			Diff     []executor.Op      `json:"diff"`
-			Desired  json.RawMessage    `json:"desired"`
+			RouterID string          `json:"routerId"`
+			Resource string          `json:"resource"`
+			Diff     []executor.Op   `json:"diff"`
+			Desired  json.RawMessage `json:"desired"`
 		}
 		if !readJSONBody(r, &body) || body.RouterID == "" || body.Resource == "" {
 			writeError(w, http.StatusBadRequest, "invalid_body",
@@ -166,8 +166,8 @@ func (s *server) registerOrchestrRoutes(mux *http.ServeMux, mgr *orchestr.Manage
 		}
 
 		var body struct {
-			PlanID string                 `json:"planId"`
-			Result executor.ApplyResult  `json:"result"`
+			PlanID string               `json:"planId"`
+			Result executor.ApplyResult `json:"result"`
 		}
 		if !readJSONBody(r, &body) || body.PlanID == "" {
 			writeError(w, http.StatusBadRequest, "invalid_body")
@@ -205,10 +205,10 @@ func bearerToken(r *http.Request) string {
 // Errores sentinelas del cálculo de diff (mapeados a códigos HTTP por
 // writeModuleErr).
 var (
-	errRouterNotFound           = errors.New("router_not_found")
-	errUnknownModule            = errors.New("unknown_module")
-	errProbeFailed              = errors.New("probe_failed")
-	errInvalidDesired           = errors.New("invalid_desired")
+	errRouterNotFound          = errors.New("router_not_found")
+	errUnknownModule           = errors.New("unknown_module")
+	errProbeFailed             = errors.New("probe_failed")
+	errInvalidDesired          = errors.New("invalid_desired")
 	errAdGuardGatewayOnly      = errors.New("adguard_gateway_only")
 	errAdGuardAlreadyOnGateway = errors.New("adguard_already_on_gateway")
 	errAdGuardInsufficientRAM  = errors.New("adguard_insufficient_ram")
@@ -301,6 +301,26 @@ func (s *server) computeModuleDiff(resource, routerID string, desired json.RawMe
 			return nil, "", fmt.Errorf("%w: %v", errProbeFailed, err)
 		}
 		ops := orchestr.DdnsOps(d, sc)
+		return ops, guestWiFiMethod(d.Enabled), nil
+	case "sqm":
+		var d orchestr.SqmDesired
+		if err := json.Unmarshal(desired, &d); err != nil {
+			return nil, "", fmt.Errorf("%w: %v", errInvalidDesired, err)
+		}
+		host := s.hostOfRouter(routerID)
+		if host == "" {
+			return nil, "", errRouterNotFound
+		}
+		// Gateway-only por defecto (patrón #120/#17.2).
+		isGateway, _ := s.gatewayInfo(routerID)
+		if !isGateway && !d.AllowNonGateway {
+			return nil, "", errGatewayOnly
+		}
+		sc, err := orchestr.DetectSqm(s.pool, host)
+		if err != nil {
+			return nil, "", fmt.Errorf("%w: %v", errProbeFailed, err)
+		}
+		ops := orchestr.SqmOps(d, sc)
 		return ops, guestWiFiMethod(d.Enabled), nil
 	default:
 		return nil, "", fmt.Errorf("%w: %s", errUnknownModule, resource)
@@ -396,6 +416,13 @@ func invertDesired(resource string, desired json.RawMessage) (json.RawMessage, e
 		return json.Marshal(d)
 	case "ddns":
 		var d orchestr.DdnsDesired
+		if err := json.Unmarshal(desired, &d); err != nil {
+			return nil, fmt.Errorf("desired inválido: %w", err)
+		}
+		d.Enabled = !d.Enabled
+		return json.Marshal(d)
+	case "sqm":
+		var d orchestr.SqmDesired
 		if err := json.Unmarshal(desired, &d); err != nil {
 			return nil, fmt.Errorf("desired inválido: %w", err)
 		}

--- a/server-go/internal/orchestr/sqm.go
+++ b/server-go/internal/orchestr/sqm.go
@@ -1,0 +1,226 @@
+// sqm.go — módulo de orquestación "QoS / SQM" (Fase 17.4).
+//
+// Instala sqm-scripts (apk/opkg según el router) y configura Smart Queue
+// Management (SQM) en la interfaz elegida: sección UCI `queue` con download,
+// upload, qdisc y script, y arranca el servicio `sqm`. Reutiliza los Kinds de
+// 17.1 (apk_install / install) y el patrón de índices @queue[n] del 17.2.
+package orchestr
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gnacho/netpulse/agent/executor"
+)
+
+// sqmDefaults: valores por defecto razonables para OpenWrt cuando el desired
+// no los trae (mismos que la UI LuCI de sqm-scripts).
+const (
+	sqmDefaultQdisc    = "cake"
+	sqmDefaultScript   = "piece_of_cake.qos"
+	sqmDefaultLink     = "ethernet"
+	sqmDefaultOverhead = "44"
+)
+
+// SqmDesired es el estado deseado del módulo QoS.
+type SqmDesired struct {
+	Enabled bool `json:"enabled"`
+	// Interface: interfaz WAN/LAN a gestionar (p. ej. "eth1"). Obligatoria.
+	Interface string `json:"interface"`
+	// Download / Upload: ancho de banda en kbit/s (p. ej. "85000").
+	Download string `json:"download"`
+	Upload   string `json:"upload"`
+	// Qdisc / Script: disciplinas y script de SQM (defaults LuCI).
+	Qdisc     string `json:"qdisc"`
+	Script    string `json:"script"`
+	Linklayer string `json:"linklayer"`
+	Overhead  string `json:"overhead"`
+	// AllowNonGateway: gateway-only por defecto (patrón #120).
+	AllowNonGateway bool `json:"allowNonGateway,omitempty"`
+}
+
+// SqmSection es una sección `queue` del config sqm.
+type SqmSection struct {
+	// Idx: referencia UCI "@queue[n]" (o nombre si la sección es nombrada).
+	Idx string
+	// Interface: valor de option interface.
+	Interface string
+	// Enabled: option enabled == '1'.
+	Enabled bool
+}
+
+// SqmScenario describe el estado del SQM en el router.
+type SqmScenario struct {
+	// Manager: "apk" | "opkg" (gestor de paquetes del router).
+	Manager string
+	// Installed: /etc/init.d/sqm existe (sqm-scripts instalado).
+	Installed bool
+	// Sections: secciones queue existentes en uci.
+	Sections []SqmSection
+}
+
+// probeSqmCmd detecta gestor, instalación y secciones sqm.
+const probeSqmCmd = `echo '===PKG_MGR==='
+[ -x /usr/bin/apk ] && echo apk || echo opkg
+echo '===INSTALLED==='
+[ -x /etc/init.d/sqm ] && echo yes || echo no
+echo '===SQM_UCI==='
+uci show sqm 2>/dev/null
+echo '===END==='`
+
+// DetectSqm ejecuta el probe y devuelve el escenario.
+func DetectSqm(run CommandRunner, host string) (SqmScenario, error) {
+	out, err := run.Run(host, probeSqmCmd, 8*time.Second)
+	if err != nil {
+		return SqmScenario{}, err
+	}
+	return parseSqm(out), nil
+}
+
+// parseSqm extrae el escenario del output del probe. Función pura.
+//
+// Formato de `uci show sqm`:
+//
+//	sqm.@queue[0]=queue
+//	sqm.@queue[0].interface='eth1'
+//	sqm.@queue[0].enabled='0'
+//	sqm.@queue[0].download='85000'
+//	...
+func parseSqm(out string) SqmScenario {
+	sc := SqmScenario{}
+	sections := splitSections(out)
+	sc.Manager = strings.TrimSpace(firstNonEmpty(sections["PKG_MGR"]))
+	sc.Installed = strings.TrimSpace(firstNonEmpty(sections["INSTALLED"])) == "yes"
+	uci := strings.Join(sections["SQM_UCI"], "\n")
+
+	// Secciones: líneas "sqm.@queue[n]=queue" o "sqm.<nombre>=queue".
+	for _, line := range strings.Split(uci, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "sqm.") || !strings.HasSuffix(line, "=queue") {
+			continue
+		}
+		raw := strings.TrimSuffix(strings.TrimPrefix(line, "sqm."), "=queue")
+		sec := SqmSection{Idx: raw}
+		// Leer option interface y enabled de la sección.
+		if v := sqmOptionValue(uci, raw, "interface"); v != "" {
+			sec.Interface = v
+		}
+		if v := sqmOptionValue(uci, raw, "enabled"); v == "1" {
+			sec.Enabled = true
+		}
+		sc.Sections = append(sc.Sections, sec)
+	}
+	return sc
+}
+
+// sqmOptionValue lee el valor de una option de una sección en el output de
+// `uci show sqm` ("sqm.@queue[0].interface='eth1'" → "eth1").
+func sqmOptionValue(uci, section, option string) string {
+	prefix := "sqm." + section + "." + option + "="
+	for _, line := range strings.Split(uci, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, prefix) {
+			return strings.Trim(strings.TrimPrefix(line, prefix), "'")
+		}
+	}
+	return ""
+}
+
+// SqmOps genera las Ops para activar/desactivar SQM.
+func SqmOps(desired SqmDesired, sc SqmScenario) []executor.Op {
+	if !desired.Enabled {
+		return sqmDisableOps(desired, sc)
+	}
+	iface := desired.Interface
+	if iface == "" {
+		if len(sc.Sections) > 0 {
+			iface = sc.Sections[0].Interface
+		}
+	}
+	if iface == "" {
+		iface = "eth1" // fallback razonable (la mayoría de routers OpenWrt)
+	}
+	// Resolver la sección a gestionar: la que ya tenga esa interfaz, o la
+	// primera existente, o crear una nueva (@queue[-1]).
+	idx := sqmSectionFor(sc, iface)
+	var ops []executor.Op
+	if !sc.Installed {
+		if sc.Manager == "apk" {
+			ops = append(ops, executor.Op{Kind: "apk_install", Args: map[string]string{"package": "sqm-scripts"}, Desc: "Install sqm-scripts (apk)"})
+		} else {
+			ops = append(ops, executor.Op{Kind: "install", Args: map[string]string{"package": "sqm-scripts"}, Desc: "Install sqm-scripts (opkg)"})
+		}
+	}
+	if idx == "" {
+		ops = append(ops, executor.Op{Kind: "uci_add", Args: map[string]string{"config": "sqm", "type": "queue"}, Desc: "Create sqm queue section"})
+		idx = "@queue[-1]"
+	}
+	ops = append(ops,
+		executor.Op{Kind: "uci_set", Args: map[string]string{"config": "sqm", "section": idx, "option": "enabled", "value": "1"}, Desc: "Enable SQM"},
+		executor.Op{Kind: "uci_set", Args: map[string]string{"config": "sqm", "section": idx, "option": "interface", "value": iface}, Desc: "Set SQM interface " + iface},
+		executor.Op{Kind: "uci_set", Args: map[string]string{"config": "sqm", "section": idx, "option": "download", "value": sqmOrDefault(desired.Download, "100000")}, Desc: "Set download bandwidth"},
+		executor.Op{Kind: "uci_set", Args: map[string]string{"config": "sqm", "section": idx, "option": "upload", "value": sqmOrDefault(desired.Upload, "20000")}, Desc: "Set upload bandwidth"},
+		executor.Op{Kind: "uci_set", Args: map[string]string{"config": "sqm", "section": idx, "option": "qdisc", "value": sqmOrDefault(desired.Qdisc, sqmDefaultQdisc)}, Desc: "Set SQM qdisc"},
+		executor.Op{Kind: "uci_set", Args: map[string]string{"config": "sqm", "section": idx, "option": "script", "value": sqmOrDefault(desired.Script, sqmDefaultScript)}, Desc: "Set SQM script"},
+		executor.Op{Kind: "uci_set", Args: map[string]string{"config": "sqm", "section": idx, "option": "linklayer", "value": sqmOrDefault(desired.Linklayer, sqmDefaultLink)}, Desc: "Set SQM link layer"},
+		executor.Op{Kind: "uci_set", Args: map[string]string{"config": "sqm", "section": idx, "option": "overhead", "value": sqmOrDefault(desired.Overhead, sqmDefaultOverhead)}, Desc: "Set SQM overhead"},
+		executor.Op{Kind: "uci_commit", Args: map[string]string{"config": "sqm"}, Desc: "Commit sqm config"},
+		executor.Op{Kind: "service", Args: map[string]string{"name": "sqm", "action": "enable"}, Desc: "Enable sqm on boot"},
+		executor.Op{Kind: "service", Args: map[string]string{"name": "sqm", "action": "start"}, Desc: "Start sqm service"},
+	)
+	return ops
+}
+
+// sqmDisableOps desactiva SQM sin desinstalar el paquete.
+func sqmDisableOps(desired SqmDesired, sc SqmScenario) []executor.Op {
+	iface := desired.Interface
+	if iface == "" && len(sc.Sections) > 0 {
+		iface = sc.Sections[0].Interface
+	}
+	idx := sqmSectionFor(sc, iface)
+	if idx == "" {
+		// No hay sección que desactivar.
+		return []executor.Op{}
+	}
+	return []executor.Op{
+		{Kind: "uci_set", Args: map[string]string{"config": "sqm", "section": idx, "option": "enabled", "value": "0"}, Desc: "Disable SQM"},
+		{Kind: "uci_commit", Args: map[string]string{"config": "sqm"}, Desc: "Commit sqm config"},
+		{Kind: "service", Args: map[string]string{"name": "sqm", "action": "stop"}, Desc: "Stop sqm service"},
+		{Kind: "service", Args: map[string]string{"name": "sqm", "action": "disable"}, Desc: "Disable sqm on boot"},
+	}
+}
+
+// sqmSectionFor devuelve la referencia UCI de la sección a gestionar: la que
+// ya tiene la interfaz deseada, o la primera existente ("" si no hay ninguna).
+func sqmSectionFor(sc SqmScenario, iface string) string {
+	if iface != "" {
+		for _, s := range sc.Sections {
+			if s.Interface == iface {
+				return s.Idx
+			}
+		}
+	}
+	if len(sc.Sections) > 0 {
+		return sc.Sections[0].Idx
+	}
+	return ""
+}
+
+// sqmOrDefault devuelve val si no está vacío, si no fallback.
+func sqmOrDefault(val, fallback string) string {
+	if val == "" {
+		return fallback
+	}
+	return val
+}
+
+// validateSqmOps valida cada op contra el executor (usado en tests).
+func validateSqmOps(ops []executor.Op) error {
+	for _, op := range ops {
+		if err := executor.Validate(op); err != nil {
+			return fmt.Errorf("%s: %w", op.Desc, err)
+		}
+	}
+	return nil
+}

--- a/server-go/internal/orchestr/sqm_test.go
+++ b/server-go/internal/orchestr/sqm_test.go
@@ -1,0 +1,166 @@
+package orchestr
+
+import "testing"
+
+// Fixture real de rt2 (Redmi AX6, OpenWrt apk) — sqm-scripts NO instalado,
+// sección sqm.eth1=queue preexistente con enabled=0 (config del paquete).
+const sqmOut = `===PKG_MGR===
+apk
+===INSTALLED===
+no
+===SQM_UCI===
+sqm.eth1=queue
+sqm.eth1.enabled='0'
+sqm.eth1.interface='eth1'
+sqm.eth1.download='85000'
+sqm.eth1.upload='10000'
+sqm.eth1.qdisc='cake'
+sqm.eth1.script='piece_of_cake.qos'
+sqm.eth1.qdisc_advanced='0'
+sqm.eth1.ingress_ecn='ECN'
+sqm.eth1.egress_ecn='ECN'
+sqm.eth1.qdisc_really_really_advanced='0'
+sqm.eth1.itarget='auto'
+sqm.eth1.etarget='auto'
+sqm.eth1.linklayer='none'
+===END===`
+
+// TestParseSqm: gestor apk, NO instalado, sección eth1 detectada con sus
+// options interface/enabled.
+func TestParseSqm(t *testing.T) {
+	sc := parseSqm(sqmOut)
+	if sc.Manager != "apk" {
+		t.Errorf("Manager: got %q want apk", sc.Manager)
+	}
+	if sc.Installed {
+		t.Error("Installed: esperaba false (sqm-scripts no instalado)")
+	}
+	if len(sc.Sections) != 1 {
+		t.Fatalf("Sections: got %d want 1", len(sc.Sections))
+	}
+	sec := sc.Sections[0]
+	if sec.Idx != "eth1" {
+		t.Errorf("Sections[0].Idx: got %q want eth1", sec.Idx)
+	}
+	if sec.Interface != "eth1" {
+		t.Errorf("Sections[0].Interface: got %q want eth1", sec.Interface)
+	}
+	if sec.Enabled {
+		t.Error("Sections[0].Enabled: esperaba false (enabled='0')")
+	}
+}
+
+// TestParseSqmSinConfig: sin sqm en uci → sin secciones.
+func TestParseSqmSinConfig(t *testing.T) {
+	out := "===PKG_MGR===\napk\n===INSTALLED===\nno\n===SQM_UCI===\n===END==="
+	sc := parseSqm(out)
+	if sc.Manager != "apk" {
+		t.Errorf("Manager: got %q want apk", sc.Manager)
+	}
+	if len(sc.Sections) != 0 {
+		t.Errorf("Sections: got %d want 0", len(sc.Sections))
+	}
+}
+
+// TestSqmEnableConSeccionExistente: enable reusa la sección eth1, instala
+// sqm-scripts (apk) y configura. Sin uci_add (sección ya existe).
+func TestSqmEnableConSeccionExistente(t *testing.T) {
+	sc := parseSqm(sqmOut)
+	desired := SqmDesired{
+		Enabled:   true,
+		Interface: "eth1",
+		Download:  "90000",
+		Upload:    "15000",
+	}
+	ops := SqmOps(desired, sc)
+	if len(ops) < 10 {
+		t.Fatalf("ops: got %d, esperaba >= 10", len(ops))
+	}
+	// Primer op: apk_install sqm-scripts.
+	if ops[0].Kind != "apk_install" || ops[0].Args["package"] != "sqm-scripts" {
+		t.Errorf("ops[0]: got %v, esperaba apk_install sqm-scripts", ops[0])
+	}
+	// Sin uci_add (la sección eth1 ya existe).
+	for _, op := range ops {
+		if op.Kind == "uci_add" {
+			t.Errorf("no esperaba uci_add: la sección eth1 ya existe")
+		}
+	}
+	// La sección gestionada es eth1 (no @queue[-1]).
+	found := false
+	for _, op := range ops {
+		if op.Kind == "uci_set" && op.Args["section"] == "eth1" && op.Args["option"] == "enabled" {
+			found = true
+			if op.Args["value"] != "1" {
+				t.Errorf("enabled: got %q want 1", op.Args["value"])
+			}
+		}
+	}
+	if !found {
+		t.Error("esperaba uci_set sqm.eth1.enabled=1")
+	}
+	if err := validateSqmOps(ops); err != nil {
+		t.Fatalf("validateSqmOps: %v", err)
+	}
+}
+
+// TestSqmEnableCreaSeccion: sin sección previa → uci_add + @queue[-1].
+func TestSqmEnableCreaSeccion(t *testing.T) {
+	out := "===PKG_MGR===\nopkg\n===INSTALLED===\nno\n===SQM_UCI===\n===END==="
+	sc := parseSqm(out)
+	desired := SqmDesired{Enabled: true, Interface: "wan", Download: "50000", Upload: "5000"}
+	ops := SqmOps(desired, sc)
+	hasAdd := false
+	hasNewRef := false
+	for _, op := range ops {
+		if op.Kind == "uci_add" {
+			hasAdd = true
+		}
+		if op.Kind == "uci_set" && op.Args["section"] == "@queue[-1]" && op.Args["option"] == "interface" {
+			hasNewRef = true
+		}
+	}
+	if !hasAdd {
+		t.Error("esperaba uci_add (no hay sección)")
+	}
+	if !hasNewRef {
+		t.Error("esperaba uci_set en @queue[-1] (sección recién creada)")
+	}
+	// opkg → install (no apk_install).
+	if ops[0].Kind != "install" {
+		t.Errorf("ops[0].Kind: got %q want install (opkg)", ops[0].Kind)
+	}
+	if err := validateSqmOps(ops); err != nil {
+		t.Fatalf("validateSqmOps: %v", err)
+	}
+}
+
+// TestSqmDisable: usa la sección existente, enabled=0 + stop + disable.
+func TestSqmDisable(t *testing.T) {
+	sc := parseSqm(sqmOut)
+	desired := SqmDesired{Enabled: false, Interface: "eth1"}
+	ops := SqmOps(desired, sc)
+	if len(ops) != 4 {
+		t.Fatalf("ops: got %d want 4 (uci_set+commit+stop+disable)", len(ops))
+	}
+	if ops[0].Kind != "uci_set" || ops[0].Args["option"] != "enabled" || ops[0].Args["value"] != "0" {
+		t.Errorf("ops[0]: got %v, esperaba uci_set enabled=0", ops[0])
+	}
+	if ops[3].Kind != "service" || ops[3].Args["action"] != "disable" {
+		t.Errorf("ops[3]: got %v, esperaba service sqm disable", ops[3])
+	}
+	if err := validateSqmOps(ops); err != nil {
+		t.Fatalf("validateSqmOps: %v", err)
+	}
+}
+
+// TestSqmDisableSinSeccion: sin sección → no-op (0 ops).
+func TestSqmDisableSinSeccion(t *testing.T) {
+	out := "===PKG_MGR===\napk\n===INSTALLED===\nno\n===SQM_UCI===\n===END==="
+	sc := parseSqm(out)
+	desired := SqmDesired{Enabled: false}
+	ops := SqmOps(desired, sc)
+	if len(ops) != 0 {
+		t.Errorf("ops: got %d want 0 (no hay sección que desactivar)", len(ops))
+	}
+}


### PR DESCRIPTION
Closes #136

## What

Phase 17.4 — QoS / Smart Queue Management (SQM) orchestration module,
backend and frontend.

- **Probe**: detects the package manager (apk/opkg), whether sqm-scripts
  is installed (`/etc/init.d/sqm`) and the current `uci show sqm` queue
  sections (interface + enabled).
- **Enable**: installs sqm-scripts if missing, reuses the queue section
  matching the desired interface (or creates one via `uci_add` +
  `@queue[-1]`), sets enabled/interface/download/upload/qdisc/script/
  linklayer/overhead, commits, and enables + starts the `sqm` service.
- **Disable**: sets enabled=0, stops + disables the service (keeps the
  package installed, idempotent re-enable).
- Gateway-only by default (`allowNonGateway`), and `invertDesired`
  supports `sqm` for manual rollback.

## Changes

- `server-go/internal/orchestr/sqm.go` (+ tests): module with probe, pure
  parser, enable/disable ops and executor-contract validation.
- `server-go/internal/httpapi/orchestr.go`: `computeModuleDiff` case
  `sqm` + `invertDesired` case.
- `agent/executor/executor.go` (+ test): `reSection` now accepts digits so
  real UCI interface sections (`eth1`, `wlan0`, `br-lan`) validate. This
  extends the allowlist for all modules and requires an agent redeploy.
- `app/src/pages/Orchestration.tsx` + `app/public/locales/{es,en}`:
  QoS/SQM pill with form (interface, download, upload, qdisc, script,
  link layer, overhead) and i18n keys.

## Verification

- `go test -race` green (orchestr + httpapi + executor), `go vet` clean,
  `tsc --noEmit` + `vite build` clean.
- Deployed to CT 226 (server) and all 4 routers (agent `2.10.0-qos`,
  surgical scp + restart). Verified with Playwright against production
  (9/9): QoS pill, form fields, plan generation on the gateway with no
  errors.
- Dry-runs confirmed against real routers: `422 gateway_only` on a
  non-gateway without the flag; with `allowNonGateway` a 12-op plan
  reusing the existing `sqm.eth1` section + `apk_install sqm-scripts`.
  No apply performed (needs user confirmation).
