### PR TITLE
fix(landing): add goatcounter tracker to record visits

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -84,6 +84,7 @@
     ]
   }
   </script>
+<script data-goatcounter="https://stats.netpulse.cloudless.club/count" async src="//stats.netpulse.cloudless.club/count.js"></script>
 </head>
 <body>
   <canvas id="bgCanvas" aria-hidden="true"></canvas>


### PR DESCRIPTION
The landing at netpulse.cloudless.club was not recording visits: GoatCounter site 5 had only 2 lifetime hits and zero since 17-Aug. The tracker added on 13-Aug (backup `index.html.bak-tracker-20260813` on webs2) was lost in a later landing deploy, and neither prod nor `main` had any analytics snippet.

Adds the tracker line to `web/index.html` (the landing source; same pattern as the other cloudless landings). The nginx CSP already allows `stats.netpulse.cloudless.club`.

Verified end-to-end in production: index.html md5 prod == repo, Playwright with real UA loads `count.js` and sends `POST /count` with zero JS errors, and the GoatCounter DB shows the new 20-Aug hit.

Closes #194