### PR TITLE
release: v2.10.1 — fix update banner duplicate version and stable hint (#191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 ## [Unreleased]
 
+## [2.10.1] - 2026-08-18
+
+### Fixed
+
+- **Aviso de actualización sin versión duplicada**: cuando GitHub publica una
+  release cuyo nombre coincide con el tag (p. ej. `v2.10.0`), el banner ya no
+  muestra "Nueva versión disponible: v2.10.0 — v2.10.0". Ahora solo aparece la
+  versión una vez. #191
+
+- **Hint visible en instalaciones estables**: en despliegues que usan
+  `install.sh` (modo estable), el banner ahora muestra debajo del mensaje
+  "Instalación estable: re-ejecuta install.sh para actualizar", haciendo
+  explícito por qué no hay botón "Actualizar" y clarificando el enlace
+  "Ver en GitHub" como siguiente paso. #191
+
 ## [2.10.0] - 2026-08-14
 
 ### Added

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.10.0",
+  "version": "2.10.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -986,7 +986,8 @@
     "timeRange": "Time range"
   },
   "update": {
-    "available": "New version available: {{version}} — {{msg}}",
+    "available": "New version available: {{version}}",
+    "availableWithMsg": "New version available: {{version}} — {{msg}}",
     "button": "Update",
     "getRelease": "View on GitHub",
     "stableHint": "Stable install: re-run install.sh to update",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -986,7 +986,8 @@
     "timeRange": "Rango temporal"
   },
   "update": {
-    "available": "Nueva versión disponible: {{version}} — {{msg}}",
+    "available": "Nueva versión disponible: {{version}}",
+    "availableWithMsg": "Nueva versión disponible: {{version}} — {{msg}}",
     "button": "Actualizar",
     "getRelease": "Ver en GitHub",
     "stableHint": "Instalación estable: re-ejecuta install.sh para actualizar",

--- a/app/src/components/UpdateBanner.tsx
+++ b/app/src/components/UpdateBanner.tsx
@@ -11,6 +11,10 @@ import { DownloadCloud, ExternalLink, Loader2, X } from 'lucide-react'
 import { useAuth } from '@/data/AuthContext'
 import { ReadinessPanel, type UpdateReadiness } from '@/components/UpdateReadiness'
 
+function normalizeVersion(s: string) {
+  return s.trim().toLowerCase().replace(/^v/, '')
+}
+
 interface UpdateStatus {
   current: string
   latest: string | null
@@ -142,6 +146,15 @@ export function UpdateBanner() {
   const step = status.updating ? status.updating.step : 'start'
   const ready = status.readiness ? status.readiness.ready : true
 
+  const latest = status.latest
+  const latestMsg = status.latestMsg ?? ''
+  const showMsg = latestMsg && normalizeVersion(latestMsg) !== normalizeVersion(latest)
+  const message = updating
+    ? t('update.updating', { step: t(`update.step.${step}`) })
+    : showMsg
+      ? t('update.availableWithMsg', { version: latest, msg: latestMsg })
+      : t('update.available', { version: latest })
+
   return (
     <AnimatePresence>
       <motion.div
@@ -154,11 +167,12 @@ export function UpdateBanner() {
       >
         <div className="flex items-center gap-3 rounded-xl border border-accent/40 bg-accent-soft px-4 py-2.5">
           <DownloadCloud className="h-4 w-4 shrink-0 text-accent" strokeWidth={1.75} />
-          <p className="min-w-0 flex-1 truncate text-sm text-text-primary">
-            {updating
-              ? t('update.updating', { step: t(`update.step.${step}`) })
-              : t('update.available', { version: status.latest, msg: status.latestMsg ?? '' })}
-          </p>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm text-text-primary">{message}</p>
+            {!updating && !status.canApply && (
+              <p className="text-xs text-text-muted">{t('update.stableHint')}</p>
+            )}
+          </div>
           {!updating ? (
             <>
               {status.canApply ? (

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Version es la versión del backend (app.js:18).
-const Version = "2.10.0"
+const Version = "2.10.1"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Bump to v2.10.1. Includes the fix for #191.

Closes #191