### PR TITLE
feat(settings): store contracted WAN link speed and show utilization

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -272,7 +272,10 @@
       "time": "Time",
       "title": "Network traffic",
       "total24h": "Total 24h",
-      "uploadMbps": "Upload (Mbps)"
+      "uploadMbps": "Upload (Mbps)",
+      "contracted": "Contracted: ↓ {{down}} / ↑ {{up}} Mbps",
+      "contractedLine": "↓ {{mbps}} Mbps",
+      "utilization": "Today's peak: {{pct}} % of contracted"
     },
     "upload": "Upload",
     "greetingName": ", {{name}}"
@@ -876,24 +879,24 @@
     },
     "labs": {
       "title": "Labs",
-      "caption": "External devices that push data via API (scrapers, non-OpenWrt switches\u2026). Not polled via SSH.",
+      "caption": "External devices that push data via API (scrapers, non-OpenWrt switches…). Not polled via SSH.",
       "empty": "No external devices yet. Add your first device.",
       "addDevice": "Add external device",
       "namePlaceholder": "Name (becomes the device slug)",
       "cancel": "Cancel",
-      "loading": "Loading devices\u2026",
+      "loading": "Loading devices…",
       "lastSeen": "Seen",
       "justNow": "now",
       "fresh": "Connected",
       "rotateToken": "Regenerate token",
       "noToken": "Create token",
       "tokenFor": "Token for {{slug}}",
-      "tokenOnce": "Copy the token now. It won\u2019t be shown again.",
+      "tokenOnce": "Copy the token now. It won’t be shown again.",
       "copyToken": "Copy token",
-      "ingestHint": "Use this token to authenticate the scraper\u2019s ingest:",
+      "ingestHint": "Use this token to authenticate the scraper’s ingest:",
       "dismiss": "Dismiss",
       "deleteTitle": "Revoke device token",
-      "deleteDesc": "The token for \u201c{{slug}}\u201d will be revoked. The scraper will stop sending data until you regenerate the token."
+      "deleteDesc": "The token for “{{slug}}” will be revoked. The scraper will stop sending data until you regenerate the token."
     },
     "saved": "Preferences saved",
     "services": {
@@ -954,6 +957,18 @@
       "cancel": "Cancel",
       "newPassword": "New password (min. 6)",
       "savePassword": "Save"
+    },
+    "wanSpeed": {
+      "title": "Contracted WAN link speed",
+      "caption": "Compare measured traffic against your plan",
+      "down": "Download (Mbps)",
+      "up": "Upload (Mbps)",
+      "hint": "Declared by you; not auto-detected. Used to mark capacity on the traffic chart and compute utilization.",
+      "save": "Save",
+      "saving": "Saving…",
+      "saved": "Saved",
+      "invalid": "Enter speeds greater than 0 and at most 100000 Mbps",
+      "saveError": "Could not save the speed"
     }
   },
   "statcard": {

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -272,7 +272,10 @@
       "time": "Hora",
       "title": "Tráfico de red",
       "total24h": "Total 24h",
-      "uploadMbps": "Subida (Mbps)"
+      "uploadMbps": "Subida (Mbps)",
+      "contracted": "Contratado: ↓ {{down}} / ↑ {{up}} Mbps",
+      "contractedLine": "↓ {{mbps}} Mbps",
+      "utilization": "Pico hoy: {{pct}} % del contratado"
     },
     "upload": "Subida",
     "greetingName": ", {{name}}"
