### PR TITLE
release: v2.10.0 — device offline/online events (#184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 ## [Unreleased]
 
+## [2.10.0] - 2026-08-14
+
+### Added
+
+- **Eventos offline/online de dispositivos**: el poller registra las
+  transiciones de presencia wireless (un dispositivo que deja de verse 3
+  ticks seguidos = `offline`; al reaparecer = `online`) con timestamp, router
+  y última señal. Nueva tabla `device_events` (retención 30 días) y endpoint
+  `GET /api/device-events` con filtros `limit/since/router/mac/state`.
+  Permite correlacionar incidentes (qué cayó, cuándo, cuánto tardó en volver).
+  #184
+
 ## [2.9.6] - 2026-08-13
 
 ### Added

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.9.6",
+  "version": "2.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Version es la versión del backend (app.js:18).
-const Version = "2.9.6"
+const Version = "2.10.0"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Release v2.10.0.

- feat: track device offline/online events (#184) — merged in #185.
- Bump app + server-go version to 2.10.0, CHANGELOG updated.