### PR TITLE
fix(topology): Ethernet/Wi-Fi + IP on one row in chip tooltip (#149)

### DIFF
--- a/app/src/components/topology/TopologyMap.tsx
+++ b/app/src/components/topology/TopologyMap.tsx
@@ -292,10 +292,15 @@ function ChipTooltip({
         {d.manufacturer} · {d.mac}
       </div>
       <div className="mt-2 space-y-1.5">
-        {/* IP a ancho completo: no se trunca (issue #149) */}
+        {/* Conexión + IP en una horizontal; la IP no se trunca (issue #149) */}
         <div className="flex items-center justify-between gap-2 rounded-lg bg-canvas/60 px-2 py-1.5">
-          <span className="text-caption uppercase tracking-[0.06em] text-text-muted">IP</span>
-          <span className="font-mono text-mono-sm text-text-primary">{d.ip || '—'}</span>
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="font-mono text-mono-sm font-semibold text-text-primary">
+              {chip.wired ? 'Ethernet' : 'Wi-Fi'}
+            </span>
+            <span className="shrink-0 text-caption uppercase tracking-[0.06em] text-text-muted">IP</span>
+          </span>
+          <span className="truncate font-mono text-mono-sm text-text-primary">{d.ip || '—'}</span>
         </div>
         <div className="grid grid-cols-2 gap-1.5">
           <MiniStat
@@ -304,7 +309,6 @@ function ChipTooltip({
             hot={!chip.wired && chip.weak}
           />
           <MiniStat label={t('topology.traffic')} value={`${d.trafficMbps} Mbps`} />
-          <MiniStat label={t('topology.connection')} value={chip.wired ? 'Ethernet' : 'Wi-Fi'} />
         </div>
       </div>
       {d.lldp && (


### PR DESCRIPTION
Follow-up to #149 per author feedback: the connection label (Ethernet/Wi-Fi) and the IP now share a single horizontal row (label left, full IP right, never truncated); port/signal and traffic are the two cards underneath. Removes the separate connection card.

Verified in production (CT 226): row renders 'Ethernet' + full IP (192.168.1.114), grid below has exactly 2 cards (Port, Traffic). Build green.