### PR TITLE
Use plain hyphen in browser tab title

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -17,7 +17,7 @@
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
-    <title>NetPulse — Tu red, de un vistazo</title>
+    <title>NetPulse - Tu red, de un vistazo</title>
     <style>
       /* Splash oscuro mientras carga el bundle (PWA) */
       #root:empty {


### PR DESCRIPTION
Replace the em dash with a plain hyphen in the browser tab title (#165).