### PR TITLE
release: v2.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 ## [Unreleased]
 
+## [2.10.2] - 2026-08-21
+
+### Added
+
+- **Dispositivos de confianza**: nueva allowlist `known_macs` gestionable desde
+  Ajustes ("Dispositivos de confianza"). Una MAC registrada nunca dispara la
+  alerta "Dispositivo desconocido" y su nombre se usa como alias. Endpoints
+  admin `GET/PUT/DELETE /api/settings/known-macs`. #196
+
+### Fixed
+
+- **Falsos positivos de "Dispositivo desconocido"**: la alerta se disparaba
+  con los propios routers de la red y con dispositivos ya conocidos cuando el
+  sondeo del gateway era lento (su bridgeMAC se colaba como cliente de un AP)
+  o el lease DHCP no se resolvía en ese tick. Ahora la bridgeMAC de cada
+  router se persiste en `routers.mac` y se excluye siempre, y la alerta de
+  desconocido deja de ser urgente (warn informativo, categoría `clients`
+  pasa a `all`). #196
+
 ## [2.10.1] - 2026-08-18
 
 ### Fixed

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.10.1",
+  "version": "2.10.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Version es la versión del backend (app.js:18).
-const Version = "2.10.1"
+const Version = "2.10.2"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Bump v2.10.2 + CHANGELOG.

- **Added**: trusted devices allowlist (`known_macs`) — Settings "Trusted devices" card, admin `GET/PUT/DELETE /api/settings/known-macs`. A registered MAC never triggers "unknown device" and its name is used as an alias.
- **Fixed**: "unknown device" false positives for the monitored routers themselves (persistent `routers.mac` exclusion) and for known hosts (allowlist), and the alert is no longer urgent (clients level now `all`).

Closes #196 (already merged via #197); this is the release bump.