### PR TITLE
release: v2.9.5 — ingesta benigna en demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 ## [Unreleased]
 
+## [2.9.5] - 2026-08-13
+
+### Fixed
+
+- **Ingesta externa en modo demo**: los colectores/scrapers externos (p. ej.
+  un scraper de switch vía timer) recibían `409 demo_read_only` al empujar
+  datos en modo demo y reportaban fallos de un estado esperado. Ahora la
+  ingesta se acepta como no-op benigno (`202` + `demo:true`) sin tocar la BD,
+  manteniendo la validación de token y firma HMAC. #168
+
 ## [2.9.4] - 2026-08-13
 
 ### Fixed

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.9.4",
+  "version": "2.9.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Version es la versión del backend (app.js:18).
-const Version = "2.9.4"
+const Version = "2.9.5"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Release v2.9.5 with the demo-mode ingest fix (#176).