### PR TITLE
fix(home): static span classes so service cards don't break mobile grid

### DIFF
--- a/app/src/pages/Home.tsx
+++ b/app/src/pages/Home.tsx
@@ -17,6 +17,11 @@ export default function Home() {
     <RecentAlerts key="alerts" />,
   ].filter(Boolean)
   const span = Math.max(4, Math.floor(12 / cards.length))
+  const spanCls = {
+    4: 'lg:col-span-4',
+    6: 'lg:col-span-6',
+    12: 'lg:col-span-12',
+  }[span]
   return (
     <div className="grid grid-cols-1 gap-4 md:gap-5 lg:grid-cols-12">
       {/* ① Hero 50% + Tráfico 50% */}
@@ -28,7 +33,7 @@ export default function Home() {
       </div>
       {/* ② Servicios marcados en Ajustes + Alertas en una fila */}
       {cards.map((card, i) => (
-        <div key={i} className={`lg:col-span-${span} lg:col-span-4 xl:col-span-${span}`} style={{ gridColumn: `span ${span} / span ${span}` }}>
+        <div key={i} className={spanCls}>
           {card}
         </div>
       ))}


### PR DESCRIPTION
Fixes the mobile layout on the Home page where service cards forced implicit grid columns, leaving the hero strip and traffic card on the same horizontal row.

**Root cause:** `app/src/pages/Home.tsx` applied an inline `gridColumn: span N / span N` at every breakpoint. On mobile the grid defines a single column (`grid-cols-1`), so the forced span made the browser create implicit columns and lay the hero/traffic cards out side by side (hero collapsed to width 0). The `lg:col-span-${span}` classes were dynamic, so Tailwind JIT never generated them — which is presumably why the inline style was introduced in the first place.

**Fix:** drop the inline style and use a static class lookup keyed off the computed span (always 4/6/12 for 3/2/1 visible cards), keeping the classes statically detectable by Tailwind.

**Verification:** Playwright at 390px shows a single column with all cards stacked; 1440px keeps the 12-col layout. Deployed to the CT and the live demo.

Ref #173