### PR TITLE
fix(update): readiness git check ignores untracked runtime files

### DIFF
--- a/server-go/internal/updater/readiness.go
+++ b/server-go/internal/updater/readiness.go
@@ -103,12 +103,15 @@ func (u *Updater) checkDisk() CheckResult {
 }
 
 // checkGit verifica que el working tree está limpio (update.sh hace
-// git reset --hard: cualquier cambio sin commitear se perdería).
+// git reset --hard: cualquier cambio sin commitear se perdería). Se ignoran
+// los untracked (--untracked-files=no): artefactos runtime del servidor
+// (.env, data/, binarios, backups) viven fuera de git y un reset --hard no
+// los toca — de otro modo el apply quedaría bloqueado para siempre.
 func (u *Updater) checkGit() CheckResult {
 	if u.mode != "rolling" {
 		return CheckResult{OK: true, Detail: "no aplica (layout estable)"}
 	}
-	out, err := exec.Command("git", "-C", u.repoRoot, "status", "--porcelain").Output()
+	out, err := exec.Command("git", "-C", u.repoRoot, "status", "--porcelain", "--untracked-files=no").Output()
 	if err != nil {
 		return CheckResult{OK: false, Detail: "no se pudo leer el estado de git"}
 	}

--- a/server-go/internal/updater/updater_readiness_test.go
+++ b/server-go/internal/updater/updater_readiness_test.go
@@ -49,18 +49,43 @@ func TestReadinessGitDirty(t *testing.T) {
 	root := t.TempDir()
 	writeDeployScript(t, root)
 	writeGitHead(t, root)
-	// Ensuciar el working tree: el update hace git reset --hard y lo perdería.
+	// Un archivo untracked NO debe bloquear: los artefactos runtime del
+	// servidor (.env, data/, binarios, backups) viven fuera de git y un
+	// `git reset --hard` del update.sh no los toca. De lo contrario el
+	// apply quedaría bloqueado para siempre en un layout real.
 	if err := os.WriteFile(filepath.Join(root, "untracked.txt"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	withAPI(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
 	u := New(root, "owner/netpulse", "", "2.0.0", nil)
 	r := u.Readiness()
+	if !r.Git.OK {
+		t.Errorf("git NO debería fallar con solo untracked: %+v", r.Git)
+	}
+	if !r.Ready {
+		t.Error("ready debería ser true con solo untracked")
+	}
+}
+
+func TestReadinessGitTrackedModificado(t *testing.T) {
+	if !gitAvailable() {
+		t.Skip("git no disponible")
+	}
+	root := t.TempDir()
+	writeDeployScript(t, root)
+	writeGitHead(t, root)
+	// Un cambio en un archivo tracked SÍ se perdería con git reset --hard.
+	if err := os.WriteFile(filepath.Join(root, "f"), []byte("modificado"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	withAPI(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	u := New(root, "owner/netpulse", "", "2.0.0", nil)
+	r := u.Readiness()
 	if r.Git.OK {
-		t.Errorf("git debería fallar con cambios sin commitear: %+v", r.Git)
+		t.Errorf("git debería fallar con un tracked modificado: %+v", r.Git)
 	}
 	if r.Ready {
-		t.Error("ready debería ser false con git sucio")
+		t.Error("ready debería ser false con tracked modificado")
 	}
 }
 


### PR DESCRIPTION
The readiness `git` check used `git status --porcelain`, which includes untracked files. On a real server layout the repo always contains runtime artifacts outside git (`.env`, `data/`, binaries, backups), so the apply button would be permanently blocked.

`git reset --hard` (run by `update.sh`) does not touch untracked files, so only changes to tracked files matter. The check now uses `--untracked-files=no`, and the test is split: untracked files pass, a modified tracked file fails.