@@ -876,24 +879,24 @@
     },
     "labs": {
       "title": "Labs",
-      "caption": "Dispositivos externos que envían datos vía API (scrapers, switches no OpenWrt\u2026). No se sondean por SSH.",
+      "caption": "Dispositivos externos que envían datos vía API (scrapers, switches no OpenWrt…). No se sondean por SSH.",
       "empty": "Sin dispositivos externos. Añade tu primer dispositivo.",
       "addDevice": "Añadir dispositivo externo",
-      "namePlaceholder": "Nombre (ser\u00e1 el slug del dispositivo)",
+      "namePlaceholder": "Nombre (será el slug del dispositivo)",
       "cancel": "Cancelar",
-      "loading": "Cargando dispositivos\u2026",
+      "loading": "Cargando dispositivos…",
       "lastSeen": "Visto",
       "justNow": "ahora",
       "fresh": "Conectado",
       "rotateToken": "Regenerar token",
       "noToken": "Crear token",
       "tokenFor": "Token para {{slug}}",
-      "tokenOnce": "Copia el token ahora. No se volver\u00e1 a mostrar.",
+      "tokenOnce": "Copia el token ahora. No se volverá a mostrar.",
       "copyToken": "Copiar token",
       "ingestHint": "Usa este token para autenticar la ingesta del scraper:",
       "dismiss": "Cerrar",
       "deleteTitle": "Revocar token del dispositivo",
-      "deleteDesc": "Se revocar\u00e1 el token de \"{{slug}}\". El scraper dejar\u00e1 de poder enviar datos hasta que regeneres el token."
+      "deleteDesc": "Se revocará el token de \"{{slug}}\". El scraper dejará de poder enviar datos hasta que regeneres el token."
     },
     "saved": "Preferencias guardadas",
     "services": {
@@ -954,6 +957,18 @@
       "cancel": "Cancelar",
       "newPassword": "Nueva contraseña (mín. 6)",
       "savePassword": "Guardar"
+    },
+    "wanSpeed": {
+      "title": "Velocidad WAN contratada",
+      "caption": "Para comparar el tráfico medido con tu plan",
+      "down": "Descarga (Mbps)",
+      "up": "Subida (Mbps)",
+      "hint": "Declarada por ti; no se detecta automáticamente. Se usa para marcar la capacidad en el gráfico de tráfico y calcular la utilización.",
+      "save": "Guardar",
+      "saving": "Guardando…",
+      "saved": "Guardada",
+      "invalid": "Introduce velocidades mayores que 0 y como máximo 100000 Mbps",
+      "saveError": "No se pudo guardar la velocidad"
     }
   },
   "statcard": {

--- a/app/src/data/types.ts
+++ b/app/src/data/types.ts
@@ -64,6 +64,9 @@ export interface WanInfo {
   peakTodayTime: string
   avgDownMbps: number
   total24h: string
+  /** Velocidad contratada declarada por el admin (Mbps, issue #151). Ausente si no configurada. */
+  contractDownMbps?: number
+  contractUpMbps?: number
 }
 
 export interface TrafficPoint {

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -1508,6 +1508,138 @@ function BackupsPanel() {
 }
 
 // ---------------------------------------------------------------------------
+// Velocidad WAN contratada (issue #151) — declarada por el admin en kv y
+// persistida vía GET/PUT /api/settings/wanspeed. Se muestra como sub-sección
+// de la tarjeta «Datos y umbrales» (mismo ámbito: métricas WAN).
+// ---------------------------------------------------------------------------
+
+function WanSpeedCard({ onSaved, disabled = false }: { onSaved: () => void; disabled?: boolean }) {
+  const { t } = useTranslation()
+  const { refresh: refreshOverview } = useNetPulse()
+  const [down, setDown] = useState('')
+  const [up, setUp] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+  const loaded = useRef(false)
+
+  // Carga el valor persistido una sola vez al montar (no se pisa al guardar).
+  useEffect(() => {
+    let alive = true
+    void fetch('/api/settings/wanspeed')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (!alive || !d || loaded.current) return
+        loaded.current = true
+        if (typeof d.downMbps === 'number') setDown(String(d.downMbps))
+        if (typeof d.upMbps === 'number') setUp(String(d.upMbps))
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        if (alive) setLoading(false)
+      })
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  const invalid = (v: string) => {
+    const n = Number(v)
+    return !Number.isFinite(n) || n <= 0 || n > 100000
+  }
+
+  const save = useCallback(async () => {
+    if (invalid(down) || invalid(up)) {
+      setError(t('settings.wanSpeed.invalid'))
+      return
+    }
+    setError(null)
+    setBusy(true)
+    try {
+      const res = await fetch('/api/settings/wanspeed', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ downMbps: Number(down), upMbps: Number(up) }),
+      })
+      if (!res.ok) {
+        setError(t('settings.wanSpeed.saveError'))
+        return
+      }
+      loaded.current = true
+      setSaved(true)
+      window.setTimeout(() => setSaved(false), 2000)
+      refreshOverview() // la capacidad contratada del gráfico WAN se actualiza en vivo
+      onSaved()
+    } finally {
+      setBusy(false)
+    }
+  }, [down, up, onSaved, refreshOverview, t])
+
+  return (
+    <div className="mt-4 space-y-3 border-t border-border pt-4">
+      <div>
+        <div className="text-sm font-medium text-text-primary">{t('settings.wanSpeed.title')}</div>
+        <div className="text-caption text-text-muted">{t('settings.wanSpeed.caption')}</div>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <label className="block">
+          <span className="text-label uppercase text-text-muted">{t('settings.wanSpeed.down')}</span>
+          <input
+            type="number"
+            inputMode="decimal"
+            min="0.1"
+            max="100000"
+            step="any"
+            value={down}
+            onChange={(e) => setDown(e.target.value)}
+            disabled={disabled || loading}
+            aria-label={t('settings.wanSpeed.down')}
+            className="mt-1 w-full rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+          />
+        </label>
+        <label className="block">
+          <span className="text-label uppercase text-text-muted">{t('settings.wanSpeed.up')}</span>
+          <input
+            type="number"
+            inputMode="decimal"
+            min="0.1"
+            max="100000"
+            step="any"
+            value={up}
+            onChange={(e) => setUp(e.target.value)}
+            disabled={disabled || loading}
+            aria-label={t('settings.wanSpeed.up')}
+            className="mt-1 w-full rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+          />
+        </label>
+      </div>
+      <p className="text-caption text-text-muted">{t('settings.wanSpeed.hint')}</p>
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => void save()}
+          disabled={disabled || busy || loading}
+          className="inline-flex h-9 shrink-0 cursor-pointer items-center gap-1.5 rounded-xl border border-accent bg-accent-soft px-3 text-[13px] font-medium text-accent transition-colors hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {busy ? t('settings.wanSpeed.saving') : t('settings.wanSpeed.save')}
+        </button>
+        {saved && (
+          <span role="status" className="text-caption text-ok">
+            {t('settings.wanSpeed.saved')}
+          </span>
+        )}
+        {error && (
+          <span role="alert" className="text-caption text-danger">
+            {error}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Página Ajustes `/settings` (settings.md)
 // ---------------------------------------------------------------------------
 
@@ -3042,6 +3174,9 @@ export default function Settings() {
                 </div>
               ))}
             </div>
