### PR TITLE
fix(api): accept external ingest as benign no-op in demo mode

### DIFF
--- a/server-go/internal/httpapi/agent.go
+++ b/server-go/internal/httpapi/agent.go
@@ -216,6 +216,13 @@ func (s *server) handleIngestAgent(w http.ResponseWriter, r *http.Request) {
 			"el servidor no tiene registry de agentes")
 		return
 	}
+	// En modo demo los scrapers/colectores externos siguen empujando (issue
+	// #168): se acepta como no-op (202) sin tocar el registry ni la BD. La
+	// demo sirve un dataset canónico en memoria; los datos reales no existen.
+	if s.cfg != nil && s.cfg.DemoMode {
+		writeJSON(w, http.StatusAccepted, map[string]any{"ok": true, "demo": true})
+		return
+	}
 	s.agents.Ingest(&p)
 	// Fase 8.2 (R8): persistir el último push en kv (agent.state.<slug>) para
 	// que lastSeen/versión/payload sobrevivan a un reinicio del servidor.

--- a/server-go/internal/httpapi/demoreadonly.go
+++ b/server-go/internal/httpapi/demoreadonly.go
@@ -17,12 +17,14 @@ import (
 //   - /api/refresh : no escribe en BD; el botón "Refrescar" sigue vivo
 //   - /api/push/* y /api/users/me/* : preferencias de usuario/UI (idioma,
 //     nombre, push), no tocan el dataset canónico
+//   - /api/ingest/agent : los colectores/scrapers externos siguen empujando;
+//     en demo el handler los acepta (202) como no-op sin escribir (issue #168)
 func demoAllowlist(path string) bool {
 	if strings.HasPrefix(path, "/api/auth/") {
 		return true
 	}
 	switch path {
-	case "/api/demo/enable", "/api/refresh":
+	case "/api/demo/enable", "/api/refresh", "/api/ingest/agent":
 		return true
 	}
 	if strings.HasPrefix(path, "/api/push/") || strings.HasPrefix(path, "/api/users/me/") {

--- a/server-go/internal/httpapi/demoreadonly_test.go
+++ b/server-go/internal/httpapi/demoreadonly_test.go
@@ -1,11 +1,22 @@
 package httpapi_test
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/adapters"
+	"github.com/gnacho/netpulse/server-go/internal/auth"
+	"github.com/gnacho/netpulse/server-go/internal/config"
+	"github.com/gnacho/netpulse/server-go/internal/db"
+	"github.com/gnacho/netpulse/server-go/internal/httpapi"
+	"github.com/gnacho/netpulse/server-go/internal/sse"
 )
 
 // demoReadOnly (issue #118): en modo demo las mutaciones fuera de la allowlist
@@ -76,5 +87,113 @@ func TestDemoReadOnly(t *testing.T) {
 	// GET sigue funcionando (solo lectura)
 	if status, _ := do("GET", "/api/topology/overrides", ""); status != http.StatusOK {
 		t.Errorf("GET overrides en demo: status %d, esperado 200", status)
+	}
+}
+
+// makeDemoAgentTestServer: server en modo demo CON registry de agentes, para
+// probar que la ingesta externa en demo es no-op benigna (issue #168).
+func makeDemoAgentTestServer(t *testing.T) *agentTestServer {
+	t.Helper()
+	auth.SetTrustProxy(true)
+	t.Cleanup(func() { auth.SetTrustProxy(false) })
+	dataDir := t.TempDir()
+	cfg, err := config.Load(map[string]string{
+		"AUTH_USER": "admin", "AUTH_PASS": "test1234",
+		"DEMO_MODE": "1", "DATA_DIR": dataDir, "NODE_ENV": "test",
+	}, dataDir)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	d, err := db.Open(dataDir)
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	secret, err := auth.EnsureSessionSecret(d, cfg)
+	if err != nil {
+		t.Fatalf("secret: %v", err)
+	}
+	if err := auth.EnsureUsers(d, cfg); err != nil {
+		t.Fatalf("users: %v", err)
+	}
+	reg := adapters.NewAgentRegistry(90 * time.Second)
+	hub := sse.NewHub(d, cfg.MaxSSEClients, func() any { return nil })
+	handler := httpapi.NewHandler(httpapi.Deps{
+		Config: cfg, DB: d, Adapter: adapters.NewDemo(), Hub: hub, Secret: secret,
+		Agents: reg, Started: time.Now(),
+	})
+	srv := httptest.NewServer(handler)
+	status, cookie, _ := loginCookie(t, srv.URL, "admin", "test1234")
+	if status != 204 {
+		t.Fatalf("login: %d", status)
+	}
+	ts := &agentTestServer{Server: srv, db: d, agents: reg, cookie: cookie}
+	t.Cleanup(func() {
+		srv.Close()
+		d.Close()
+	})
+	return ts
+}
+
+// TestIngestAgentNoOpEnDemo (issue #168): en modo demo la ingesta externa de
+// scrapers/colectores se acepta (202 + demo:true) como no-op, sin tocar el
+// registry ni la BD. La validación (token + HMAC + anti-replay) se mantiene.
+func TestIngestAgentNoOpEnDemo(t *testing.T) {
+	ts := makeDemoAgentTestServer(t)
+	// En demo no se pueden crear tokens por API (409 demo_read_only), igual
+	// que en producción: el scraper ya tenía su token ANTES de entrar en demo.
+	// Lo insertamos directo en kv (sha256), simulando ese flujo real.
+	token := "feedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface"
+	sum := sha256.Sum256([]byte(token))
+	if _, err := ts.db.Exec("INSERT INTO kv (key, value) VALUES ('agent.token.patio', ?)",
+		hex.EncodeToString(sum[:])); err != nil {
+		t.Fatalf("sembrar token: %v", err)
+	}
+
+	// Ingesta válida en demo → 202 con demo:true (no-op benigno)
+	res := ingest(t, ts, token, "10.0.0.1", validPayload())
+	body := readJSON(t, res)
+	if res.StatusCode != http.StatusAccepted {
+		t.Fatalf("ingest demo: status %d, esperado 202 (body=%v)", res.StatusCode, body)
+	}
+	if body["ok"] != true || body["demo"] != true {
+		t.Fatalf("body esperado {ok:true, demo:true}, got %v", body)
+	}
+
+	// No-op: el registry NO debe haber ingerido el payload
+	if _, _, ok := ts.agents.Info("patio"); ok {
+		t.Fatal("en demo el registry NO debe actualizarse")
+	}
+	// No-op: tampoco debe persistirse el estado del agente en kv
+	var stored string
+	if err := ts.db.QueryRow("SELECT value FROM kv WHERE key = 'agent.state.patio'").Scan(&stored); err == nil {
+		t.Fatalf("no debería persistirse estado de agente en demo (kv=%q)", stored)
+	}
+
+	// La validación sigue viva: token inválido → 401 (no un falso 202)
+	res = ingest(t, ts, "deadbeef", "10.0.0.2", validPayload())
+	body = readJSON(t, res)
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("token inválido en demo: status %d, esperado 401", res.StatusCode)
+	}
+	if body["error"] != "unauthorized" {
+		t.Fatalf("error=%v, esperado unauthorized", body["error"])
+	}
+	// Firma HMAC incorrecta (token correcto, sig errónea) → 401 invalid_signature
+	payload := validPayload()
+	req, _ := http.NewRequest("POST", ts.URL+"/api/ingest/agent", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-For", "10.0.0.3")
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("X-Agent-Signature", strings.Repeat("0", 64))
+	res2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("ingest sig: %v", err)
+	}
+	body = readJSON(t, res2)
+	if res2.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("HMAC inválido en demo: status %d, esperado 401", res2.StatusCode)
+	}
+	if body["error"] != "invalid_signature" {
+		t.Fatalf("error=%v, esperado invalid_signature", body["error"])
 	}
 }


### PR DESCRIPTION
When demo mode is on, external scrapers/collectors (e.g. a LAN switch scraper on a systemd timer posting to `/api/ingest/agent`) kept getting `409 demo_read_only`, so they reported failures and polluted logs for an expected state.

**Fix:** accept the ingest as a benign no-op in demo mode:
- `/api/ingest/agent` is added to the demo read-only allowlist so the guard no longer rejects it.
- `handleIngestAgent` returns `202 {"ok":true,"demo":true}` after full validation, without touching the agent registry or persisting state to the DB.
- Security validation stays intact: invalid token → 401 `unauthorized`, broken HMAC → 401 `invalid_signature`.

**Tests:** new `TestIngestAgentNoOpEnDemo` covers the 202 + `demo:true` body, that the registry and `agent.state.*` kv stay untouched, and that token/HMAC validation still rejects in demo. Full `go test -race ./internal/...` green.

Closes #168