### PR TITLE
feat: track device offline/online events (#184)

### DIFF
--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gnacho/netpulse/server-go/internal/alerts"
 	"github.com/gnacho/netpulse/server-go/internal/config"
 	"github.com/gnacho/netpulse/server-go/internal/db"
+	"github.com/gnacho/netpulse/server-go/internal/deviceevents"
 )
 
 // fmtUptime: "<d>d <h>h" (index.js:32-36).
@@ -159,6 +160,13 @@ type Live struct {
 	wgActive       map[string]bool
 	weakAlerted    map[string]int64
 	onlineMacs     map[string]bool
+	// Presencia wireless (issue #184): devicePresence = MAC → online del
+	// último ciclo evaluado; presenceMisses = ticks seguidos sin verse.
+	// presenceSeen evita la avalancha del primer ciclo (anti-arranque).
+	presenceSeen        bool
+	devicePresence      map[string]bool
+	presenceMisses      map[string]int
+	presenceOfflineAfter int // ticks sin verse antes de declarar offline (default 3)
 	// dawnAvailable: cache de "¿hay DAWN en algún router?" para el flag del
 	// overview (entrada /roaming). Refrescado asíncronamente (TTL 30s, 1 SSH
 	// al gateway) por dawnAvailableCached para no bloquear buildOverview.
@@ -211,6 +219,9 @@ func NewLive(cfg *config.Config, d *db.DB, initial []RouterConfig, pool *SSHPool
 		wgActive:      map[string]bool{},
 		weakAlerted:   map[string]int64{},
 		onlineMacs:    map[string]bool{},
+		devicePresence: map[string]bool{},
+		presenceMisses: map[string]int{},
+		presenceOfflineAfter: 3,
 		wanDown:       map[string]int{},
 		backhaulCache: map[string]backhaulCacheEntry{},
 		lldpCache:     map[string]lldpCacheEntry{},
@@ -989,6 +1000,67 @@ func (l *Live) emitUnknownDevice(d Device) {
 	})
 }
 
+// trackDevicePresence emite device_offline/device_online cuando una MAC
+// wireless pasa de vista a no-vista (N ticks) o viceversa (issue #184).
+// Solo se rastrean MACs wireless (Band != "cable"): el FDB de cableados es
+// volátil y daría falsos offline. Anti-falsos positivos: un tick perdido no
+// dispara — hace falta `presenceOfflineAfter` ticks seguidos sin verse.
+// Anti-arranque: el primer ciclo solo puebla el estado (todo lo ya conectado
+// en boot no genera online). Toma l.mu.
+func (l *Live) trackDevicePresence(devices []Device, nowMs int64) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	seen := map[string]bool{}
+	for _, d := range devices {
+		if !d.Online || d.Band == "cable" {
+			continue
+		}
+		seen[d.MAC] = true
+		if l.presenceSeen && !l.devicePresence[d.MAC] {
+			l.insertDeviceEvent(d.MAC, d.RouterID, deviceevents.StateOnline, d.SignalDbm, nowMs)
+		}
+		l.devicePresence[d.MAC] = true
+		l.presenceMisses[d.MAC] = 0
+	}
+	for mac, wasOnline := range l.devicePresence {
+		if !wasOnline {
+			continue
+		}
+		if seen[mac] {
+			continue
+		}
+		l.presenceMisses[mac]++
+		if l.presenceMisses[mac] >= l.presenceOfflineAfter {
+			l.insertDeviceEvent(mac, l.lastRouterFor(mac), deviceevents.StateOffline, nil, nowMs)
+			l.devicePresence[mac] = false
+		}
+	}
+	l.presenceSeen = true
+}
+
+// insertDeviceEvent persiste una transición de presencia. Con db nil
+// (demo/tests sin BD) es no-op. Debe llamarse con l.mu tomado.
+func (l *Live) insertDeviceEvent(mac, routerID, state string, signalDbm *int, nowMs int64) {
+	if l.db == nil {
+		return
+	}
+	_ = deviceevents.Insert(l.db.DB, deviceevents.Event{
+		TsMs: nowMs, MAC: mac, RouterID: routerID, State: state,
+		SignalDbm: signalDbm,
+	})
+}
+
+// lastRouterFor devuelve el último router conocido de una MAC desde
+// device_attrib (o vacío si no hay registro). Debe llamarse con l.mu tomado.
+func (l *Live) lastRouterFor(mac string) string {
+	if l.db == nil {
+		return ""
+	}
+	var routerID string
+	_ = l.db.QueryRow("SELECT router_id FROM device_attrib WHERE mac = ?", mac).Scan(&routerID)
+	return routerID
+}
+
 // pollAdGuard: stats del cliente configurado; fallback inactivo si falla.
 func (l *Live) pollAdGuard(ctx context.Context) *AdGuardStats {
 	std, gl := l.getAdguardClient()
@@ -1417,6 +1489,7 @@ func (l *Live) buildOverview(ctx context.Context) (*Overview, error) {
 		}
 	}
 	l.trackUnknownDevices(devices)