+
+            {/* Velocidad WAN contratada (issue #151) — sub-sección del mismo ámbito */}
+            <WanSpeedCard onSaved={notify} disabled={isDemo} />
           </Card>
         </div>
 

--- a/app/src/sections/WanTraffic.tsx
+++ b/app/src/sections/WanTraffic.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis } from 'recharts'
+import { Area, AreaChart, CartesianGrid, ReferenceLine, ResponsiveContainer, Tooltip, XAxis } from 'recharts'
 import { motion } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
 import type { TimeRange, TrafficPoint } from '@/data/mock'
@@ -63,7 +63,6 @@ export function WanTraffic() {
     { label: t('home.traffic.total24h'), value: wan.total24h },
     { label: t('home.traffic.loss'), value: `${wan.lossPct} %` },
   ] as const
-
   // Carga de datos por rango (crossfade vía key en el chart)
   useEffect(() => {
     setLiveData(trafficByRange[range])
@@ -139,6 +138,21 @@ export function WanTraffic() {
               minTickGap={40}
             />
             <Tooltip content={<TrafficTooltip />} cursor={{ stroke: 'rgb(var(--border-strong))', strokeWidth: 1 }} />
+            {wan.contractDownMbps ? (
+              <ReferenceLine
+                y={wan.contractDownMbps}
+                stroke="#FBBF24"
+                strokeDasharray="4 4"
+                strokeOpacity={0.7}
+                label={{
+                  value: t('home.traffic.contractedLine', { mbps: fmtEs(wan.contractDownMbps, 0) }),
+                  position: 'insideTopRight',
+                  fill: '#FBBF24',
+                  fontSize: 9,
+                  fontFamily: '"JetBrains Mono", monospace',
+                }}
+              />
+            ) : null}
             <Area
               type="monotone"
               dataKey="down"
@@ -193,6 +207,21 @@ export function WanTraffic() {
           </motion.div>
         ))}
       </div>
+
+      {/* Utilización vs velocidad contratada (issue #151). Solo se muestra
+          cuando el admin ha declarado la velocidad en Ajustes. */}
+      {wan.contractDownMbps ? (
+        <p className="mt-3 border-t border-border pt-3 text-caption text-text-muted">
+          {t('home.traffic.contracted', {
+            down: fmtEs(wan.contractDownMbps, 0),
+            up: fmtEs(wan.contractUpMbps ?? 0, 0),
+          })}
+          {' · '}
+          {t('home.traffic.utilization', {
+            pct: fmtEs(wan.peakTodayMbps > 0 ? (wan.peakTodayMbps / wan.contractDownMbps) * 100 : 0, 1),
+          })}
+        </p>
+      ) : null}
     </section>
   )
 }

