### PR TITLE
fix(trust): known-macs allowlist and persistent router mac exclusion (#196)

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -969,6 +969,25 @@
       "saved": "Saved",
       "invalid": "Enter speeds greater than 0 and at most 100000 Mbps",
       "saveError": "Could not save the speed"
+    },
+    "knownMacs": {
+      "title": "Trusted devices",
+      "caption": "The MAC no longer warns as an 'unknown device' and its name is used as an alias",
+      "hint": "Devices you own (routers, TVs, scales…) that come and go normally. Marking them here stops unknown-device alerts.",
+      "empty": "No trusted devices yet. Add one with the 'Add' button.",
+      "add": "Add",
+      "adding": "Adding…",
+      "mac": "MAC address",
+      "macPlaceholder": "AA:BB:CC:DD:EE:FF",
+      "name": "Name (alias)",
+      "namePlaceholder": "e.g. Withings scale",
+      "save": "Save",
+      "saving": "Saving…",
+      "delete": "Remove",
+      "invalidMac": "Invalid MAC address (format AA:BB:CC:DD:EE:FF)",
+      "saveError": "Could not save the device",
+      "deleteError": "Could not remove the device",
+      "loadError": "Could not load trusted devices"
     }
   },
   "statcard": {

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -969,6 +969,25 @@
       "saved": "Guardada",
       "invalid": "Introduce velocidades mayores que 0 y como máximo 100000 Mbps",
       "saveError": "No se pudo guardar la velocidad"
+    },
+    "knownMacs": {
+      "title": "Dispositivos de confianza",
+      "caption": "La MAC no se avisa como «dispositivo desconocido» y su nombre se usa como alias",
+      "hint": "Dispositivos propios (routers, TV, básculas…) que entran y salen de la red con normalidad. Al marcarlos aquí dejan de generar alertas de desconocido.",
+      "empty": "Sin dispositivos de confianza todavía. Añade uno con el botón «Añadir».",
+      "add": "Añadir",
+      "adding": "Añadiendo…",
+      "mac": "Dirección MAC",
+      "macPlaceholder": "AA:BB:CC:DD:EE:FF",
+      "name": "Nombre (alias)",
+      "namePlaceholder": "p. ej. Báscula Withings",
+      "save": "Guardar",
+      "saving": "Guardando…",
+      "delete": "Quitar",
+      "invalidMac": "Dirección MAC inválida (formato AA:BB:CC:DD:EE:FF)",
+      "saveError": "No se pudo guardar el dispositivo",
+      "deleteError": "No se pudo quitar el dispositivo",
+      "loadError": "No se pudieron cargar los dispositivos de confianza"
     }
   },
   "statcard": {

--- a/app/src/components/KnownMacsManager.tsx
+++ b/app/src/components/KnownMacsManager.tsx
@@ -1,0 +1,182 @@
+/**
+ * NetPulse — Gestor de dispositivos de confianza (issue #196).
+ * Allowlist de MACs que no avisan como «dispositivo desconocido» y cuyo
+ * nombre se usa como alias. CRUD contra /api/settings/known-macs (admin).
+ */
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Plus, ShieldCheck, Trash2 } from 'lucide-react'
+import { useNetPulse } from '@/data/DataProvider'
+import { cn } from '@/lib/utils'
+
+interface KnownMacItem {
+  mac: string
+  name: string
+  note?: string
+}
+
+interface Props {
+  onSaved?: () => void
+}
+
+const MAC_RE = /^([0-9A-F]{2}:){5}[0-9A-F]{2}$/i
+
+export function KnownMacsManager({ onSaved }: Props) {
+  const { t } = useTranslation()
+  const { refresh } = useNetPulse()
+  const [list, setList] = useState<KnownMacItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [mac, setMac] = useState('')
+  const [name, setName] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch('/api/settings/known-macs')
+      if (res.status === 401) {
+        window.location.assign('/login')
+        return
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const json = (await res.json()) as { items: KnownMacItem[] }
+      setList(json.items)
+      setError(null)
+    } catch {
+      setError(t('settings.knownMacs.loadError'))
+    } finally {
+      setLoading(false)
+    }
+  }, [t])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const m = mac.trim().toUpperCase()
+    if (!MAC_RE.test(m) || submitting) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/settings/known-macs', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mac: m, name: name.trim() }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setMac('')
+      setName('')
+      await load()
+      refresh()
+      onSaved?.()
+    } catch {
+      setError(t('settings.knownMacs.saveError'))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const remove = async (m: string) => {
+    try {
+      const res = await fetch(`/api/settings/known-macs/${encodeURIComponent(m)}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      await load()
+      refresh()
+      onSaved?.()
+    } catch {
+      setError(t('settings.knownMacs.deleteError'))
+    }
+  }
+
+  const macInvalid = mac.trim() !== '' && !MAC_RE.test(mac.trim())
+
+  return (
+    <div className="mt-4 space-y-3 border-t border-border pt-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-sm font-medium text-text-primary">{t('settings.knownMacs.title')}</div>
+          <div className="text-caption text-text-muted">{t('settings.knownMacs.caption')}</div>
+          <p className="mt-1 text-caption text-text-muted">{t('settings.knownMacs.hint')}</p>
+        </div>
+        <ShieldCheck className="h-5 w-5 shrink-0 text-ok" strokeWidth={1.75} aria-hidden="true" />
+      </div>
+
+      {loading ? (
+        <div className="py-4 text-caption text-text-muted">…</div>
+      ) : list.length === 0 ? (
+        <div className="rounded-lg border border-border bg-elevated px-3 py-4 text-center text-caption text-text-muted">
+          {t('settings.knownMacs.empty')}
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {list.map((item) => (
+            <li
+              key={item.mac}
+              className="flex items-center justify-between gap-3 rounded-lg border border-border bg-elevated px-3 py-2"
+            >
+              <div className="min-w-0">
+                <div className="truncate font-mono text-mono-sm text-text-primary">{item.mac}</div>
+                {item.name && (
+                  <div className="truncate text-caption text-text-secondary">{item.name}</div>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => void remove(item.mac)}
+                aria-label={`${t('settings.knownMacs.delete')} ${item.mac}`}
+                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border text-text-secondary transition-colors hover:border-danger/40 hover:text-danger"
+              >
+                <Trash2 className="h-4 w-4" strokeWidth={1.75} aria-hidden="true" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <form onSubmit={submit} className="grid grid-cols-1 gap-3 sm:grid-cols-[1fr_1fr_auto]">
+        <label className="block">
+          <span className="text-label uppercase text-text-muted">{t('settings.knownMacs.mac')}</span>
+          <input
+            type="text"
+            inputMode="text"
+            value={mac}
+            onChange={(e) => setMac(e.target.value)}
+            placeholder={t('settings.knownMacs.macPlaceholder')}
+            aria-label={t('settings.knownMacs.mac')}
+            aria-invalid={macInvalid}
+            className={cn(
+              'mt-1 w-full rounded-lg border bg-canvas px-3 py-2 font-mono text-mono-sm text-text-primary placeholder:text-text-muted focus:outline-none',
+              macInvalid ? 'border-danger' : 'border-border focus:border-accent',
+            )}
+          />
+        </label>
+        <label className="block">
+          <span className="text-label uppercase text-text-muted">{t('settings.knownMacs.name')}</span>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder={t('settings.knownMacs.namePlaceholder')}
+            aria-label={t('settings.knownMacs.name')}
+            className="mt-1 w-full rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+          />
+        </label>
+        <div className="flex items-end">
+          <button
+            type="submit"
+            disabled={submitting || macInvalid || mac.trim() === ''}
+            className="inline-flex h-[38px] shrink-0 items-center gap-1.5 rounded-lg border border-accent bg-accent-soft px-3 text-[13px] font-medium text-accent transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Plus className="h-4 w-4" strokeWidth={1.75} aria-hidden="true" />
+            {submitting ? t('settings.knownMacs.adding') : t('settings.knownMacs.add')}
+          </button>
+        </div>
+      </form>
+
+      {macInvalid && <p className="text-xs text-danger">{t('settings.knownMacs.invalidMac')}</p>}
+      {error && <p role="alert" className="text-xs text-danger">{error}</p>}
+    </div>
+  )
+}

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -42,6 +42,7 @@ import {
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { HealthRing } from '@/components/HealthRing'
+import { KnownMacsManager } from '@/components/KnownMacsManager'
 import { SegmentedControl } from '@/components/SegmentedControl'
 import { TopologyOverridesManager } from '@/components/topology/TopologyOverridesManager'
 import { ReadinessPanel, type UpdateReadiness } from '@/components/UpdateReadiness'
@@ -3456,6 +3457,21 @@ export default function Settings() {
               reduce={reduce}
             >
               <TopologyOverridesManager onSaved={notify} />
+            </Card>
+          </div>
+        )}
+
+        {/* Dispositivos de confianza (issue #196): allowlist de MACs que no
+            avisan como «desconocido» y cuyo nombre se usa como alias. */}
+        {!isDemo && auth?.role === 'admin' && (
+          <div className="lg:col-span-12">
+            <Card
+              title={t('settings.knownMacs.title')}
+              caption={t('settings.knownMacs.caption')}
+              index={5}
+              reduce={reduce}
+            >
+              <KnownMacsManager onSaved={notify} />
             </Card>
           </div>
         )}

--- a/server-go/internal/adapters/alerts_live_test.go
+++ b/server-go/internal/adapters/alerts_live_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gnacho/netpulse/server-go/internal/alerts"
+	"github.com/gnacho/netpulse/server-go/internal/db"
 )
 
 // Las 5 alertas canon pasan por el motor con config default y sobreviven
@@ -154,8 +155,9 @@ func TestLiveUnknownDeviceTaxonomy(t *testing.T) {
 		t.Fatalf("desconocido: %d alertas", len(list))
 	}
 	a := list[0]
-	if a.Category != alerts.CatClients || !a.Urgent || a.Severity != "warn" {
-		t.Fatalf("desconocido: (%s,%v,%s), esperaba (clients,true,warn)", a.Category, a.Urgent, a.Severity)
+	// issue #196: la alerta de desconocido NO es urgente (warn informativa).
+	if a.Category != alerts.CatClients || a.Urgent || a.Severity != "warn" {
+		t.Fatalf("desconocido: (%s,%v,%s), esperaba (clients,false,warn)", a.Category, a.Urgent, a.Severity)
 	}
 }
 
@@ -181,7 +183,7 @@ func TestLiveTrackUnknownDevices(t *testing.T) {
 	if len(list) != 1 {
 		t.Fatalf("reconexión de desconocido: %d alertas", len(list))
 	}
-	if list[0].Category != alerts.CatClients || !list[0].Urgent {
+	if list[0].Category != alerts.CatClients || list[0].Urgent {
 		t.Fatalf("taxonomía: %+v", list[0])
 	}
 	// El dispositivo CON nombre nunca alerta aunque se reconecte
@@ -189,5 +191,22 @@ func TestLiveTrackUnknownDevices(t *testing.T) {
 	l.trackUnknownDevices([]Device{unknown, named})
 	if len(l.engine.List()) != 1 {
 		t.Fatal("dispositivo conocido no debía alertar")
+	}
+}
+
+func TestLiveTrackUnknownDevicesTrustedAllowlist(t *testing.T) {
+	l := liveTestLive()
+	l.db = openLiveTestDB(t) // allowlist en BD real
+	trusted := Device{MAC: "A4:7E:FA:65:0C:AA", Name: "A4:7E:FA:65:0C:AA", RouterID: "living", Online: true}
+	if err := l.db.UpsertKnownMac(db.KnownMac{MAC: "A4:7E:FA:65:0C:AA", Name: "Withings"}); err != nil {
+		t.Fatal(err)
+	}
+	// Primer ciclo siembra; desconexión; reconexión: la MAC de la allowlist
+	// NUNCA alerta, aunque siga sin nombre/lease (issue #196).
+	l.trackUnknownDevices([]Device{trusted})
+	l.trackUnknownDevices([]Device{})
+	l.trackUnknownDevices([]Device{trusted})
+	if len(l.engine.List()) != 0 {
+		t.Fatalf("MAC confiable alertó: %d", len(l.engine.List()))
 	}
 }

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -877,6 +877,12 @@ func (l *Live) pollAll(ctx context.Context) map[string]*routerPolled {
 		if res.err == nil {
 			polled[res.cfg.ID] = res.p
 			l.failCount[res.cfg.ID] = 0
+			// Persiste la bridgeMAC del router (issue #196): la exclusión de
+			// "dispositivo desconocido" no debe depender de que este router se
+			// sondee bien en el tick actual.
+			if l.db != nil && res.p.brMac != "" {
+				_, _ = l.db.Exec("UPDATE routers SET mac = ? WHERE id = ?", res.p.brMac, res.cfg.ID)
+			}
 			// Router recuperado (offline→online, SPEC-ALERTAS §1)
 			if l.lastStatus[res.cfg.ID] == "offline" {
 				name := res.cfg.Name
@@ -967,16 +973,33 @@ func (l *Live) trackWanDown(cfg *RouterConfig, p *routerPolled) {
 // cliente SIN nombre (Name == MAC, sin hostname DHCP ni alias — device_attrib
 // no guarda alias) pasa de no-online a online. El primer ciclo de sondeo del
 // proceso NO alerta (evita la avalancha de arranque: todo lo ya conectado
-// sería "nuevo"). Toma l.mu internamente.
+// sería "nuevo"). Las MAC de la allowlist known_macs (issue #196) nunca
+// alertan, haya alias o no. Toma l.mu internamente.
 func (l *Live) trackUnknownDevices(devices []Device) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	// issue #196: MACs de la allowlist (confiables) → nunca "desconocido".
+	trusted := map[string]bool{}
+	if l.db != nil {
+		if rows, err := l.db.Query("SELECT mac FROM known_macs"); err == nil {
+			for rows.Next() {
+				var mac string
+				if rows.Scan(&mac) == nil {
+					trusted[mac] = true
+				}
+			}
+			rows.Close()
+		}
+	}
 	nowOnline := map[string]bool{}
 	for _, d := range devices {
 		if !d.Online {
 			continue
 		}
 		nowOnline[d.MAC] = true
+		if trusted[d.MAC] {
+			continue
+		}
 		if l.seenOnlineMacs && !l.onlineMacs[d.MAC] && d.Name == d.MAC {
 			l.emitUnknownDevice(d)
 		}
@@ -986,13 +1009,13 @@ func (l *Live) trackUnknownDevices(devices []Device) {
 }
 
 // emitUnknownDevice: evento "dispositivo desconocido se conecta" (category
-// clients, urgent true, warn — SPEC-ALERTAS §1). "Desconocido" = sin nombre/
-// alias: device_attrib no guarda alias, así que la señal práctica es un
-// cliente sin hostname DHCP (Name == MAC). Debe llamarse con l.mu tomado.
+// clients, warn, NO urgente — issue #196). "Desconocido" = sin nombre/alias:
+// device_attrib no guarda alias, así que la señal práctica es un cliente sin
+// hostname DHCP (Name == MAC). Debe llamarse con l.mu tomado.
 func (l *Live) emitUnknownDevice(d Device) {
 	l.engine.Emit(AlertEvent{
 		ID:       fmt.Sprintf("alert-unknown-%s-%d", d.MAC, time.Now().UnixMilli()),
-		Category: alerts.CatClients, Urgent: true,
+		Category: alerts.CatClients, Urgent: false,
 		Severity:    "warn",
 		Title:       "Dispositivo desconocido",
 		Description: fmt.Sprintf("%s se ha conectado a %s", d.MAC, d.RouterID),
@@ -1267,9 +1290,36 @@ func (l *Live) buildDevices(polled map[string]*routerPolled) []Device {
 		allMacs[mac] = true
 	}
 	routerMacs := map[string]bool{}
+	// issue #196: MACs de bridge de los routers REGISTRADOS (persistidas),
+	// no solo las de los routers que sondeó bien en este tick. Un router que
+	// falló el sondeo sigue sin ser "cliente desconocido".
+	if l.db != nil {
+		if rows, err := l.db.Query("SELECT mac FROM routers WHERE mac IS NOT NULL AND mac != ''"); err == nil {
+			for rows.Next() {
+				var mac string
+				if rows.Scan(&mac) == nil {
+					routerMacs[mac] = true
+				}
+			}
+			rows.Close()
+		}
+	}
 	for _, p := range polled {
 		if p.brMac != "" {
 			routerMacs[p.brMac] = true
+		}
+	}
+	// issue #196: allowlist de dispositivos confiables (mac → alias).
+	knownMacs := map[string]string{}
+	if l.db != nil {
+		if rows, err := l.db.Query("SELECT mac, name FROM known_macs"); err == nil {
+			for rows.Next() {
+				var mac, name string
+				if rows.Scan(&mac, &name) == nil {
+					knownMacs[mac] = name
+				}
+			}
+			rows.Close()
 		}
 	}
 	devices := []Device{}
@@ -1303,6 +1353,11 @@ func (l *Live) buildDevices(polled map[string]*routerPolled) []Device {
 					d.Name = gl.Hostname
 				}
 			}
+		}
+		// issue #196: la allowlist manda sobre el nombre por defecto. Con
+		// alias (Name != MAC) el dispositivo deja de ser "desconocido".
+		if alias, ok := knownMacs[mac]; ok && alias != "" {
+			d.Name = alias
 		}
 		// Tipo estimado por hostname (el DHCP/FDB no dice qué es el cliente).
 		// Con nombre-MAC (sin hostname) queda "desconocido".

--- a/server-go/internal/alerts/alerts.go
+++ b/server-go/internal/alerts/alerts.go
@@ -72,11 +72,13 @@ type Notifier interface {
 }
 
 // DefaultConfig devuelve una copia de los defaults del SPEC §2.
+// clients=all desde issue #196: "dispositivo desconocido" ya no es urgente
+// pero debe seguir siendo visible (con clients:urgent se descartaría entero).
 func DefaultConfig() map[string]string {
 	return map[string]string{
 		CatRouter:   LevelUrgent,
 		CatInternet: LevelUrgent,
-		CatClients:  LevelUrgent,
+		CatClients:  LevelAll,
 		CatSignal:   LevelNone,
 		CatVPN:      LevelNone,
 		CatSystem:   LevelAll,

--- a/server-go/internal/alerts/alerts_test.go
+++ b/server-go/internal/alerts/alerts_test.go
@@ -28,9 +28,9 @@ func TestDefaultConfig(t *testing.T) {
 			t.Fatalf("default %s: %q, esperaba %q", cat, cfg[cat], want[cat])
 		}
 	}
-	// Defaults exactos del SPEC §2
+	// Defaults exactos del SPEC §2 (clients=all desde #196)
 	if cfg[CatRouter] != "urgent" || cfg[CatInternet] != "urgent" ||
-		cfg[CatClients] != "urgent" || cfg[CatSignal] != "none" ||
+		cfg[CatClients] != "all" || cfg[CatSignal] != "none" ||
 		cfg[CatVPN] != "none" || cfg[CatSystem] != "all" {
 		t.Fatalf("defaults SPEC: %v", cfg)
 	}
@@ -69,19 +69,26 @@ func TestEmitFiltering(t *testing.T) {
 	if e.Emit(ev("s1", CatSignal, true)) {
 		t.Fatal("signal:none debía descartar")
 	}
-	// urgent → solo urgentes (clients por defecto)
-	if e.Emit(ev("c1", CatClients, false)) {
-		t.Fatal("clients:urgent debía descartar no-urgente")
+	// urgent → solo urgentes (router por defecto)
+	if e.Emit(ev("r1", CatRouter, false)) {
+		t.Fatal("router:urgent debía descartar no-urgente")
+	}
+	if !e.Emit(ev("r2", CatRouter, true)) {
+		t.Fatal("router:urgent debía aceptar urgente")
+	}
+	// all → pasa todo (clients=all desde #196)
+	if !e.Emit(ev("c1", CatClients, false)) {
+		t.Fatal("clients:all debía aceptar no-urgente")
 	}
 	if !e.Emit(ev("c2", CatClients, true)) {
-		t.Fatal("clients:urgent debía aceptar urgente")
+		t.Fatal("clients:all debía aceptar urgente")
 	}
 	// all → pasa todo (system por defecto)
 	if !e.Emit(ev("y1", CatSystem, false)) {
 		t.Fatal("system:all debía aceptar no-urgente")
 	}
-	if got := len(e.List()); got != 2 {
-		t.Fatalf("lista: %d, esperaba 2", got)
+	if got := len(e.List()); got != 4 {
+		t.Fatalf("lista: %d, esperaba 4", got)
 	}
 	// Cambio de nivel reconfigura el filtrado
 	if err := e.SetConfig(map[string]string{"signal": "all"}); err != nil {

--- a/server-go/internal/db/db.go
+++ b/server-go/internal/db/db.go
@@ -117,6 +117,14 @@ CREATE TABLE IF NOT EXISTS routers (
   is_gateway INTEGER NOT NULL DEFAULT 0,
   created_at INTEGER NOT NULL
 );
+-- Allowlist de dispositivos confiables (issue #196): una MAC conocida no
+-- dispara "dispositivo desconocido" y su name se usa como alias.
+CREATE TABLE IF NOT EXISTS known_macs (
+  mac TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  note TEXT,
+  created_at INTEGER NOT NULL
+);
 -- Suscripciones Web Push (Fase 3 Bloque C; sin paridad Node: el push es
 -- nuevo en Go). created_at en milisegundos como el resto de epochs.
 CREATE TABLE IF NOT EXISTS push_subscriptions (
@@ -321,6 +329,8 @@ func Open(dataDir string, opts ...OpenOption) (*DB, error) {
 	// SPEC-65 D65-5: nombre visible por usuario ("" = usar el username).
 	migrate(sqldb, "users", "display_name", "ALTER TABLE users ADD COLUMN display_name TEXT DEFAULT ''")
 	migrate(sqldb, "routers", "agent_only", "ALTER TABLE routers ADD COLUMN agent_only INTEGER NOT NULL DEFAULT 0")
+	// issue #196: bridgeMAC persistido del router (exclusión de "desconocido").
+	migrate(sqldb, "routers", "mac", "ALTER TABLE routers ADD COLUMN mac TEXT")
 
 	// Si no hubo migración Node (instalación fresca creada por Go), marca la
 	// DB para que el siguiente arranque no dispare una "migración" espuria
@@ -565,4 +575,46 @@ func (d *DB) ShutdownContext(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+// KnownMac es una fila de la allowlist (issue #196).
+type KnownMac struct {
+	MAC       string
+	Name      string
+	Note      string
+	CreatedAt int64
+}
+
+// ListKnownMacs devuelve la allowlist ordenada por MAC.
+func (d *DB) ListKnownMacs() ([]KnownMac, error) {
+	rows, err := d.Query("SELECT mac, name, note, created_at FROM known_macs ORDER BY mac")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []KnownMac{}
+	for rows.Next() {
+		var k KnownMac
+		var note sql.NullString
+		if err := rows.Scan(&k.MAC, &k.Name, &note, &k.CreatedAt); err == nil {
+			k.Note = note.String
+			out = append(out, k)
+		}
+	}
+	return out, rows.Err()
+}
+
+// UpsertKnownMac inserta o actualiza una MAC de la allowlist (por MAC).
+func (d *DB) UpsertKnownMac(k KnownMac) error {
+	_, err := d.Exec(
+		`INSERT INTO known_macs (mac, name, note, created_at) VALUES (?, ?, ?, ?)
+		 ON CONFLICT(mac) DO UPDATE SET name=excluded.name, note=excluded.note`,
+		k.MAC, k.Name, k.Note, NowMS())
+	return err
+}
+
+// DeleteKnownMac quita una MAC de la allowlist.
+func (d *DB) DeleteKnownMac(mac string) error {
+	_, err := d.Exec("DELETE FROM known_macs WHERE mac = ?", mac)
+	return err
 }

--- a/server-go/internal/httpapi/alerts_api_test.go
+++ b/server-go/internal/httpapi/alerts_api_test.go
@@ -101,7 +101,7 @@ func TestAlertsConfigEndpoints(t *testing.T) {
 	if len(cfg) != 6 {
 		t.Fatalf("config: %d claves, esperaba 6", len(cfg))
 	}
-	want := map[string]string{"router": "urgent", "internet": "urgent", "clients": "urgent",
+	want := map[string]string{"router": "urgent", "internet": "urgent", "clients": "all",
 		"signal": "none", "vpn": "none", "system": "all"}
 	for k, v := range want {
 		if cfg[k] != v {

--- a/server-go/internal/httpapi/settings.go
+++ b/server-go/internal/httpapi/settings.go
@@ -9,8 +9,10 @@ import (
 	"database/sql"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gnacho/netpulse/server-go/internal/auth"
+	"github.com/gnacho/netpulse/server-go/internal/db"
 )
 
 // orchestrationKey es la clave kv que activa el menú de orquestación (#121).
@@ -134,5 +136,88 @@ func (s *server) registerSettingsRoutes(mux *http.ServeMux) {
 			return
 		}
 		writeJSON(w, http.StatusOK, wanSpeedResponse{DownMbps: body.DownMbps, UpMbps: body.UpMbps})
+	})))
+
+	s.registerKnownMacsRoutes(mux)
+}
+
+// knownMacItem es la forma JSON de una entrada de la allowlist (#196).
+type knownMacItem struct {
+	MAC  string `json:"mac"`
+	Name string `json:"name"`
+	Note string `json:"note,omitempty"`
+}
+
+// validMAC normaliza y valida una dirección MAC (AA:BB:CC:DD:EE:FF).
+func validMAC(raw string) (string, bool) {
+	m := strings.ToUpper(strings.TrimSpace(raw))
+	if len(m) != 17 {
+		return "", false
+	}
+	for i := 0; i < 17; i++ {
+		if i%3 == 2 {
+			if m[i] != ':' {
+				return "", false
+			}
+		} else if !isHex(m[i]) {
+			return "", false
+		}
+	}
+	return m, true
+}
+
+func isHex(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F')
+}
+
+// registerKnownMacsRoutes: GET/PUT/DELETE /api/settings/known-macs (admin,
+// issue #196) — allowlist de dispositivos confiables que no alertan como
+// "desconocido" y cuyo nombre se usa como alias.
+func (s *server) registerKnownMacsRoutes(mux *http.ServeMux) {
+	// GET /api/settings/known-macs — lista completa de la allowlist.
+	mux.Handle("GET /api/settings/known-macs", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		items, err := s.db.ListKnownMacs()
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "db_error")
+			return
+		}
+		out := make([]knownMacItem, 0, len(items))
+		for _, k := range items {
+			out = append(out, knownMacItem{MAC: k.MAC, Name: k.Name, Note: k.Note})
+		}
+		writeJSON(w, http.StatusOK, map[string][]knownMacItem{"items": out})
+	})))
+
+	// PUT /api/settings/known-macs — alta o actualización de una MAC.
+	mux.Handle("PUT /api/settings/known-macs", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body knownMacItem
+		if !readJSONBody(r, &body) {
+			writeError(w, http.StatusBadRequest, "invalid_body")
+			return
+		}
+		mac, ok := validMAC(body.MAC)
+		if !ok {
+			writeError(w, http.StatusBadRequest, "invalid_input", "dirección MAC inválida (AA:BB:CC:DD:EE:FF)")
+			return
+		}
+		if err := s.db.UpsertKnownMac(db.KnownMac{MAC: mac, Name: body.Name, Note: body.Note}); err != nil {
+			writeError(w, http.StatusInternalServerError, "db_error")
+			return
+		}
+		writeJSON(w, http.StatusOK, knownMacItem{MAC: mac, Name: body.Name, Note: body.Note})
+	})))
+
+	// DELETE /api/settings/known-macs/{mac} — baja de la allowlist.
+	mux.Handle("DELETE /api/settings/known-macs/{mac}", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mac, ok := validMAC(r.PathValue("mac"))
+		if !ok {
+			writeError(w, http.StatusBadRequest, "invalid_input", "dirección MAC inválida (AA:BB:CC:DD:EE:FF)")
+			return
+		}
+		if err := s.db.DeleteKnownMac(mac); err != nil {
+			writeError(w, http.StatusInternalServerError, "db_error")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 	})))
 }

--- a/server-go/internal/httpapi/settings_knownmacs_test.go
+++ b/server-go/internal/httpapi/settings_knownmacs_test.go
@@ -1,0 +1,84 @@
+// settings_knownmacs_test.go — contrato de /api/settings/known-macs
+// (issue #196): allowlist de dispositivos confiables que no alertan como
+// "desconocido" y cuyo nombre se usa como alias.
+package httpapi_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestKnownMacsRoundtrip: GET vacío → PUT → GET lo devuelve → DELETE.
+func TestKnownMacsRoundtrip(t *testing.T) {
+	srv := makeTestServer(t)
+	_, cookie, _ := loginCookie(t, srv.URL, "admin", "test1234")
+	if cookie == "" {
+		t.Fatal("login no devolvió cookie")
+	}
+
+	res, body := wanSpeedRequest(t, "GET", srv.URL, "/api/settings/known-macs", cookie, "")
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("GET: status %d, esperado 200", res.StatusCode)
+	}
+	items, ok := body["items"].([]any)
+	if !ok || len(items) != 0 {
+		t.Fatalf("GET inicial: %v, esperado items vacío", body)
+	}
+
+	res, body = wanSpeedRequest(t, "PUT", srv.URL, "/api/settings/known-macs", cookie,
+		`{"mac":"A4:7E:FA:65:0C:AA","name":"Withings","note":"báscula"}`)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("PUT: status %d, esperado 200 (%v)", res.StatusCode, body)
+	}
+
+	res, body = wanSpeedRequest(t, "GET", srv.URL, "/api/settings/known-macs", cookie, "")
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("GET tras PUT: status %d", res.StatusCode)
+	}
+	items, ok = body["items"].([]any)
+	if !ok || len(items) != 1 {
+		t.Fatalf("GET tras PUT: %v, esperado 1 item", body)
+	}
+	it := items[0].(map[string]any)
+	if it["mac"] != "A4:7E:FA:65:0C:AA" || it["name"] != "Withings" {
+		t.Fatalf("item: %v", it)
+	}
+
+	res, _ = wanSpeedRequest(t, "DELETE", srv.URL, "/api/settings/known-macs/A4:7E:FA:65:0C:AA", cookie, "")
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("DELETE: status %d, esperado 200", res.StatusCode)
+	}
+	res, body = wanSpeedRequest(t, "GET", srv.URL, "/api/settings/known-macs", cookie, "")
+	items, _ = body["items"].([]any)
+	if len(items) != 0 {
+		t.Fatalf("GET tras DELETE: %v, esperado vacío", body)
+	}
+}
+
+// TestKnownMacsInvalidInput: MAC mal formada → 400; PUT sin admin → 401.
+func TestKnownMacsInvalidInput(t *testing.T) {
+	srv := makeTestServer(t)
+	_, cookie, _ := loginCookie(t, srv.URL, "admin", "test1234")
+
+	for _, body := range []string{
+		`{"mac":"A4:7E:FA:65:0C","name":"x"}`,       // corta
+		`{"mac":"A4:7E-FA:65:0C:AA","name":"x"}`,    // separador mal
+		`{"mac":"G4:7E:FA:65:0C:AA","name":"x"}`,    // hex inválido
+		`not-json`,                                  // body roto
+	} {
+		res, _ := wanSpeedRequest(t, "PUT", srv.URL, "/api/settings/known-macs", cookie, body)
+		if res.StatusCode != http.StatusBadRequest {
+			t.Errorf("PUT %s: status %d, esperado 400", body, res.StatusCode)
+		}
+	}
+
+	// Sin sesión admin → 401 (PUT y DELETE)
+	res, _ := wanSpeedRequest(t, "PUT", srv.URL, "/api/settings/known-macs", "", `{"mac":"AA:BB:CC:DD:EE:FF","name":"x"}`)
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("PUT sin auth: status %d, esperado 401", res.StatusCode)
+	}
+	res, _ = wanSpeedRequest(t, "DELETE", srv.URL, "/api/settings/known-macs/AA:BB:CC:DD:EE:FF", "", "")
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("DELETE sin auth: status %d, esperado 401", res.StatusCode)
+	}
+}


### PR DESCRIPTION
## What

Issue #196: unknown-device alerts were firing for the monitored routers themselves and already-known devices.

- **Persistent router MAC exclusion**: each router's bridge MAC is now stored in the `routers.mac` column on every successful poll, and `buildDevices` excludes those MACs from the device list even when the router fails a tick. Previously the exclusion was rebuilt per tick, so a slow/failed gateway poll let the gateway's own MAC slip through as an "unknown client" of a satellite AP.
- **Trusted-devices allowlist** (`known_macs` table): admin endpoints `GET/PUT/DELETE /api/settings/known-macs` plus a "Trusted devices" card in Settings. A MAC in the allowlist never triggers "unknown device" and its name is used as an alias. Covers known hosts whose DHCP lease is not resolved in a given tick.
- **Not urgent anymore**: the "unknown device" alert becomes a non-urgent warn, and the default `clients` alert level moves from `urgent` to `all` so the alert stays visible.

## Verification

- `go build ./...`, `go vet ./internal/...`, `go test -race ./internal/...` green; `tsc --noEmit`, `vite build`, eslint clean.
- Deployed to the live install (CT 226). After the deploy: no new unknown-device alerts in prod (gateway flapping, TV, mini-cargador and the Withings device all stop alerting once registered), the gateway no longer appears as a client, and the allowlist endpoints work end to end.

Closes #196