+	l.trackDevicePresence(devices, time.Now().UnixMilli())
 	// Clientes reales por router (atribución wireless/FDB, no leases)
 	for i := range routerList {
 		n := 0

--- a/server-go/internal/adapters/presence_live_test.go
+++ b/server-go/internal/adapters/presence_live_test.go
@@ -1,0 +1,135 @@
+package adapters
+
+import (
+	"testing"
+)
+
+// testLivePresence: Live con DB real y estado de presencia inicializado.
+func testLivePresence(t *testing.T) *Live {
+	t.Helper()
+	d := openLiveTestDB(t)
+	return &Live{
+		db:                  d,
+		devicePresence:      map[string]bool{},
+		presenceMisses:      map[string]int{},
+		presenceOfflineAfter: 3,
+	}
+}
+
+func countDeviceEvents(t *testing.T, l *Live) int {
+	t.Helper()
+	var n int
+	if err := l.db.QueryRow("SELECT COUNT(*) FROM device_events").Scan(&n); err != nil {
+		t.Fatalf("count device_events: %v", err)
+	}
+	return n
+}
+
+// TestTrackDevicePresenceAntiStartup: el primer ciclo NO emite nada (solo
+// puebla el estado) — evita la avalancha de arranque.
+func TestTrackDevicePresenceAntiStartup(t *testing.T) {
+	l := testLivePresence(t)
+	d := Device{MAC: "AA:BB:CC:DD:EE:01", RouterID: "rt1", Online: true, Band: "5 GHz"}
+	sig := -45
+	d.SignalDbm = &sig
+
+	l.trackDevicePresence([]Device{d}, 1000)
+	if n := countDeviceEvents(t, l); n != 0 {
+		t.Fatalf("primer ciclo: %d eventos, esperaba 0", n)
+	}
+}
+
+// TestTrackDevicePresenceOfflineTransition: online → (3 ticks sin ver) →
+// offline emite EXACTAMENTE un evento; el tick perdido aislado NO emite.
+func TestTrackDevicePresenceOfflineTransition(t *testing.T) {
+	l := testLivePresence(t)
+	d := Device{MAC: "AA:BB:CC:DD:EE:01", RouterID: "rt1", Online: true, Band: "5 GHz"}
+	sig := -45
+	d.SignalDbm = &sig
+
+	// Ciclo 1 (siembra): no emite.
+	l.trackDevicePresence([]Device{d}, 1000)
+	// Ciclo 2 (online sigue): no emite.
+	l.trackDevicePresence([]Device{d}, 5000)
+	if n := countDeviceEvents(t, l); n != 0 {
+		t.Fatalf("2 ciclos online: %d eventos, esperaba 0", n)
+	}
+
+	// Un solo tick sin ver (poller lento): NO dispara offline.
+	l.trackDevicePresence([]Device{}, 9000)
+	if n := countDeviceEvents(t, l); n != 0 {
+		t.Fatalf("un tick perdido: %d eventos, esperaba 0", n)
+	}
+
+	// Vuelve a verse: el tick perdido no cuenta, sigue online sin eventos.
+	l.trackDevicePresence([]Device{d}, 13000)
+	if n := countDeviceEvents(t, l); n != 0 {
+		t.Fatalf("recuperación tras 1 tick: %d eventos, esperaba 0", n)
+	}
+
+	// 3 ticks seguidos sin ver → offline.
+	l.trackDevicePresence([]Device{}, 17000)
+	l.trackDevicePresence([]Device{}, 21000)
+	l.trackDevicePresence([]Device{}, 25000)
+	if n := countDeviceEvents(t, l); n != 1 {
+		t.Fatalf("tras 3 ticks sin ver: %d eventos, esperaba 1", n)
+	}
+}
+
+// TestTrackDevicePresenceOnlineAfterOffline: tras el offline, cuando la MAC
+// reaparece se emite device_online.
+func TestTrackDevicePresenceOnlineAfterOffline(t *testing.T) {
+	l := testLivePresence(t)
+	d := Device{MAC: "AA:BB:CC:DD:EE:01", RouterID: "rt1", Online: true, Band: "2.4 GHz"}
+	sig := -50
+	d.SignalDbm = &sig
+
+	l.trackDevicePresence([]Device{d}, 1000) // siembra
+	l.trackDevicePresence([]Device{}, 5000)
+	l.trackDevicePresence([]Device{}, 9000)
+	l.trackDevicePresence([]Device{}, 13000) // → offline
+	if n := countDeviceEvents(t, l); n != 1 {
+		t.Fatalf("offline: %d eventos, esperaba 1", n)
+	}
+
+	// Reaparece → online. Mismo ciclo de recuperación ya puede emitir online
+	// porque la transición es offline→online (devicePresence[mac]=false).
+	l.trackDevicePresence([]Device{d}, 17000)
+	if n := countDeviceEvents(t, l); n != 2 {
+		t.Fatalf("tras reaparecer: %d eventos, esperaba 2 (offline+online)", n)
+	}
+}
+
+// TestTrackDevicePresenceNoDoubleOffline: una MAC ya declarada offline no
+// re-emite offline en ciclos posteriores mientras siga sin verse.
+func TestTrackDevicePresenceNoDoubleOffline(t *testing.T) {
+	l := testLivePresence(t)
+	d := Device{MAC: "AA:BB:CC:DD:EE:01", RouterID: "rt1", Online: true, Band: "5 GHz"}
+	sig := -45
+	d.SignalDbm = &sig
+
+	l.trackDevicePresence([]Device{d}, 1000) // siembra
+	l.trackDevicePresence([]Device{}, 5000)
+	l.trackDevicePresence([]Device{}, 9000)
+	l.trackDevicePresence([]Device{}, 13000) // → offline (1)
+	l.trackDevicePresence([]Device{}, 17000) // sigue sin verse → NO re-emite
+	l.trackDevicePresence([]Device{}, 21000) // sigue sin verse → NO re-emite
+	if n := countDeviceEvents(t, l); n != 1 {
+		t.Fatalf("offline repetido: %d eventos, esperaba 1", n)
+	}
+}
+
+// TestTrackDevicePresenceCableSkip: los dispositivos cableados (FDB) no se
+// rastrean — su presencia no genera eventos de presencia.
+func TestTrackDevicePresenceCableSkip(t *testing.T) {
+	l := testLivePresence(t)
+	d := Device{MAC: "AA:BB:CC:DD:EE:02", RouterID: "rt1", Online: true, Band: "cable"}
+
+	l.trackDevicePresence([]Device{d}, 1000)
+	l.trackDevicePresence([]Device{}, 5000)
+	l.trackDevicePresence([]Device{}, 9000)
+	l.trackDevicePresence([]Device{}, 13000)
+	if n := countDeviceEvents(t, l); n != 0 {
+		t.Fatalf("cableado: %d eventos, esperaba 0", n)
+	}
+}

--- a/server-go/internal/db/db.go
+++ b/server-go/internal/db/db.go
@@ -173,6 +173,20 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_roam_events_dedup ON roam_events(content_h
 CREATE INDEX IF NOT EXISTS idx_roam_events_ts ON roam_events(ts_ms DESC);
 CREATE INDEX IF NOT EXISTS idx_roam_events_router_ts ON roam_events(router_id, ts_ms DESC);
 
+-- device_events: transiciones offline/online detectadas por el poller (issue #184).
+-- Generados por el adapter Live en el ciclo de buildDevices; consultables por API.
+CREATE TABLE IF NOT EXISTS device_events (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts_ms      INTEGER NOT NULL,
+  mac        TEXT NOT NULL,
+  router_id  TEXT,
+  state      TEXT NOT NULL,          -- 'offline' | 'online'
+  signal_dbm INTEGER,
+  detail     TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_device_events_ts ON device_events(ts_ms DESC);
+CREATE INDEX IF NOT EXISTS idx_device_events_mac_ts ON device_events(mac, ts_ms DESC);
+
 -- Overrides manuales de topología (issue #142, Fase A): capa 2 sobre el
 -- autodiscover. El builder los aplica DESPUÉS de inferTopology.
 --   kind 'hypervisor' (target MAC): el dispositivo es un hipervisor; los CTs
@@ -422,6 +436,12 @@ func (d *DB) NightlyJob() {
 	if res, err := d.Exec("DELETE FROM roam_events WHERE ts_ms < ?", cutoff); err == nil {
 		if n, _ := res.RowsAffected(); n > 0 {
 			log.Printf("[netpulse] roam_events: purgados %d eventos >30d", n)
+		}
+	}
+	// 7) device_events: misma retención 30 días (issue #184).
+	if res, err := d.Exec("DELETE FROM device_events WHERE ts_ms < ?", cutoff); err == nil {
+		if n, _ := res.RowsAffected(); n > 0 {
+			log.Printf("[netpulse] device_events: purgados %d eventos >30d", n)
 		}
 	}
 

--- a/server-go/internal/deviceevents/deviceevents.go
+++ b/server-go/internal/deviceevents/deviceevents.go
@@ -1,0 +1,75 @@
+// Package deviceevents — persistencia de transiciones offline/online de
+// dispositivos detectadas por el poller WiFi (issue #184).
+//
+// El adapter Live detecta cuándo una MAC wireless deja de verse (tras N ticks
+// de polling) y cuándo reaparece, y registra cada transición como un evento
+// consultable por la API (GET /api/device-events), espejo de roam_events.
+package deviceevents
+
+import "database/sql"
+
+// Estado del dispositivo en el evento.
+const (
+	StateOffline = "offline"
+	StateOnline  = "online"
+)
+
+// Event es una fila de device_events (transición de presencia).
+type Event struct {
+	ID        int64  `json:"id"`
+	TsMs      int64  `json:"ts_ms"`
+	MAC       string `json:"mac"`
+	RouterID  string `json:"router_id,omitempty"`
+	State     string `json:"state"`
+	SignalDbm *int   `json:"signal_dbm,omitempty"`
+	Detail    string `json:"detail,omitempty"`
+}
+
+// Insert registra una transición de presencia.
+func Insert(db *sql.DB, ev Event) error {
+	_, err := db.Exec(
+		`INSERT INTO device_events (ts_ms, mac, router_id, state, signal_dbm, detail)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		ev.TsMs, ev.MAC, ev.RouterID, ev.State, ev.SignalDbm, ev.Detail,
+	)
+	return err
+}
+
+// ListEvents lee eventos ordenados por ts DESC. Filtros opcionales: router,
+// mac y state. limit se acota a [1,1000] (default 100); sinceMs excluye
+// eventos anteriores.
+func ListEvents(db *sql.DB, limit int, sinceMs int64, routerID, mac, state string) ([]Event, error) {
+	if limit <= 0 || limit > 1000 {
+		limit = 100
+	}
+	q := "SELECT id, ts_ms, mac, COALESCE(router_id,''), state, signal_dbm, COALESCE(detail,'') FROM device_events WHERE ts_ms >= ?"
+	args := []any{sinceMs}
+	if routerID != "" {
+		q += " AND router_id = ?"
+		args = append(args, routerID)
+	}
+	if mac != "" {
+		q += " AND mac = ?"
+		args = append(args, mac)
+	}
+	if state != "" {
+		q += " AND state = ?"
+		args = append(args, state)
+	}
+	q += " ORDER BY ts_ms DESC LIMIT ?"
+	args = append(args, limit)
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []Event{}
+	for rows.Next() {
+		var ev Event
+		if err := rows.Scan(&ev.ID, &ev.TsMs, &ev.MAC, &ev.RouterID, &ev.State, &ev.SignalDbm, &ev.Detail); err != nil {
+			continue
+		}
+		out = append(out, ev)
+	}
+	return out, nil
+}

--- a/server-go/internal/deviceevents/deviceevents_test.go
+++ b/server-go/internal/deviceevents/deviceevents_test.go
@@ -1,0 +1,125 @@
+package deviceevents
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// openMemDB abre SQLite en memoria con el schema mínimo de device_events.
+// (db.Open arranca goroutines de mantenimiento que cuelgan el test runner.)
+func openMemDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	schema := `
+CREATE TABLE device_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts_ms INTEGER NOT NULL,
+  mac TEXT NOT NULL,
+  router_id TEXT,
+  state TEXT NOT NULL,
+  signal_dbm INTEGER,
+  detail TEXT
+);
+CREATE INDEX idx_device_events_ts ON device_events(ts_ms DESC);
+CREATE INDEX idx_device_events_mac_ts ON device_events(mac, ts_ms DESC);
+`
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatalf("schema: %v", err)
+	}
+	return db
+}
+
+// TestInsertAndList cubre insert + lectura con todos los filtros y orden DESC.
+func TestInsertAndList(t *testing.T) {
+	db := openMemDB(t)
+	events := []Event{
+		{TsMs: 1000, MAC: "AA:AA:AA:AA:AA:01", RouterID: "rt1", State: "offline", SignalDbm: nil, Detail: ""},
+		{TsMs: 2000, MAC: "AA:AA:AA:AA:AA:02", RouterID: "rt2", State: "online", SignalDbm: intPtr(-45), Detail: "resumed"},
+		{TsMs: 3000, MAC: "AA:AA:AA:AA:AA:01", RouterID: "rt1", State: "online", SignalDbm: intPtr(-50), Detail: "back"},
+	}
+	for _, ev := range events {
+		if err := Insert(db, ev); err != nil {
+			t.Fatalf("Insert(%+v): %v", ev, err)
+		}
+	}
+
+	// Sin filtro: 3 eventos, orden DESC por ts.
+	got, err := ListEvents(db, 100, 0, "", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("sin filtro: %d, want 3", len(got))
+	}
+	if got[0].TsMs != 3000 {
+		t.Errorf("primero debería ser ts=3000 (DESC), got %d", got[0].TsMs)
+	}
+	if got[0].State != "online" || got[0].MAC != "AA:AA:AA:AA:AA:01" {
+		t.Errorf("fila ts=3000 mal: %+v", got[0])
+	}
+
+	// Filtro mac.
+	got, err = ListEvents(db, 100, 0, "", "AA:AA:AA:AA:AA:01", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("filtro mac: %d, want 2", len(got))
+	}
+
+	// Filtro state.
+	got, err = ListEvents(db, 100, 0, "", "", "offline")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].State != "offline" {
+		t.Fatalf("filtro state: %+v, want 1 offline", got)
+	}
+
+	// Filtro router.
+	got, err = ListEvents(db, 100, 0, "rt2", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].RouterID != "rt2" {
+		t.Fatalf("filtro router: %+v, want 1 rt2", got)
+	}
+
+	// Filtro since.
+	got, err = ListEvents(db, 100, 2000, "", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("filtro since: %d, want 2", len(got))
+	}
+
+	// limit acota.
+	got, err = ListEvents(db, 1, 0, "", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("limit 1: %d, want 1", len(got))
+	}
+
+	// Sin datos → slice no-nil.
+	if _, err := db.Exec("DELETE FROM device_events"); err != nil {
+		t.Fatal(err)
+	}
+	got, err = ListEvents(db, 100, 0, "", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Errorf("ListEvents vacío debería devolver []Event{} no-nil, got nil")
+	}
+}
+
+func intPtr(v int) *int { return &v }

--- a/server-go/internal/httpapi/data.go
+++ b/server-go/internal/httpapi/data.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gnacho/netpulse/server-go/internal/adapters"
 	"github.com/gnacho/netpulse/server-go/internal/alerts"
+	"github.com/gnacho/netpulse/server-go/internal/deviceevents"
 	"github.com/gnacho/netpulse/server-go/internal/roamevents"
 )
 
@@ -367,6 +368,37 @@ func (s *server) handleRoamEvents(w http.ResponseWriter, r *http.Request) {
 	}
 	if events == nil {
 		events = []roamevents.Event{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"events": events})
+}
+
+// handleDeviceEvents: eventos offline/online de dispositivos detectados por
+// el poller (issue #184), espejo de /api/roam-events.
+// Query params: limit (default 100, máx 1000), since (epoch ms), router, mac,
+// state ('offline' | 'online').
+func (s *server) handleDeviceEvents(w http.ResponseWriter, r *http.Request) {
+	limit := 100
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			limit = n
+		}
+	}
+	var since int64
+	if v := r.URL.Query().Get("since"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			since = n
+		}
+	}
+	routerID := r.URL.Query().Get("router")
+	mac := r.URL.Query().Get("mac")
+	state := r.URL.Query().Get("state")
+	events, err := deviceevents.ListEvents(s.db.DB, limit, since, routerID, mac, state)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error")
+		return
+	}
+	if events == nil {
+		events = []deviceevents.Event{}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"events": events})
 }

--- a/server-go/internal/httpapi/device_events_test.go
+++ b/server-go/internal/httpapi/device_events_test.go
@@ -1,0 +1,94 @@
+// device_events_test.go — contrato del endpoint GET /api/device-events
+// (issue #184): eventos offline/online de dispositivos.
+package httpapi_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestDeviceEventsProtegido: sin sesión → 401; con sesión → 200 con lista.
+func TestDeviceEventsProtegido(t *testing.T) {
+	srv := makeTestServer(t)
+
+	res := get(t, srv.URL, "/api/device-events", "")
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("sin cookie: got %d want 401", res.StatusCode)
+	}
+	body := readJSON(t, res)
+	if body["error"] != "unauthorized" {
+		t.Fatalf("error: %v", body)
+	}
+
+	// Login y siembra de 2 eventos (la tabla la crea el schema al arrancar).
+	_, cookie, _ := loginCookie(t, srv.URL, "admin", "test1234")
+	if _, err := srv.db.Exec(
+		"INSERT INTO device_events (ts_ms, mac, router_id, state, signal_dbm) VALUES (?,?,?,?,?), (?,?,?,?,?)",
+		1000, "AA:BB:CC:DD:EE:01", "rt1", "offline", nil,
+		2000, "AA:BB:CC:DD:EE:01", "rt1", "online", -45,
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	res2 := get(t, srv.URL, "/api/device-events", cookie)
+	if res2.StatusCode != http.StatusOK {
+		t.Fatalf("con cookie: got %d want 200", res2.StatusCode)
+	}
+	body2 := readJSON(t, res2)
+	events, ok := body2["events"].([]any)
+	if !ok || len(events) != 2 {
+		t.Fatalf("events: %v", body2["events"])
+	}
+	// Orden DESC por ts_ms: primero online (2000).
+	first := events[0].(map[string]any)
+	if first["state"] != "online" || first["mac"] != "AA:BB:CC:DD:EE:01" {
+		t.Fatalf("primero: %v", first)
+	}
+}
+
+// TestDeviceEventsFiltros: mac y state filtran; limit acota; sin auth → 401.
+func TestDeviceEventsFiltros(t *testing.T) {
+	srv := makeTestServer(t)
+	if _, err := srv.db.Exec(
+		"INSERT INTO device_events (ts_ms, mac, router_id, state) VALUES (?,?,?,?), (?,?,?,?), (?,?,?,?)",
+		1000, "AA:BB:CC:DD:EE:01", "rt1", "offline",
+		2000, "AA:BB:CC:DD:EE:01", "rt1", "online",
+		3000, "AA:BB:CC:DD:EE:02", "rt2", "offline",
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, cookie, _ := loginCookie(t, srv.URL, "admin", "test1234")
+
+	// Filtro state=online → 1.
+	res := get(t, srv.URL, "/api/device-events?state=online", cookie)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("state filter: got %d want 200", res.StatusCode)
+	}
+	if events := readJSON(t, res)["events"].([]any); len(events) != 1 {
+		t.Fatalf("state=online: %d, want 1", len(events))
+	}
+
+	// Filtro mac → 2.
+	res = get(t, srv.URL, "/api/device-events?mac=AA:BB:CC:DD:EE:01", cookie)
+	if events := readJSON(t, res)["events"].([]any); len(events) != 2 {
+		t.Fatalf("mac filter: %d, want 2", len(events))
+	}
+
+	// Filtro router=rt2 → 1.
+	res = get(t, srv.URL, "/api/device-events?router=rt2", cookie)
+	if events := readJSON(t, res)["events"].([]any); len(events) != 1 {
+		t.Fatalf("router filter: %d, want 1", len(events))
+	}
+
+	// limit=1 → 1.
+	res = get(t, srv.URL, "/api/device-events?limit=1", cookie)
+	if events := readJSON(t, res)["events"].([]any); len(events) != 1 {
+		t.Fatalf("limit=1: %d, want 1", len(events))
+	}
+
+	// since=2000 → solo ts>=2000 (2 eventos).
+	res = get(t, srv.URL, "/api/device-events?since=2000", cookie)
+	if events := readJSON(t, res)["events"].([]any); len(events) != 2 {
+		t.Fatalf("since=2000: %d, want 2", len(events))
+	}
+}

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -163,6 +163,7 @@ func NewHandler(d Deps) http.Handler {
 	mux.HandleFunc("GET /api/dot11r", s.handleDot11r)
 	mux.HandleFunc("GET /api/survey", s.handleSurvey)
 	mux.HandleFunc("GET /api/roam-events", s.handleRoamEvents)
+	mux.HandleFunc("GET /api/device-events", s.handleDeviceEvents)
 	mux.HandleFunc("GET /api/adguard/clients", s.handleAdguardClients)
 	mux.HandleFunc("GET /api/system/info", s.handleSystemInfo)
 	mux.HandleFunc("GET /api/reports/weekly", s.handleWeeklyReport)


### PR DESCRIPTION
Closes #184

Track device offline/online transitions as first-class events with timestamps, so incidents can be correlated (which devices dropped, when, and how long until recovery).

## What

- New `device_events` table (`db.go`): `ts_ms, mac, router_id, state, signal_dbm, detail` + indexes + 30-day retention alongside roam_events.
- New `internal/deviceevents` package: `Insert` + `ListEvents` mirroring `roamevents`.
- Poller detection in `live.go`: `trackDevicePresence` runs each poll cycle, tracks wireless MACs only (wired FDB is volatile), emits `online` when a MAC appears and `offline` after 3 consecutive missed ticks (anti false positives). First cycle only populates state (anti avalanche on boot).
- `GET /api/device-events` endpoint mirroring `/api/roam-events`, with `limit/since/router/mac/state` filters.

## Verification

- `go build ./...`, `go vet ./internal/...`, `go test -race ./internal/...` all green (unit tests for deviceevents + presence detection + HTTP contract).
- Deployed to the home CT: `/api/device-events` returns real offline/online transitions captured from the live network.

No UI included (API only for now).