--- a/server-go/internal/adapters/types.go
+++ b/server-go/internal/adapters/types.go
@@ -49,6 +49,12 @@ type WAN struct {
 	PeakTodayTime string  `json:"peakTodayTime"`
 	AvgDownMbps   float64 `json:"avgDownMbps"`
 	Total24h      string  `json:"total24h"`
+	// ContractDownMbps/ContractUpMbps: velocidad contratada declarada por el
+	// admin en Ajustes (issue #151). Punteros: ausentes (null) si no está
+	// configurado. Los inyecta el server en handleOverview desde el kv — el
+	// adapter no los conoce.
+	ContractDownMbps *float64 `json:"contractDownMbps,omitempty"`
+	ContractUpMbps   *float64 `json:"contractUpMbps,omitempty"`
 }
 
 // TrafficPoint es un punto {t, down, up} de las series de tráfico WAN.

--- a/server-go/internal/httpapi/data.go
+++ b/server-go/internal/httpapi/data.go
@@ -117,6 +117,14 @@ func (s *server) handleOverview(w http.ResponseWriter, r *http.Request) {
 	// Menú de orquestación: opt-in por admin (#121). Se expone aquí (no en el
 	// adapter) porque el kv vive en el server, no en el poller.
 	out.Orchestration = kvGetBool(s.db.DB, orchestrationKey)
+	// Velocidad WAN contratada (#151): declarada por el admin en Ajustes y
+	// persistida en kv. Se inyecta aquí por el mismo motivo que orchestration.
+	if v, ok := kvGetFloat(s.db.DB, wanSpeedDownKey); ok {
+		out.WAN.ContractDownMbps = &v
+	}
+	if v, ok := kvGetFloat(s.db.DB, wanSpeedUpKey); ok {
+		out.WAN.ContractUpMbps = &v
+	}
 	writeJSON(w, http.StatusOK, &out)
 }
 

--- a/server-go/internal/httpapi/settings.go
+++ b/server-go/internal/httpapi/settings.go
@@ -1,18 +1,30 @@
 // settings.go — ajustes globales persistidos en kv (issue #121).
 //
-// Por ahora solo el flag de orquestación: el menú de orquestación (escritura
-// en routers) está oculto por defecto y se muestra solo si el admin lo activa.
+// Por ahora el flag de orquestación y la velocidad WAN contratada (issue
+// #151): el menú de orquestación (escritura en routers) está oculto por
+// defecto y se muestra solo si el admin lo activa.
 package httpapi
 
 import (
 	"database/sql"
 	"net/http"
+	"strconv"
 
 	"github.com/gnacho/netpulse/server-go/internal/auth"
 )
 
 // orchestrationKey es la clave kv que activa el menú de orquestación (#121).
 const orchestrationKey = "settings.orchestration_enabled"
