### PR TITLE
release: v2.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 ## [Unreleased]
 
+## [2.9.3] - 2026-08-12
+
+### Fixed
+
+- **Resumen WAN en modo live**: "Pico hoy", "Media" y "Total 24h" se
+  calculaban solo en el modo demo; en live quedaban siempre a 0 / "—".
+  Ahora se calculan desde las métricas almacenadas del gateway (pico del
+  día con su hora, media de bajada 24h y volumen total 24h). #169
+
 ## [2.9.1] - 2026-08-11
 
 ### Added

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.9.1",
+  "version": "2.9.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Version es la versión del backend (app.js:18).
-const Version = "2.9.1"
+const Version = "2.9.3"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Release v2.9.3: compute peak today, avg and 24h total WAN stats from stored metrics in live mode (#169).