+
+// Claves kv de la velocidad WAN contratada (#151).
+const (
+	wanSpeedDownKey = "settings.wan.speed_down"
+	wanSpeedUpKey   = "settings.wan.speed_up"
+)
+
+// maxContractMbps es el techo de sanidad de la velocidad contratada (1 Gbps
+// simétrico → 100000 Mbps; por encima es casi seguro un error de entrada).
+const maxContractMbps = 100000.0
 
 // kvGetBool lee un flag "1"/"0" del kv. Ausente o inválido → false.
 func kvGetBool(db *sql.DB, key string) bool {
@@ -31,7 +43,42 @@ func kvSetBool(db *sql.DB, key string, val bool) error {
 	return err
 }
 
-// registerSettingsRoutes: GET/PUT /api/settings/orchestration (admin).
+// kvGetFloat lee un número del kv. Devuelve (valor, false) si la clave está
+// ausente o no es un número válido (→ "no configurado").
+func kvGetFloat(db *sql.DB, key string) (float64, bool) {
+	raw := kvGet(db, key)
+	if raw == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil || v <= 0 {
+		return 0, false
+	}
+	return v, true
+}
+
+// kvSetFloat escribe un número en el kv (UPSERT).
+func kvSetFloat(db *sql.DB, key string, val float64) error {
+	_, err := db.Exec(
+		`INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+		key, strconv.FormatFloat(val, 'f', -1, 64))
+	return err
+}
+
+// wanSpeedResponse es la forma JSON de GET /api/settings/wanspeed. Los campos
+// son punteros: null cuando la velocidad no está configurada.
+type wanSpeedResponse struct {
+	DownMbps *float64 `json:"downMbps"`
+	UpMbps   *float64 `json:"upMbps"`
+}
+
+// validWanSpeed valida una velocidad contratada (> 0, ≤ maxContractMbps).
+func validWanSpeed(v float64) bool {
+	return v > 0 && v <= maxContractMbps
+}
+
+// registerSettingsRoutes: GET/PUT /api/settings/orchestration (admin) y
+// GET/PUT /api/settings/wanspeed (admin, #151).
 func (s *server) registerSettingsRoutes(mux *http.ServeMux) {
 	mux.Handle("GET /api/settings/orchestration", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]bool{"enabled": kvGetBool(s.db.DB, orchestrationKey)})
@@ -49,5 +96,43 @@ func (s *server) registerSettingsRoutes(mux *http.ServeMux) {
 			return
 		}
 		writeJSON(w, http.StatusOK, map[string]bool{"enabled": body.Enabled})
+	})))
+
+	// GET /api/settings/wanspeed — velocidad contratada declarada (#151).
+	mux.Handle("GET /api/settings/wanspeed", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res := wanSpeedResponse{}
+		if v, ok := kvGetFloat(s.db.DB, wanSpeedDownKey); ok {
+			res.DownMbps = &v
+		}
+		if v, ok := kvGetFloat(s.db.DB, wanSpeedUpKey); ok {
+			res.UpMbps = &v
+		}
+		writeJSON(w, http.StatusOK, res)
+	})))
+
+	// PUT /api/settings/wanspeed — guarda ambas velocidades (down y up).
+	mux.Handle("PUT /api/settings/wanspeed", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body wanSpeedResponse
+		if !readJSONBody(r, &body) {
+			writeError(w, http.StatusBadRequest, "invalid_body")
+			return
+		}
+		if body.DownMbps == nil || body.UpMbps == nil {
+			writeError(w, http.StatusBadRequest, "invalid_input", "downMbps and upMbps are required")
+			return
+		}
+		if !validWanSpeed(*body.DownMbps) || !validWanSpeed(*body.UpMbps) {
+			writeError(w, http.StatusBadRequest, "invalid_input", "velocidad contratada debe ser mayor que 0 y como máximo 100000 Mbps")
+			return
+		}
+		if err := kvSetFloat(s.db.DB, wanSpeedDownKey, *body.DownMbps); err != nil {
+			writeError(w, http.StatusInternalServerError, "kv_error")
+			return
+		}
+		if err := kvSetFloat(s.db.DB, wanSpeedUpKey, *body.UpMbps); err != nil {
+			writeError(w, http.StatusInternalServerError, "kv_error")
+			return
+		}
+		writeJSON(w, http.StatusOK, wanSpeedResponse{DownMbps: body.DownMbps, UpMbps: body.UpMbps})
 	})))
 }

--- a/server-go/internal/httpapi/settings_wanspeed_test.go
+++ b/server-go/internal/httpapi/settings_wanspeed_test.go
@@ -1,0 +1,124 @@
+// settings_wanspeed_test.go — contrato de GET/PUT /api/settings/wanspeed
+// (issue #151): velocidad WAN contratada declarada por el admin.
+package httpapi_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// wanSpeedRequest hace una petición con body JSON + cookie de sesión.
+func wanSpeedRequest(t *testing.T, method, base, path, cookie, body string) (*http.Response, map[string]any) {
+	t.Helper()
+	var req *http.Request
+	if body != "" {
+		req, _ = http.NewRequest(method, base+path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req, _ = http.NewRequest(method, base+path, nil)
+	}
+	if cookie != "" {
+		req.Header.Set("Cookie", "session="+cookie)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer res.Body.Close()
+	var parsed map[string]any
+	raw, _ := io.ReadAll(res.Body)
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &parsed)
+	}
+	return res, parsed
+}
+
+// TestWanSpeedDefaultEmpty: sin configurar, GET devuelve null en ambos campos.
+func TestWanSpeedDefaultEmpty(t *testing.T) {
+	srv := makeTestServer(t)
+	_, cookie, _ := loginCookie(t, srv.URL, "admin", "test1234")
+	if cookie == "" {
+		t.Fatal("login no devolvió cookie")
+	}
+	res, body := wanSpeedRequest(t, "GET", srv.URL, "/api/settings/wanspeed", cookie, "")
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("GET: status %d, esperado 200", res.StatusCode)
+	}
+	if body["downMbps"] != nil {
+		t.Errorf("downMbps=%v, esperado null", body["downMbps"])
+	}
+	if body["upMbps"] != nil {
+		t.Errorf("upMbps=%v, esperado null", body["upMbps"])
+	}
+}
+
+// TestWanSpeedRoundtrip: PUT válido guarda y GET lo devuelve.
+func TestWanSpeedRoundtrip(t *testing.T) {
+	srv := makeTestServer(t)
+	_, cookie, _ := loginCookie(t, srv.URL, "admin", "test1234")
+	if cookie == "" {
+		t.Fatal("login no devolvió cookie")
+	}
+	res, body := wanSpeedRequest(t, "PUT", srv.URL, "/api/settings/wanspeed", cookie, `{"downMbps":600,"upMbps":300}`)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("PUT: status %d, esperado 200 (%v)", res.StatusCode, body)
+	}
+	if body["downMbps"] != float64(600) || body["upMbps"] != float64(300) {
+		t.Errorf("PUT echo incorrecto: %v", body)
+	}
+	res, body = wanSpeedRequest(t, "GET", srv.URL, "/api/settings/wanspeed", cookie, "")
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("GET tras PUT: status %d, esperado 200", res.StatusCode)
+	}
+	if body["downMbps"] != float64(600) || body["upMbps"] != float64(300) {
+		t.Errorf("GET tras PUT: %v, esperado downMbps 600 / upMbps 300", body)
+	}
+}
+
+// TestWanSpeedInvalidInput: PUT inválido → 400 sin guardar nada.
+func TestWanSpeedInvalidInput(t *testing.T) {
+	srv := makeTestServer(t)
+	_, cookie, _ := loginCookie(t, srv.URL, "admin", "test1234")
+	if cookie == "" {
+		t.Fatal("login no devolvió cookie")
+	}
+	cases := []string{
+		`{"downMbps":0,"upMbps":300}`,      // down cero
+		`{"downMbps":-5,"upMbps":300}`,     // down negativo
+		`{"downMbps":600,"upMbps":0}`,      // up cero
+		`{"downMbps":100001,"upMbps":300}`, // down sobre el techo
+		`{"downMbps":600}`,                 // up ausente
+		`{"upMbps":300}`,                   // down ausente
+		`not-json`,                         // body roto
+	}
+	for _, body := range cases {
+		res, _ := wanSpeedRequest(t, "PUT", srv.URL, "/api/settings/wanspeed", cookie, body)
+		if res.StatusCode != http.StatusBadRequest {
+			t.Errorf("PUT %s: status %d, esperado 400", body, res.StatusCode)
+		}
+	}
+	// Nada se guardó
+	res, got := wanSpeedRequest(t, "GET", srv.URL, "/api/settings/wanspeed", cookie, "")
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("GET: status %d", res.StatusCode)
+	}
+	if got["downMbps"] != nil || got["upMbps"] != nil {
+		t.Errorf("el kv no debería haber cambiado tras PUTs inválidos: %v", got)
+	}
+}
+
+// TestWanSpeedRequiresAuth: sin sesión → 401.
+func TestWanSpeedRequiresAuth(t *testing.T) {
+	srv := makeTestServer(t)
+	res, _ := wanSpeedRequest(t, "GET", srv.URL, "/api/settings/wanspeed", "", "")
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Errorf("GET sin auth: status %d, esperado 401", res.StatusCode)
+	}
+	res, _ = wanSpeedRequest(t, "PUT", srv.URL, "/api/settings/wanspeed", "", `{"downMbps":600,"upMbps":300}`)
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Errorf("PUT sin auth: status %d, esperado 401", res.StatusCode)
+	}
+}


### PR DESCRIPTION
Lets the user declare the contracted WAN link speed (down/up in Mbps) in Settings, and shows it alongside measured traffic.

- **Backend**: `GET/PUT /api/settings/wanspeed` (admin), persisted in kv (`settings.wan.speed_down/up`), validated (0 < v ≤ 100000 Mbps → 400 otherwise). Injected into `/api/overview` as `wan.contractDownMbps`/`contractUpMbps` (optional, absent when unset).
- **Frontend**: "Velocidad WAN contratada" inputs in the Settings data card; in the WAN traffic chart a dashed reference line at the contracted download speed + a "Contratado ↓X/↑Y · Pico Z %" line when configured. Nothing changes when unset.
- **Tests**: GET empty → null, PUT roundtrip, 7 invalid cases → 400, no auth → 401.

Optional multi-WAN profiles (failover/load balancing) left for a future iteration.

Closes #151