### PR TITLE
feat: audit round — firmware target, SSH key rotation, agent upgrade & reinstall

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,6 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # publicar assets en la prerelease go-latest
+    env:
+      # Versión del agente embebido en el servidor. Se inyecta igual en el
+      # binario del agente (main.Version) y en el servidor
+      # (agentbin.EmbeddedAgentVersion): el campo updateAvailable de
+      # GET /api/agents compara la versión reportada del agente contra esa
+      # versión. Bumpear aquí y en agentbin.md el valor único de verdad.
+      AGENT_VERSION: "0.1.0"
     strategy:
       matrix:
         arch: [amd64, arm64]
@@ -64,11 +71,6 @@ jobs:
         env:
           CGO_ENABLED: 0
           GOOS: linux
-          # Versión inyectada en el binario del agente embebido. Debe coincidir
-          # con agentbin.EmbeddedAgentVersion (server-go/internal/agentbin):
-          # el campo updateAvailable de GET /api/agents compara la versión del
-          # agente conectado contra esa constante. Bumpear ambos a la vez.
-          AGENT_VERSION: "0.1.0"
         run: |
           set -e
           # amd64
@@ -87,7 +89,9 @@ jobs:
         # -X updater.BuildCommit: sin esto el updater del CT cae a git rev-parse
         # (repo stale dubious-ownership) y reporta un SHA viejo → falso "update
         # available" permanente aunque el binario sea el de main HEAD.
-        run: go build -trimpath -ldflags "-s -w -X github.com/gnacho/netpulse/server-go/internal/updater.BuildCommit=${GITHUB_SHA::7}" -o netpulse ./cmd/netpulse
+        # -X agentbin.EmbeddedAgentVersion: la versión del agente embebido;
+        # alimenta el campo updateAvailable de GET /api/agents.
+        run: go build -trimpath -ldflags "-s -w -X github.com/gnacho/netpulse/server-go/internal/updater.BuildCommit=${GITHUB_SHA::7} -X github.com/gnacho/netpulse/server-go/internal/agentbin.EmbeddedAgentVersion=${AGENT_VERSION}" -o netpulse ./cmd/netpulse
 
       - name: Empaqueta binario + despliegue
         run: tar czf netpulse-server-${{ github.sha }}-linux-${{ matrix.arch }}.tar.gz -C server-go netpulse .env.example -C .. deploy

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -64,14 +64,19 @@ jobs:
         env:
           CGO_ENABLED: 0
           GOOS: linux
+          # Versión inyectada en el binario del agente embebido. Debe coincidir
+          # con agentbin.EmbeddedAgentVersion (server-go/internal/agentbin):
+          # el campo updateAvailable de GET /api/agents compara la versión del
+          # agente conectado contra esa constante. Bumpear ambos a la vez.
+          AGENT_VERSION: "0.1.0"
         run: |
           set -e
           # amd64
-          (cd agent && GOARCH=amd64 go build -trimpath -ldflags "-s -w" -o ../server-go/internal/agentbin/agents/netpulse-agent-amd64 ./cmd/netpulse-agent)
+          (cd agent && GOARCH=amd64 go build -trimpath -ldflags "-s -w -X main.Version=$AGENT_VERSION" -o ../server-go/internal/agentbin/agents/netpulse-agent-amd64 ./cmd/netpulse-agent)
           # arm64
-          (cd agent && GOARCH=arm64 go build -trimpath -ldflags "-s -w" -o ../server-go/internal/agentbin/agents/netpulse-agent-arm64 ./cmd/netpulse-agent)
+          (cd agent && GOARCH=arm64 go build -trimpath -ldflags "-s -w -X main.Version=$AGENT_VERSION" -o ../server-go/internal/agentbin/agents/netpulse-agent-arm64 ./cmd/netpulse-agent)
           # armv7
-          (cd agent && GOARCH=arm GOARM=7 go build -trimpath -ldflags "-s -w" -o ../server-go/internal/agentbin/agents/netpulse-agent-armv7 ./cmd/netpulse-agent)
+          (cd agent && GOARCH=arm GOARM=7 go build -trimpath -ldflags "-s -w -X main.Version=$AGENT_VERSION" -o ../server-go/internal/agentbin/agents/netpulse-agent-armv7 ./cmd/netpulse-agent)
 
       - name: Build binario (linux/${{ matrix.arch }})
         working-directory: server-go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,14 +48,19 @@ jobs:
         env:
           CGO_ENABLED: 0
           GOOS: linux
+          # Versión inyectada en el binario del agente embebido. Debe coincidir
+          # con agentbin.EmbeddedAgentVersion (server-go/internal/agentbin):
+          # el campo updateAvailable de GET /api/agents compara la versión del
+          # agente conectado contra esa constante. Bumpear ambos a la vez.
+          AGENT_VERSION: "0.1.0"
         run: |
           set -e
           # amd64
-          (cd agent && GOARCH=amd64 go build -trimpath -ldflags "-s -w" -o ../server-go/internal/agentbin/agents/netpulse-agent-amd64 ./cmd/netpulse-agent)
+          (cd agent && GOARCH=amd64 go build -trimpath -ldflags "-s -w -X main.Version=$AGENT_VERSION" -o ../server-go/internal/agentbin/agents/netpulse-agent-amd64 ./cmd/netpulse-agent)
           # arm64
-          (cd agent && GOARCH=arm64 go build -trimpath -ldflags "-s -w" -o ../server-go/internal/agentbin/agents/netpulse-agent-arm64 ./cmd/netpulse-agent)
+          (cd agent && GOARCH=arm64 go build -trimpath -ldflags "-s -w -X main.Version=$AGENT_VERSION" -o ../server-go/internal/agentbin/agents/netpulse-agent-arm64 ./cmd/netpulse-agent)
           # armv7
-          (cd agent && GOARCH=arm GOARM=7 go build -trimpath -ldflags "-s -w" -o ../server-go/internal/agentbin/agents/netpulse-agent-armv7 ./cmd/netpulse-agent)
+          (cd agent && GOARCH=arm GOARM=7 go build -trimpath -ldflags "-s -w -X main.Version=$AGENT_VERSION" -o ../server-go/internal/agentbin/agents/netpulse-agent-armv7 ./cmd/netpulse-agent)
 
       - name: Valida config goreleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      # Versión del agente embebido en el servidor. Se inyecta igual en el
+      # binario del agente (main.Version) y en el servidor
+      # (agentbin.EmbeddedAgentVersion vía .goreleaser.yaml): alimenta el
+      # campo updateAvailable de GET /api/agents. Bumpear en un solo sitio.
+      AGENT_VERSION: "0.1.0"
     steps:
       - uses: actions/checkout@v4
 
@@ -48,11 +54,6 @@ jobs:
         env:
           CGO_ENABLED: 0
           GOOS: linux
-          # Versión inyectada en el binario del agente embebido. Debe coincidir
-          # con agentbin.EmbeddedAgentVersion (server-go/internal/agentbin):
-          # el campo updateAvailable de GET /api/agents compara la versión del
-          # agente conectado contra esa constante. Bumpear ambos a la vez.
-          AGENT_VERSION: "0.1.0"
         run: |
           set -e
           # amd64

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,10 @@ legacy/server-node/.env
 .DS_Store
 
 # Binarios compilados
-netpulse-agent*
+# (solo el binario local de `go build` en el módulo agent; el patrón `netpulse-agent*`
+# coincidía con el directorio fuente agent/cmd/netpulse-agent/ e ignoraba su código)
+netpulse-agent
+agent/netpulse-agent
 server-go/netpulse
 server-go/netpulse-server
 collector/netpulse-collector

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,7 @@ builds:
       - -s
       - -w
       - "-X github.com/gnacho/netpulse/server-go/internal/updater.BuildCommit={{.ShortCommit}}"
+      - "-X github.com/gnacho/netpulse/server-go/internal/agentbin.EmbeddedAgentVersion={{ .Env.AGENT_VERSION }}"
 
   - id: netpulse-collector
     dir: collector

--- a/agent/cmd/netpulse-agent/main.go
+++ b/agent/cmd/netpulse-agent/main.go
@@ -261,6 +261,9 @@ func run() error {
 			if ev.Name == "apply" && ev.Data != "" {
 				go handleApply(cfg, ex, transport, ev.Data)
 			}
+			if ev.Name == "upgrade" {
+				go handleUpgrade(cfg, transport, ev.Data)
+			}
 			slog.Debug("[netpulse-agent] SSE evento", "event", ev.Name)
 		})
 		sse.SetLogger(func(format string, args ...any) { slog.Debug("[netpulse-agent] "+fmt.Sprintf(format, args...)) })

--- a/agent/cmd/netpulse-agent/upgrade.go
+++ b/agent/cmd/netpulse-agent/upgrade.go
@@ -1,0 +1,193 @@
+// upgrade.go — Fase 6.3 (issue #243): self-update del agente.
+//
+// Al recibir el evento SSE "upgrade", el agente descarga el binario embebido
+// del propio servidor (GET /api/agents/{slug}/binary?arch=...), lo verifica,
+// lo intercambia atómicamente por el binario en marcha y reinicia su servicio
+// procd (el proceso actual muere y procd relanza el binario nuevo). El
+// resultado se reporta a POST /api/agents/{slug}/upgrade-result ANTES del
+// reinicio (que mata este proceso).
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"log/slog"
+)
+
+// Ruta del binario en marcha (instalación estándar) y del init script procd.
+// install-agent.sh los fija así; la variante --tmp usa /tmp/netpulse-agent
+// (se resuelve dinámicamente con os.Executable en currentBinPath).
+const (
+	defaultBinPath  = "/usr/sbin/netpulse-agent"
+	agentInitScript = "/etc/init.d/netpulse-agent"
+	// tmpBinPath: descarga temporal del binario nuevo antes del swap atómico.
+	tmpBinPath = "/tmp/netpulse-agent.new"
+)
+
+// netpulseArch traduce runtime.GOARCH al nombre de binario que sirve el
+// servidor (agentbin: amd64/arm64/armv7). GOARCH "arm" (armv7) no casa con
+// el sufijo del fichero embebido, así que se normaliza.
+func netpulseArch(goarch string) string {
+	switch goarch {
+	case "arm":
+		return "armv7"
+	case "amd64", "arm64":
+		return goarch
+	default:
+		return goarch
+	}
+}
+
+// currentBinPath devuelve la ruta del binario del agente en marcha, para
+// intercambiarlo en el sitio correcto (resuelve la variante --tmp en RAM).
+func currentBinPath() string {
+	if exe, err := os.Executable(); err == nil && exe != "" {
+		return exe
+	}
+	return defaultBinPath
+}
+
+// downloadBinary descarga el binario desde url (con Bearer token) y lo deja
+// en dest con permisos 0755. Error si la petición no es 200 o el cuerpo está
+// vacío. Extraída a función propia para poder testearla con httptest.
+func downloadBinary(ctx context.Context, hc *http.Client, url, token, dest string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	res, err := hc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("binario no disponible (HTTP %d)", res.StatusCode)
+	}
+
+	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	n, copyErr := io.Copy(f, res.Body)
+	closeErr := f.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if n == 0 {
+		return errors.New("binario vacío")
+	}
+	if err := os.Chmod(dest, 0o755); err != nil {
+		return err
+	}
+	return nil
+}
+
+// swapBinary intercambia atómicamente src por dst. Si src y dst están en
+// distintos filesystems (p. ej. /tmp tmpfs → /usr/sbin overlay en OpenWrt),
+// os.Rename falla con EXDEV y se cae a copiar a un temp en el dir de destino
+// y renombrar allí (atómico dentro de ese filesystem). El rename sobre un
+// binario en ejecución es seguro en Linux: el proceso vivo conserva su inode.
+func swapBinary(src, dst string) error {
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	tmp := dst + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o755); err != nil {
+		return err
+	}
+	return os.Rename(tmp, dst)
+}
+
+// restartService reinicia el servicio procd del agente. Sin init script,
+// devuelve error (no hay forma fiable de reiniciarse a sí mismo).
+func restartService() error {
+	if _, err := os.Stat(agentInitScript); err != nil {
+		return fmt.Errorf("init script %s no encontrado", agentInitScript)
+	}
+	cmd := exec.Command(agentInitScript, "restart")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%s restart: %v (%s)", agentInitScript, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// reportUpgradeResult POSTea el resultado del upgrade al servidor.
+func reportUpgradeResult(cfg config, transport http.RoundTripper, ok bool, errMsg string) {
+	m := map[string]any{"slug": cfg.slug, "ok": ok}
+	if errMsg != "" {
+		m["error"] = errMsg
+	}
+	body, _ := json.Marshal(m)
+	req, err := http.NewRequest("POST", cfg.server+"/api/agents/"+cfg.slug+"/upgrade-result", strings.NewReader(string(body)))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+cfg.token)
+	hc := &http.Client{Transport: transport, Timeout: 10 * time.Second}
+	resp, err := hc.Do(req)
+	if err != nil {
+		slog.Warn("[netpulse-agent] upgrade: result POST falló", "err", err)
+		return
+	}
+	resp.Body.Close()
+}
+
+// handleUpgrade procesa el evento SSE "upgrade": descarga el binario, lo
+// verifica, hace el swap atómico, reporta el resultado y reinicia el servicio
+// (que mata este proceso; procd relanza el binario nuevo).
+func handleUpgrade(cfg config, transport http.RoundTripper, data string) {
+	arch := runtime.GOARCH
+	if data != "" {
+		var p struct {
+			Arch string `json:"arch"`
+		}
+		if err := json.Unmarshal([]byte(data), &p); err == nil && p.Arch != "" {
+			arch = p.Arch
+		}
+	}
+	arch = netpulseArch(arch)
+
+	slog.Info("[netpulse-agent] upgrade iniciado", "slug", cfg.slug, "arch", arch)
+	url := cfg.server + "/api/agents/" + cfg.slug + "/binary?arch=" + arch
+	hc := &http.Client{Transport: transport, Timeout: 2 * time.Minute}
+
+	if err := downloadBinary(context.Background(), hc, url, cfg.token, tmpBinPath); err != nil {
+		slog.Error("[netpulse-agent] upgrade: descarga falló", "err", err)
+		reportUpgradeResult(cfg, transport, false, err.Error())
+		return
+	}
+
+	dst := currentBinPath()
+	if err := swapBinary(tmpBinPath, dst); err != nil {
+		slog.Error("[netpulse-agent] upgrade: swap falló", "err", err, "dst", dst)
+		reportUpgradeResult(cfg, transport, false, err.Error())
+		return
+	}
+
+	slog.Info("[netpulse-agent] upgrade: binario intercambiado, reiniciando servicio", "dst", dst)
+	// Reportar ANTES de reiniciar: el reinicio mata este proceso.
+	reportUpgradeResult(cfg, transport, true, "")
+	if err := restartService(); err != nil {
+		slog.Warn("[netpulse-agent] upgrade: reinicio falló", "err", err)
+	}
+}

--- a/agent/cmd/netpulse-agent/upgrade_test.go
+++ b/agent/cmd/netpulse-agent/upgrade_test.go
@@ -1,0 +1,119 @@
+// upgrade_test.go — Fase 6.3 (issue #243): tests de la lógica de self-update
+// del agente (mapeo de arquitectura, descarga+verificación y swap atómico).
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNetpulseArch(t *testing.T) {
+	cases := map[string]string{
+		"amd64":  "amd64",
+		"arm64":  "arm64",
+		"arm":    "armv7", // GOARCH arm (GOARM=7) → sufijo de binario embebido
+		"mips":   "mips",  // desconocido: se conserva
+	}
+	for in, want := range cases {
+		if got := netpulseArch(in); got != want {
+			t.Fatalf("netpulseArch(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// fakeBinaryServer sirve un binario de prueba y ejercita auth/status/empty.
+func fakeBinaryServer(t *testing.T, token string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/missing":
+			w.WriteHeader(http.StatusNotFound)
+			return
+		case "/empty":
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("\x7fELF-fake-binary-content"))
+	}))
+}
+
+func TestDownloadBinaryOK(t *testing.T) {
+	srv := fakeBinaryServer(t, "tok")
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "agent.new")
+	hc := &http.Client{}
+	if err := downloadBinary(t.Context(), hc, srv.URL+"/binary", "tok", dest); err != nil {
+		t.Fatalf("downloadBinary: %v", err)
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "\x7fELF-fake-binary-content" {
+		t.Fatalf("contenido: %q", data)
+	}
+	st, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if st.Mode().Perm() != 0o755 {
+		t.Fatalf("permisos: %o, want 755", st.Mode().Perm())
+	}
+}
+
+func TestDownloadBinaryAuth404Empty(t *testing.T) {
+	srv := fakeBinaryServer(t, "tok")
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "agent.new")
+	hc := &http.Client{}
+
+	// Token inválido → 401 → error.
+	if err := downloadBinary(t.Context(), hc, srv.URL+"/binary", "wrong", dest); err == nil {
+		t.Fatal("token inválido: quiero error")
+	}
+	// 404 → error.
+	if err := downloadBinary(t.Context(), hc, srv.URL+"/missing", "tok", dest); err == nil {
+		t.Fatal("404: quiero error")
+	}
+	// Cuerpo vacío → error (verificación de no-vacío).
+	if err := downloadBinary(t.Context(), hc, srv.URL+"/empty", "tok", dest); err == nil {
+		t.Fatal("body vacío: quiero error")
+	}
+}
+
+func TestSwapBinary(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+
+	if err := os.WriteFile(src, []byte("nuevo-binario"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := swapBinary(src, dst); err != nil {
+		t.Fatalf("swapBinary: %v", err)
+	}
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("ReadFile dst: %v", err)
+	}
+	if string(data) != "nuevo-binario" {
+		t.Fatalf("contenido dst: %q", data)
+	}
+	st, _ := os.Stat(dst)
+	if st.Mode().Perm() != 0o755 {
+		t.Fatalf("permisos dst: %o, want 755", st.Mode().Perm())
+	}
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Fatal("src debe desaparecer tras el swap")
+	}
+}

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -526,7 +526,8 @@
       "upgradeSent": "Update sent",
       "upgradeNotConnected": "Agent not connected",
       "upgradeFail": "Could not update",
-      "upgradeTip": "Update from v{{version}} to the server version"
+      "upgradeTip": "Update from v{{version}} to the server version",
+      "downBanner": "Agent is down — reinstall it from the router detail"
     },
     "colClients": "Clients",
     "colCpu": "CPU",

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -849,7 +849,12 @@
       "save": "Save",
       "saving": "Saving…",
       "typeManaged": "Managed switch",
-      "typeExternal": "External"
+      "typeExternal": "External",
+      "rotateKey": "Rotate",
+      "rotateKeyTitle": "Rotate server SSH key?",
+      "rotateKeyCaption": "A new keypair will be generated and the old one will stop working immediately. You must re-authorize the new public key on every router. This cannot be undone.",
+      "rotateKeyConfirm": "Rotate key",
+      "rotating": "Rotating…"
     },
     "overrides": {
       "title": "Topology — manual tagging",

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -440,7 +440,7 @@
     "info": {
       "access": "Access",
       "copied": "Command copied",
-      "copySsh": "SSH (copy command)",
+      "copySsh": "SSH (copy)",
       "firmwareBase": "(base {{base}})",
       "firmwareTarget": "Target: {{target}}",
       "lastReboot": "Last reboot",

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -447,7 +447,16 @@
       "openLuci": "Open LuCI",
       "timezone": "Timezone",
       "title": "Information",
-      "updated": "Up to date"
+      "updated": "Up to date",
+      "reinstall": "Reinstall agent",
+      "reinstalling": "Reinstalling…",
+      "reinstalled": "Reinstalled",
+      "reinstallRetry": "Retry reinstall",
+      "reinstallTip": "Reinstall the agent on this router (binary, config and service) via SSH. Use this if the agent was removed by a firmware update or manual uninstall.",
+      "reinstallConfirm": "Reinstall the agent on {{router}}? The current agent (if any) will be replaced and its token rotated.",
+      "reinstallDone": "Agent reinstalled and reporting again.",
+      "reinstallPending": "Agent installed; waiting for it to report (up to 40s).",
+      "reinstallFail": "Reinstall failed"
     },
     "latency": {
       "24h": "Latency 24 h",

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -442,6 +442,7 @@
       "copied": "Command copied",
       "copySsh": "SSH (copy command)",
       "firmwareBase": "(base {{base}})",
+      "firmwareTarget": "Target: {{target}}",
       "lastReboot": "Last reboot",
       "openLuci": "Open LuCI",
       "timezone": "Timezone",
@@ -529,6 +530,8 @@
     "comparison": "Comparison",
     "comparisonSub": "Current metrics per router",
     "firmwareAvailable": "Available: {{version}}",
+    "firmwareOutdated": "Outdated",
+    "firmwareTargetHint": "Target: {{target}}",
     "gatewayLatency": "Gateway latency",
     "highTemp": "High temperature: {{temp}} °C · ventilation recommended",
     "mainGateway": "Main gateway",
@@ -860,7 +863,10 @@
       "rotateKeyTitle": "Rotate server SSH key?",
       "rotateKeyCaption": "A new keypair will be generated and the old one will stop working immediately. You must re-authorize the new public key on every router. This cannot be undone.",
       "rotateKeyConfirm": "Rotate key",
-      "rotating": "Rotating…"
+      "rotating": "Rotating…",
+      "firmwareTarget": "Firmware target version",
+      "firmwareTargetPlaceholder": "e.g. 25.12.5",
+      "firmwareTargetHint": "Optional. If the installed firmware doesn't match this version, NetPulse alerts."
     },
     "overrides": {
       "title": "Topology — manual tagging",

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -515,7 +515,7 @@
       "freshTip": "netpulse-agent v{{version}} · pushes every 15 s",
       "freshTipUnknown": "netpulse-agent · pushes every 15 s",
       "stale": "Agent down",
-      "staleTip": "No data from agent — polling via SSH",
+      "staleTip": "Agent registered but not responding — reinstall it from the router detail",
       "rearm": "Rearm",
       "rearming": "Restarting…",
       "rearmOk": "Agent rearmed",
@@ -527,7 +527,10 @@
       "upgradeNotConnected": "Agent not connected",
       "upgradeFail": "Could not update",
       "upgradeTip": "Update from v{{version}} to the server version",
-      "downBanner": "Agent is down — reinstall it from the router detail"
+      "downBanner": "Agent is down — reinstall it from the router detail",
+      "notInstalled": "Agent not installed",
+      "notInstalledTip": "This router is configured to run agent-only, but the agent is not installed. Reinstall it from the router detail.",
+      "notInstalledBanner": "Agent not installed — reinstall it from the router detail"
     },
     "colClients": "Clients",
     "colCpu": "CPU",

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -510,7 +510,13 @@
       "rearming": "Restarting…",
       "rearmOk": "Agent rearmed",
       "rearmPending": "Restarted; waiting for the first push",
-      "rearmFail": "Could not rearm"
+      "rearmFail": "Could not rearm",
+      "upgrade": "Update agent",
+      "upgrading": "Sending…",
+      "upgradeSent": "Update sent",
+      "upgradeNotConnected": "Agent not connected",
+      "upgradeFail": "Could not update",
+      "upgradeTip": "Update from v{{version}} to the server version"
     },
     "colClients": "Clients",
     "colCpu": "CPU",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -447,7 +447,16 @@
       "openLuci": "Abrir LuCI",
       "timezone": "Zona horaria",
       "title": "Información",
-      "updated": "Actualizado"
+      "updated": "Actualizado",
+      "reinstall": "Reinstalar agente",
+      "reinstalling": "Reinstalando…",
+      "reinstalled": "Reinstalado",
+      "reinstallRetry": "Reintentar reinstall",
+      "reinstallTip": "Reinstala el agente en este router (binario, config y servicio) vía SSH. Úsalo si el agente fue borrado por una actualización de firmware o una desinstalación manual.",
+      "reinstallConfirm": "¿Reinstalar el agente en {{router}}? El agente actual (si lo hay) será sustituido y su token rotado.",
+      "reinstallDone": "Agente reinstalado y empujando de nuevo.",
+      "reinstallPending": "Agente instalado; esperando a que empuje (hasta 40 s).",
+      "reinstallFail": "Fallo al reinstalar"
     },
     "latency": {
       "24h": "Latencia 24 h",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -442,6 +442,7 @@
       "copied": "Comando copiado",
       "copySsh": "SSH (copiar comando)",
       "firmwareBase": "(base {{base}})",
+      "firmwareTarget": "Objetivo: {{target}}",
       "lastReboot": "Último reinicio",
       "openLuci": "Abrir LuCI",
       "timezone": "Zona horaria",
@@ -529,6 +530,8 @@
     "comparison": "Comparativa",
     "comparisonSub": "Métricas actuales por equipo",
     "firmwareAvailable": "Disponible: {{version}}",
+    "firmwareOutdated": "Desactualizado",
+    "firmwareTargetHint": "Objetivo: {{target}}",
     "gatewayLatency": "Latencia al gateway",
     "highTemp": "Temperatura alta: {{temp}} °C · ventilación recomendada",
     "mainGateway": "Gateway principal",
@@ -860,7 +863,10 @@
       "rotateKeyTitle": "¿Rotar la clave SSH del servidor?",
       "rotateKeyCaption": "Se generará un par nuevo y la clave anterior dejará de funcionar de inmediato. Debes reautorizar la nueva clave pública en cada router. No se puede deshacer.",
       "rotateKeyConfirm": "Rotar clave",
-      "rotating": "Rotando…"
+      "rotating": "Rotando…",
+      "firmwareTarget": "Versión de firmware objetivo",
+      "firmwareTargetPlaceholder": "p. ej. 25.12.5",
+      "firmwareTargetHint": "Opcional. Si el firmware instalado no coincide con esta versión, NetPulse lo avisa."
     },
     "overrides": {
       "title": "Topología — etiquetado manual",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -849,7 +849,12 @@
       "save": "Guardar",
       "saving": "Guardando…",
       "typeManaged": "Switch managed",
-      "typeExternal": "Externo"
+      "typeExternal": "Externo",
+      "rotateKey": "Rotar",
+      "rotateKeyTitle": "¿Rotar la clave SSH del servidor?",
+      "rotateKeyCaption": "Se generará un par nuevo y la clave anterior dejará de funcionar de inmediato. Debes reautorizar la nueva clave pública en cada router. No se puede deshacer.",
+      "rotateKeyConfirm": "Rotar clave",
+      "rotating": "Rotando…"
     },
     "overrides": {
       "title": "Topología — etiquetado manual",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -526,7 +526,8 @@
       "upgradeSent": "Actualización enviada",
       "upgradeNotConnected": "Agente no conectado",
       "upgradeFail": "No se pudo actualizar",
-      "upgradeTip": "Actualizar de v{{version}} a la versión del servidor"
+      "upgradeTip": "Actualizar de v{{version}} a la versión del servidor",
+      "downBanner": "Agente caído — reinstálalo desde el detalle"
     },
     "colClients": "Clientes",
     "colCpu": "CPU",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -440,7 +440,7 @@
     "info": {
       "access": "Acceso",
       "copied": "Comando copiado",
-      "copySsh": "SSH (copiar comando)",
+      "copySsh": "SSH (copiar)",
       "firmwareBase": "(base {{base}})",
       "firmwareTarget": "Objetivo: {{target}}",
       "lastReboot": "Último reinicio",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -515,7 +515,7 @@
       "freshTip": "netpulse-agent v{{version}} · empuja cada 15 s",
       "freshTipUnknown": "netpulse-agent · empuja cada 15 s",
       "stale": "Agente caído",
-      "staleTip": "Sin datos del agente — sondeando por SSH",
+      "staleTip": "Agente registrado pero sin respuesta — reinstálalo desde el detalle",
       "rearm": "Rearmar",
       "rearming": "Reiniciando…",
       "rearmOk": "Agente rearmado",
@@ -527,7 +527,10 @@
       "upgradeNotConnected": "Agente no conectado",
       "upgradeFail": "No se pudo actualizar",
       "upgradeTip": "Actualizar de v{{version}} a la versión del servidor",
-      "downBanner": "Agente caído — reinstálalo desde el detalle"
+      "downBanner": "Agente caído — reinstálalo desde el detalle",
+      "notInstalled": "Agente no instalado",
+      "notInstalledTip": "El router está configurado para funcionar solo con agente, pero el agente no está instalado. Reinstálalo desde el detalle.",
+      "notInstalledBanner": "Agente no instalado — reinstálalo desde el detalle"
     },
     "colClients": "Clientes",
     "colCpu": "CPU",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -510,7 +510,13 @@
       "rearming": "Reiniciando…",
       "rearmOk": "Agente rearmado",
       "rearmPending": "Reiniciado; esperando el primer push",
-      "rearmFail": "No se pudo rearmar"
+      "rearmFail": "No se pudo rearmar",
+      "upgrade": "Actualizar agente",
+      "upgrading": "Enviando…",
+      "upgradeSent": "Actualización enviada",
+      "upgradeNotConnected": "Agente no conectado",
+      "upgradeFail": "No se pudo actualizar",
+      "upgradeTip": "Actualizar de v{{version}} a la versión del servidor"
     },
     "colClients": "Clientes",
     "colCpu": "CPU",

--- a/app/src/components/RouterCard.tsx
+++ b/app/src/components/RouterCard.tsx
@@ -71,7 +71,7 @@ export function RouterCard({ router, index = 0, className }: RouterCardProps) {
                 <span className="shrink-0 rounded-full bg-accent-soft px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent">
                   {roleLabel(router.roleBadge)}
                 </span>
-                <AgentBadge agent={agent} className="shrink-0" />
+                <AgentBadge agent={agent} agentOnly={router.agentOnly} className="shrink-0" />
               </div>
               <div className="truncate text-caption text-text-muted">{router.modelShort}</div>
             </div>

--- a/app/src/components/routers/AgentBadge.tsx
+++ b/app/src/components/routers/AgentBadge.tsx
@@ -6,18 +6,33 @@ import { cn } from '@/lib/utils'
 interface AgentBadgeProps {
   /** Agente del router; undefined/null → no se renderiza nada (demo, sin agentes) */
   agent: AgentInfo | undefined
+  /**
+   * Router configurado para funcionar solo con agente (sin SSH). Con esto hay
+   * certeza: si `agent` es undefined y `agentOnly`, el agente NO está instalado
+   * (rojo); sin agentOnly, simplemente no hay agente (nada que avisar).
+   */
+  agentOnly?: boolean
   className?: string
 }
 
 /**
  * Badge "Agente" (Fase 3 piloto):
  * - `fresh` → tono info discreto, tooltip con versión y cadencia de push.
- * - caído  → tono warn pulsante, tooltip "sondeando por SSH" (las alertas de
- *   categoría system ya narran la caída/recuperación; aquí solo el estado).
+ * - caído  → rojo, tooltip "agente registrado pero no responde" (las alertas
+ *   de categoría system ya narran la caída/recuperación; aquí solo el estado).
+ * - no instalado (agentOnly sin agente) → rojo, tooltip "reinstalar desde el
+ *   detalle".
  */
-export function AgentBadge({ agent, className }: AgentBadgeProps) {
+export function AgentBadge({ agent, agentOnly, className }: AgentBadgeProps) {
   const { t } = useTranslation()
-  if (!agent) return null
+  if (!agent && !agentOnly) return null
+  if (!agent) {
+    return (
+      <span title={t('routers.agent.notInstalledTip')} className={cn('inline-flex', className)}>
+        <StatusPill tone="danger" label={t('routers.agent.notInstalled')} pulse />
+      </span>
+    )
+  }
   const title = agent.fresh
     ? agent.version
       ? t('routers.agent.freshTip', { version: agent.version })
@@ -26,7 +41,7 @@ export function AgentBadge({ agent, className }: AgentBadgeProps) {
   return (
     <span title={title} className={cn('inline-flex', className)}>
       <StatusPill
-        tone={agent.fresh ? 'info' : 'warn'}
+        tone={agent.fresh ? 'info' : 'danger'}
         label={agent.fresh ? t('routers.agent.badge') : t('routers.agent.stale')}
         pulse={!agent.fresh}
       />

--- a/app/src/components/routers/AgentUpgradeButton.tsx
+++ b/app/src/components/routers/AgentUpgradeButton.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Loader2 } from 'lucide-react'
+import { useNetPulse } from '@/data/DataProvider'
+import { useAuth } from '@/data/AuthContext'
+import type { AgentInfo } from '@/data/types'
+import { cn } from '@/lib/utils'
+
+interface AgentUpgradeButtonProps {
+  agent: AgentInfo | undefined
+  className?: string
+}
+
+type UpgradeState = 'idle' | 'busy' | 'sent' | 'not_connected' | 'fail'
+
+/**
+ * Botón «Actualizar agente» (Fase 6.3, issue #243): solo aparece si el agente
+ * reporta una versión distinta de la del binario embebido (updateAvailable) y
+ * la sesión es admin (la API exige admin). POST /api/agents/{slug}/upgrade
+ * ordena al agente descargar el binario nuevo, intercambiarlo y reiniciarse.
+ * Refleja el resultado real del envío:
+ *   sent          → 202, comando enviado por SSE (el agente se reinicia solo)
+ *   not_connected → 409, el agente no está conectado por SSE
+ *   fail          → petición fallida (red, 4xx/5xx)
+ * El estado sent/not_connected/fail dura 6 s y vuelve a idle.
+ */
+export function AgentUpgradeButton({ agent, className }: AgentUpgradeButtonProps) {
+  const { t } = useTranslation()
+  const { upgradeAgent } = useNetPulse()
+  const auth = useAuth()
+  const [state, setState] = useState<UpgradeState>('idle')
+
+  if (!agent || !agent.updateAvailable) return null
+  if (auth?.role !== 'admin') return null
+
+  const label =
+    state === 'busy' ? t('routers.agent.upgrading')
+    : state === 'sent' ? t('routers.agent.upgradeSent')
+    : state === 'not_connected' ? t('routers.agent.upgradeNotConnected')
+    : state === 'fail' ? t('routers.agent.upgradeFail')
+    : t('routers.agent.upgrade')
+
+  const onClick = async () => {
+    if (state === 'busy') return
+    setState('busy')
+    const res = await upgradeAgent(agent.slug)
+    const next: UpgradeState = res === 'sent' ? 'sent' : res === 'not_connected' ? 'not_connected' : 'fail'
+    setState(next)
+    window.setTimeout(() => setState('idle'), 6000)
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={state === 'busy'}
+      title={t('routers.agent.upgradeTip', { version: agent.version ?? '?' })}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[11px] font-semibold transition-opacity hover:opacity-90 disabled:opacity-50',
+        state === 'sent' ? 'bg-ok text-canvas'
+        : state === 'fail' || state === 'not_connected' ? 'bg-danger text-canvas'
+        : 'bg-accent text-canvas',
+        className,
+      )}
+    >
+      {state === 'busy' && <Loader2 className="h-3 w-3 animate-spin" />}
+      {label}
+    </button>
+  )
+}

--- a/app/src/components/routers/FleetCard.tsx
+++ b/app/src/components/routers/FleetCard.tsx
@@ -63,6 +63,7 @@ export function FleetCard({ router, index = 0, refreshKey = 0 }: FleetCardProps)
   const extras = isDemo ? getRouterExtras(router.id) : EMPTY_EXTRAS
   const warn = router.status === 'warn'
   const agentDown = agent !== undefined && !agent.fresh
+  const agentMissing = agent === undefined && router.agentOnly
   const reduce = useReducedMotion()
   const isGateway = router.id === 'flint2'
   const traffic = router.sparkline.map((v, i) => ({ i, v }))
@@ -101,6 +102,14 @@ export function FleetCard({ router, index = 0, refreshKey = 0 }: FleetCardProps)
           </div>
         )}
 
+        {/* Banner de agente no instalado (router agent-only sin agente registrado) */}
+        {agentMissing && (
+          <div className="mb-4 -mx-6 -mt-6 flex items-center gap-2 border-b border-danger/30 bg-danger/10 px-6 py-2.5">
+            <AlertTriangle className="h-4 w-4 shrink-0 text-danger" strokeWidth={1.75} />
+            <span className="text-caption font-semibold text-danger">{t('routers.agent.notInstalledBanner')}</span>
+          </div>
+        )}
+
         {/* Fila superior */}
         <div className="flex items-start justify-between gap-4">
           <div className="flex min-w-0 items-center gap-3.5">
@@ -118,7 +127,7 @@ export function FleetCard({ router, index = 0, refreshKey = 0 }: FleetCardProps)
             <div className="min-w-0">
               <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
                 <h3 className="truncate font-display text-h2 text-text-primary">{router.name}</h3>
-                <AgentBadge agent={agent} />
+                <AgentBadge agent={agent} agentOnly={router.agentOnly} />
               </div>
               <div className="truncate text-caption text-text-muted">
                 {isGateway ? 'GL.iNet Flint 2 · GL-MT6000' : `OpenWrt · ${router.modelShort}`}

--- a/app/src/components/routers/FleetCard.tsx
+++ b/app/src/components/routers/FleetCard.tsx
@@ -162,6 +162,14 @@ export function FleetCard({ router, index = 0, refreshKey = 0 }: FleetCardProps)
                 title={k === 'Firmware' && extras.firmwareAvailable ? t('routers.firmwareAvailable', { version: extras.firmwareAvailable }) : undefined}
               >
                 {v}
+                {k === 'Firmware' && router.firmwareOutdated && (
+                  <span
+                    className="ml-1.5 rounded-full bg-warn/10 px-1.5 py-0.5 text-[10px] font-semibold text-warn"
+                    title={router.firmwareTarget ? t('routers.firmwareTargetHint', { target: router.firmwareTarget }) : undefined}
+                  >
+                    {t('routers.firmwareOutdated')}
+                  </span>
+                )}
                 {k === 'Firmware' && extras.firmwareAvailable && (
                   <span className="ml-1.5 rounded-full bg-warn/10 px-1.5 py-0.5 text-[10px] font-semibold text-warn">
                     {extras.firmwareAvailable}

--- a/app/src/components/routers/FleetCard.tsx
+++ b/app/src/components/routers/FleetCard.tsx
@@ -62,6 +62,7 @@ export function FleetCard({ router, index = 0, refreshKey = 0 }: FleetCardProps)
   const agent = useAgentFor(router.id)
   const extras = isDemo ? getRouterExtras(router.id) : EMPTY_EXTRAS
   const warn = router.status === 'warn'
+  const agentDown = agent !== undefined && !agent.fresh
   const reduce = useReducedMotion()
   const isGateway = router.id === 'flint2'
   const traffic = router.sparkline.map((v, i) => ({ i, v }))
@@ -89,6 +90,14 @@ export function FleetCard({ router, index = 0, refreshKey = 0 }: FleetCardProps)
             <span className="text-caption font-semibold text-warn">
               {t('routers.highTemp', { temp: router.temp })}
             </span>
+          </div>
+        )}
+
+        {/* Banner de agente caído (el router tiene agente registrado pero no responde) */}
+        {agentDown && (
+          <div className="mb-4 -mx-6 -mt-6 flex items-center gap-2 border-b border-warn/30 bg-warn/10 px-6 py-2.5">
+            <AlertTriangle className="h-4 w-4 shrink-0 text-warn" strokeWidth={1.75} />
+            <span className="text-caption font-semibold text-warn">{t('routers.agent.downBanner')}</span>
           </div>
         )}
 

--- a/app/src/components/routers/FleetTable.tsx
+++ b/app/src/components/routers/FleetTable.tsx
@@ -166,7 +166,7 @@ export function FleetTable({ refreshKey = 0 }: { refreshKey?: number }) {
                       <span>
                         <span className="flex items-center gap-2">
                           <span className="font-medium text-text-primary">{r.name}</span>
-                          <AgentBadge agent={agentBySlug.get(r.id)} />
+                          <AgentBadge agent={agentBySlug.get(r.id)} agentOnly={r.agentOnly} />
                         </span>
                         <span className="block text-caption text-text-muted">{r.modelShort}</span>
                       </span>
@@ -228,7 +228,7 @@ export function FleetTable({ refreshKey = 0 }: { refreshKey?: number }) {
                   </span>
                   <span className="min-w-0">
                     <span className="block truncate font-medium text-text-primary">{r.name}</span>
-                    <AgentBadge agent={agentBySlug.get(r.id)} className="mt-1" />
+                    <AgentBadge agent={agentBySlug.get(r.id)} agentOnly={r.agentOnly} className="mt-1" />
                   </span>
                 </span>
                 <span className="flex shrink-0 items-center gap-2">

--- a/app/src/components/routers/RouterDetailHeader.tsx
+++ b/app/src/components/routers/RouterDetailHeader.tsx
@@ -84,7 +84,7 @@ export function RouterDetailHeader({ router }: { router: Router }) {
                   animate={{ opacity: 1, scale: 1 }}
                   transition={{ duration: 0.2, delay: 0.15 + pills.length * 0.06 }}
                 >
-                  <AgentBadge agent={agent} />
+                  <AgentBadge agent={agent} agentOnly={router.agentOnly} />
                 </motion.span>
               )}
               {agent && !agent.fresh && (

--- a/app/src/components/routers/RouterDetailHeader.tsx
+++ b/app/src/components/routers/RouterDetailHeader.tsx
@@ -8,6 +8,7 @@ import { HealthRing } from '@/components/HealthRing'
 import { StatusPill } from '@/components/StatusPill'
 import { AgentBadge } from '@/components/routers/AgentBadge'
 import { AgentRearmButton } from '@/components/routers/AgentRearmButton'
+import { AgentUpgradeButton } from '@/components/routers/AgentUpgradeButton'
 import { useAgentFor } from '@/hooks/useAgentFor'
 import { cn } from '@/lib/utils'
 
@@ -93,6 +94,15 @@ export function RouterDetailHeader({ router }: { router: Router }) {
                   transition={{ duration: 0.2, delay: 0.15 + (pills.length + 1) * 0.06 }}
                 >
                   <AgentRearmButton agent={agent} />
+                </motion.span>
+              )}
+              {agent && agent.updateAvailable && (
+                <motion.span
+                  initial={reduce ? false : { opacity: 0, scale: 0.9 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={{ duration: 0.2, delay: 0.15 + (pills.length + 2) * 0.06 }}
+                >
+                  <AgentUpgradeButton agent={agent} />
                 </motion.span>
               )}
             </div>

--- a/app/src/components/routers/RouterInfo.tsx
+++ b/app/src/components/routers/RouterInfo.tsx
@@ -170,7 +170,9 @@ export function RouterInfo({ router, extras }: { router: Router; extras?: Router
                 ? 'border-ok/40 bg-ok/10 text-ok'
                 : reinstallState === 'fail'
                   ? 'border-danger/40 bg-danger/10 text-danger'
-                  : 'border-danger/40 bg-danger/10 text-danger hover:border-danger hover:bg-danger/20'
+                  : agent.fresh
+                    ? 'border-border text-text-secondary hover:border-accent/40 hover:text-accent'
+                    : 'border-danger/40 bg-danger/10 text-danger hover:border-danger hover:bg-danger/20'
             }`}
           >
             <RotateCcw className={`h-3.5 w-3.5 ${reinstallState === 'busy' ? 'animate-spin' : ''}`} strokeWidth={1.75} />

--- a/app/src/components/routers/RouterInfo.tsx
+++ b/app/src/components/routers/RouterInfo.tsx
@@ -27,6 +27,7 @@ export function RouterInfo({ router, extras }: { router: Router; extras?: Router
   const { isDemo, reinstallAgent } = useNetPulse()
   const auth = useAuth()
   const agent = useAgentFor(router.id)
+  const agentMissing = agent === undefined && router.agentOnly
   const ex = extras ?? (isDemo ? getRouterExtras(router.id) : EMPTY_EXTRAS)
   const reduce = useReducedMotion()
   const [toast, setToast] = useState(false)
@@ -73,11 +74,11 @@ export function RouterInfo({ router, extras }: { router: Router; extras?: Router
   }
 
   const reinstall = async () => {
-    if (!agent || reinstallState === 'busy') return
+    if (reinstallState === 'busy') return
     if (!window.confirm(t('routerDetail.info.reinstallConfirm', { router: router.name }))) return
     setReinstallState('busy')
     setReinstallMsg('')
-    const res = await reinstallAgent(agent.slug)
+    const res = await reinstallAgent(router.id)
     if (res && !res.error) {
       setReinstallState('done')
       setReinstallMsg(res.recovered ? t('routerDetail.info.reinstallDone') : t('routerDetail.info.reinstallPending'))
@@ -160,7 +161,7 @@ export function RouterInfo({ router, extras }: { router: Router; extras?: Router
           <Terminal className="h-3.5 w-3.5" strokeWidth={1.75} />
           {t('routerDetail.info.copySsh')}
         </button>
-        {agent && auth?.role === 'admin' && (
+        {(agent || router.agentOnly) && auth?.role === 'admin' && (
           <button
             onClick={() => void reinstall()}
             disabled={reinstallState === 'busy'}
@@ -170,9 +171,9 @@ export function RouterInfo({ router, extras }: { router: Router; extras?: Router
                 ? 'border-ok/40 bg-ok/10 text-ok'
                 : reinstallState === 'fail'
                   ? 'border-danger/40 bg-danger/10 text-danger'
-                  : agent.fresh
-                    ? 'border-border text-text-secondary hover:border-accent/40 hover:text-accent'
-                    : 'border-danger/40 bg-danger/10 text-danger hover:border-danger hover:bg-danger/20'
+                  : agentMissing || !agent?.fresh
+                    ? 'border-danger/40 bg-danger/10 text-danger hover:border-danger hover:bg-danger/20'
+                    : 'border-border text-text-secondary hover:border-accent/40 hover:text-accent'
             }`}
           >
             <RotateCcw className={`h-3.5 w-3.5 ${reinstallState === 'busy' ? 'animate-spin' : ''}`} strokeWidth={1.75} />

--- a/app/src/components/routers/RouterInfo.tsx
+++ b/app/src/components/routers/RouterInfo.tsx
@@ -49,10 +49,15 @@ export function RouterInfo({ router, extras }: { router: Router; extras?: Router
     {
       label: 'Firmware',
       node: (
-        <span className="inline-flex items-center gap-2">
-          {ex.firmware}
+        <span className="inline-flex flex-wrap items-center justify-end gap-2">
+          <span>{router.firmware ?? ex.firmware}</span>
           {ex.firmwareBase && <span className="text-text-muted">{t('routerDetail.info.firmwareBase', { base: ex.firmwareBase })}</span>}
-          {ex.firmwareUpdated ? (
+          {router.firmwareTarget && (
+            <span className="text-text-muted">{t('routerDetail.info.firmwareTarget', { target: router.firmwareTarget })}</span>
+          )}
+          {router.firmwareOutdated ? (
+            <StatusPill tone="warn" label={t('routers.firmwareOutdated')} />
+          ) : ex.firmwareUpdated ? (
             <StatusPill tone="ok" label={t('routerDetail.info.updated')} />
           ) : (
             <span title={t('routers.firmwareAvailable', { version: ex.firmwareAvailable })}>

--- a/app/src/components/routers/RouterInfo.tsx
+++ b/app/src/components/routers/RouterInfo.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Check, ExternalLink, Terminal } from 'lucide-react'
+import { Check, ExternalLink, RotateCcw, Terminal } from 'lucide-react'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
 import { fmtUptime } from '@/i18n'
@@ -9,6 +9,8 @@ import { StatusPill } from '@/components/StatusPill'
 import { getRouterExtras } from '@/components/routers/routerExtras'
 import type { RouterExtras } from '@/components/routers/routerExtras'
 import { EMPTY_EXTRAS, useNetPulse } from '@/data/DataProvider'
+import { useAuth } from '@/data/AuthContext'
+import { useAgentFor } from '@/hooks/useAgentFor'
 
 function Row({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -22,10 +24,14 @@ function Row({ label, children }: { label: string; children: React.ReactNode }) 
 /** ③ Info + Red (router-detail.md §③) — definition list + acciones ghost. */
 export function RouterInfo({ router, extras }: { router: Router; extras?: RouterExtras }) {
   const { t } = useTranslation()
-  const { isDemo } = useNetPulse()
+  const { isDemo, reinstallAgent } = useNetPulse()
+  const auth = useAuth()
+  const agent = useAgentFor(router.id)
   const ex = extras ?? (isDemo ? getRouterExtras(router.id) : EMPTY_EXTRAS)
   const reduce = useReducedMotion()
   const [toast, setToast] = useState(false)
+  const [reinstallState, setReinstallState] = useState<'idle' | 'busy' | 'done' | 'fail'>('idle')
+  const [reinstallMsg, setReinstallMsg] = useState('')
   const timer = useRef<number | null>(null)
 
   useEffect(() => () => {
@@ -41,6 +47,22 @@ export function RouterInfo({ router, extras }: { router: Router; extras?: Router
     setToast(true)
     if (timer.current) window.clearTimeout(timer.current)
     timer.current = window.setTimeout(() => setToast(false), 1800)
+  }
+
+  const reinstall = async () => {
+    if (!agent || reinstallState === 'busy') return
+    if (!window.confirm(t('routerDetail.info.reinstallConfirm', { router: router.name }))) return
+    setReinstallState('busy')
+    setReinstallMsg('')
+    const res = await reinstallAgent(agent.slug)
+    if (res && !res.error) {
+      setReinstallState('done')
+      setReinstallMsg(res.recovered ? t('routerDetail.info.reinstallDone') : t('routerDetail.info.reinstallPending'))
+    } else {
+      setReinstallState('fail')
+      setReinstallMsg(res?.error ?? t('routerDetail.info.reinstallFail'))
+    }
+    window.setTimeout(() => setReinstallState('idle'), 8000)
   }
 
   const rows: { label: string; node: React.ReactNode }[] = [
@@ -115,7 +137,33 @@ export function RouterInfo({ router, extras }: { router: Router; extras?: Router
           <Terminal className="h-3.5 w-3.5" strokeWidth={1.75} />
           {t('routerDetail.info.copySsh')}
         </button>
+        {agent && auth?.role === 'admin' && (
+          <button
+            onClick={() => void reinstall()}
+            disabled={reinstallState === 'busy'}
+            title={t('routerDetail.info.reinstallTip')}
+            className={`inline-flex h-9 items-center gap-1.5 rounded-lg border px-3 text-caption font-semibold transition-colors disabled:opacity-50 ${
+              reinstallState === 'done'
+                ? 'border-ok/40 bg-ok/10 text-ok'
+                : reinstallState === 'fail'
+                  ? 'border-danger/40 bg-danger/10 text-danger'
+                  : 'border-border text-text-secondary hover:border-accent/40 hover:text-accent'
+            }`}
+          >
+            <RotateCcw className={`h-3.5 w-3.5 ${reinstallState === 'busy' ? 'animate-spin' : ''}`} strokeWidth={1.75} />
+            {reinstallState === 'busy'
+              ? t('routerDetail.info.reinstalling')
+              : reinstallState === 'done'
+                ? t('routerDetail.info.reinstalled')
+                : reinstallState === 'fail'
+                  ? t('routerDetail.info.reinstallRetry')
+                  : t('routerDetail.info.reinstall')}
+          </button>
+        )}
       </div>
+      {reinstallMsg && reinstallState !== 'idle' && (
+        <p className={`mt-2 text-caption ${reinstallState === 'fail' ? 'text-danger' : 'text-text-muted'}`}>{reinstallMsg}</p>
+      )}
 
       {/* Toast "Comando copiado" */}
       <AnimatePresence>

--- a/app/src/components/routers/RouterInfo.tsx
+++ b/app/src/components/routers/RouterInfo.tsx
@@ -170,7 +170,7 @@ export function RouterInfo({ router, extras }: { router: Router; extras?: Router
                 ? 'border-ok/40 bg-ok/10 text-ok'
                 : reinstallState === 'fail'
                   ? 'border-danger/40 bg-danger/10 text-danger'
-                  : 'border-border text-text-secondary hover:border-accent/40 hover:text-accent'
+                  : 'border-danger/40 bg-danger/10 text-danger hover:border-danger hover:bg-danger/20'
             }`}
           >
             <RotateCcw className={`h-3.5 w-3.5 ${reinstallState === 'busy' ? 'animate-spin' : ''}`} strokeWidth={1.75} />

--- a/app/src/components/routers/RouterInfo.tsx
+++ b/app/src/components/routers/RouterInfo.tsx
@@ -39,12 +39,35 @@ export function RouterInfo({ router, extras }: { router: Router; extras?: Router
   }, [])
 
   async function copySsh() {
+    const text = `ssh root@${router.ip}`
+    let ok = false
     try {
-      await navigator.clipboard.writeText(`ssh root@${router.ip}`)
+      // Clipboard API solo funciona en contexto seguro (HTTPS/localhost);
+      // en la LAN HTTP lanza → fallback abajo.
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text)
+        ok = true
+      }
     } catch {
-      // Portapapeles no disponible (mock) — el toast igualmente confirma la acción
+      ok = false
     }
-    setToast(true)
+    if (!ok) {
+      // Fallback para HTTP: textarea oculta + execCommand('copy').
+      try {
+        const ta = document.createElement('textarea')
+        ta.value = text
+        ta.setAttribute('readonly', '')
+        ta.style.position = 'fixed'
+        ta.style.opacity = '0'
+        document.body.appendChild(ta)
+        ta.select()
+        ok = document.execCommand('copy')
+        document.body.removeChild(ta)
+      } catch {
+        ok = false
+      }
+    }
+    setToast(ok)
     if (timer.current) window.clearTimeout(timer.current)
     timer.current = window.setTimeout(() => setToast(false), 1800)
   }

--- a/app/src/data/DataProvider.tsx
+++ b/app/src/data/DataProvider.tsx
@@ -150,6 +150,12 @@ export interface NetPulseApi extends NetPulseData {
    * del envío; null si la petición falló (demo siempre null).
    */
   upgradeAgent: (slug: string) => Promise<'sent' | 'not_connected' | null>
+  /**
+   * #246: POST /api/agents/{slug}/reinstall — reinstala el agente en el router
+   * vía SSH (binario, env, servicio procd). Devuelve el resultado; null si
+   * falló (demo siempre null).
+   */
+  reinstallAgent: (slug: string) => Promise<{ recovered: boolean; token?: string; error?: string } | null>
 }
 
 // ---------------------------------------------------------------------------
@@ -727,6 +733,25 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
     }
   }, [])
 
+  const reinstallAgent = useCallback(async (slug: string): Promise<{ recovered: boolean; token?: string; error?: string } | null> => {
+    if (modeRef.current !== 'live') return null
+    try {
+      const res = await fetch(`/api/agents/${encodeURIComponent(slug)}/reinstall`, {
+        method: 'POST',
+        signal: AbortSignal.timeout(90_000),
+      })
+      if (res.status === 401) redirectLogin()
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { message?: string }
+        return { recovered: false, error: body.message ?? `HTTP ${res.status}` }
+      }
+      const json = (await res.json()) as { recovered: boolean; token?: string }
+      return { recovered: json.recovered, token: json.token }
+    } catch {
+      return { recovered: false, error: 'network' }
+    }
+  }, [])
+
   const getRouterDetail = useCallback(async (id: string): Promise<RouterDetailData | null> => {
     if (modeRef.current === 'live') {
       const res = await fetch(`/api/routers/${encodeURIComponent(id)}`)
@@ -830,8 +855,9 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
       markAllAlertsRead,
       rearmAgent,
       upgradeAgent,
+      reinstallAgent,
     }),
-    [bundle, connectionStatus, agents, isDemo, refresh, lastSnapshotAt, requestServerRefresh, getRouterDetail, getDevices, getAlerts, alertsConfig, setAlertConfig, markAlertsRead, markAllAlertsRead, rearmAgent, upgradeAgent],
+    [bundle, connectionStatus, agents, isDemo, refresh, lastSnapshotAt, requestServerRefresh, getRouterDetail, getDevices, getAlerts, alertsConfig, setAlertConfig, markAlertsRead, markAllAlertsRead, rearmAgent, upgradeAgent, reinstallAgent],
   )
 
   return <NetPulseContext.Provider value={value}>{children}</NetPulseContext.Provider>

--- a/app/src/data/DataProvider.tsx
+++ b/app/src/data/DataProvider.tsx
@@ -144,6 +144,12 @@ export interface NetPulseApi extends NetPulseData {
    * (demo siempre null: no hay agentes que rearmar).
    */
   rearmAgent: (slug: string) => Promise<{ recovered: boolean; message?: string } | null>
+  /**
+   * Fase 6.3 (issue #243): POST /api/agents/{slug}/upgrade — ordena al agente
+   * que se actualice con el binario embebido del servidor. Resuelve el estado
+   * del envío; null si la petición falló (demo siempre null).
+   */
+  upgradeAgent: (slug: string) => Promise<'sent' | 'not_connected' | null>
 }
 
 // ---------------------------------------------------------------------------
@@ -699,6 +705,28 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
     [],
   )
 
+  /**
+   * Fase 6.3 (issue #243): ordena el self-update del agente. La API devuelve
+   * 202 (comando enviado por SSE) o 409 (agente no conectado). null = fallo de
+   * red/4xx-5xx/demo. Tras enviarlo, el agente se reinicia solo; el próximo
+   * poll de agentes (~30 s) refleja la versión nueva y updateAvailable=false.
+   */
+  const upgradeAgent = useCallback(async (slug: string): Promise<'sent' | 'not_connected' | null> => {
+    if (modeRef.current !== 'live') return null
+    try {
+      const res = await fetch(`/api/agents/${encodeURIComponent(slug)}/upgrade`, {
+        method: 'POST',
+        signal: AbortSignal.timeout(30_000),
+      })
+      if (res.status === 401) redirectLogin()
+      if (res.status === 409) return 'not_connected'
+      if (!res.ok) return null
+      return 'sent'
+    } catch {
+      return null
+    }
+  }, [])
+
   const getRouterDetail = useCallback(async (id: string): Promise<RouterDetailData | null> => {
     if (modeRef.current === 'live') {
       const res = await fetch(`/api/routers/${encodeURIComponent(id)}`)
@@ -801,8 +829,9 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
       markAlertsRead,
       markAllAlertsRead,
       rearmAgent,
+      upgradeAgent,
     }),
-    [bundle, connectionStatus, agents, isDemo, refresh, lastSnapshotAt, requestServerRefresh, getRouterDetail, getDevices, getAlerts, alertsConfig, setAlertConfig, markAlertsRead, markAllAlertsRead, rearmAgent],
+    [bundle, connectionStatus, agents, isDemo, refresh, lastSnapshotAt, requestServerRefresh, getRouterDetail, getDevices, getAlerts, alertsConfig, setAlertConfig, markAlertsRead, markAllAlertsRead, rearmAgent, upgradeAgent],
   )
 
   return <NetPulseContext.Provider value={value}>{children}</NetPulseContext.Provider>

--- a/app/src/data/types.ts
+++ b/app/src/data/types.ts
@@ -28,6 +28,10 @@ export interface Router {
   mac?: string
   /** Descripción del firmware (live, system board) */
   firmware?: string
+  /** Versión objetivo configurada por el admin (issue #241). Ausente si no se configura. */
+  firmwareTarget?: string
+  /** true = el firmware instalado no cumple el target configurado (live). */
+  firmwareOutdated?: boolean
   status: Status
   /** Salud 0–100 */
   health: number

--- a/app/src/data/types.ts
+++ b/app/src/data/types.ts
@@ -32,6 +32,8 @@ export interface Router {
   firmwareTarget?: string
   /** true = el firmware instalado no cumple el target configurado (live). */
   firmwareOutdated?: boolean
+  /** Router configurado para funcionar solo con agente (sin SSH). */
+  agentOnly?: boolean
   status: Status
   /** Salud 0–100 */
   health: number

--- a/app/src/data/types.ts
+++ b/app/src/data/types.ts
@@ -357,6 +357,11 @@ export interface AgentInfo {
   /** Versión del binario netpulse-agent ("" si aún no se conoce) */
   version?: string
   fresh: boolean
+  /**
+   * true si el agente reporta una versión distinta de la del binario embebido
+   * (Fase 6.3, issue #243): hay upgrade disponible vía POST /api/agents/{slug}/upgrade.
+   */
+  updateAvailable?: boolean
 }
 
 /** Respuesta paginada (`GET /api/devices`, `GET /api/alerts`). */

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -27,9 +27,10 @@ import {
   Pencil,
   Plus,
   Lock,
-   Radar,
-   RefreshCw,
-   Router as RouterIcon,
+  Radar,
+  RefreshCw,
+  RotateCw,
+  Router as RouterIcon,
    Shield,
    ShieldCheck,
    Sun,
@@ -301,6 +302,9 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
   const [editSubmitting, setEditSubmitting] = useState(false)
   const [pubkey, setPubkey] = useState<{ publicKey: string; fingerprint: string } | null>(null)
   const [copied, setCopied] = useState(false)
+  const [rotating, setRotating] = useState(false)
+  const [rotateConfirmOpen, setRotateConfirmOpen] = useState(false)
+  const [rotateError, setRotateError] = useState<string | null>(null)
   const [scanning, setScanning] = useState(false)
   const [candidates, setCandidates] = useState<DiscoverCandidate[] | null>(null)
   const [showAddForm, setShowAddForm] = useState(false)
@@ -374,6 +378,27 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
       window.setTimeout(() => setCopied(false), 1500)
     } catch {
       /* portapapeles no disponible */
+    }
+  }
+
+  const rotateKey = async () => {
+    if (rotating) return
+    setRotating(true)
+    setRotateError(null)
+    try {
+      const res = await fetch('/api/config/sshkey/rotate', { method: 'POST' })
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { message?: string }
+        throw new Error(body.message ?? `HTTP ${res.status}`)
+      }
+      const json = (await res.json()) as { publicKey: string; fingerprint: string }
+      setPubkey({ publicKey: json.publicKey, fingerprint: json.fingerprint })
+      setCopied(false)
+      setRotateConfirmOpen(false)
+    } catch (err) {
+      setRotateError(err instanceof Error ? err.message : t('settings.routers.errorGeneric'))
+    } finally {
+      setRotating(false)
     }
   }
 
@@ -813,9 +838,44 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
               {copied ? <Check className="h-3.5 w-3.5 text-ok" strokeWidth={2} /> : <Copy className="h-3.5 w-3.5" strokeWidth={1.75} />}
               {copied ? t('settings.routers.copied') : t('settings.routers.copy')}
             </button>
+            <button
+              type="button"
+              onClick={() => {
+                setRotateError(null)
+                setRotateConfirmOpen(true)
+              }}
+              className="flex shrink-0 items-center gap-1.5 rounded-lg border border-border bg-elevated px-3 py-2 text-xs font-medium text-text-secondary transition-colors duration-150 hover:border-red-500/40 hover:text-red-500"
+            >
+              <RotateCw className="h-3.5 w-3.5" strokeWidth={1.75} />
+              {t('settings.routers.rotateKey')}
+            </button>
           </div>
         )}
       </div>
+
+      <AlertDialog open={rotateConfirmOpen} onOpenChange={setRotateConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('settings.routers.rotateKeyTitle')}</AlertDialogTitle>
+            <AlertDialogDescription>{t('settings.routers.rotateKeyCaption')}</AlertDialogDescription>
+          </AlertDialogHeader>
+          {rotateError && <p className="text-sm text-red-500">{rotateError}</p>}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={rotating}>{t('settings.users.cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault()
+                void rotateKey()
+              }}
+              disabled={rotating}
+              className="bg-red-600 text-white hover:bg-red-700"
+            >
+              <RotateCw className="mr-1.5 h-4 w-4" strokeWidth={2} />
+              {rotating ? t('settings.routers.rotating') : t('settings.routers.rotateKeyConfirm')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Card>
   )
 }

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -270,6 +270,7 @@ interface ConfigRouter {
   type: RouterType
   is_gateway: boolean
   agent_only: boolean
+  firmware_target: string
 }
 
 interface DiscoverCandidate {
@@ -299,6 +300,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
   const [editType, setEditType] = useState<RouterType>('openwrt')
   const [editGateway, setEditGateway] = useState(false)
   const [editAgentOnly, setEditAgentOnly] = useState(false)
+  const [editFirmwareTarget, setEditFirmwareTarget] = useState('')
   const [editSubmitting, setEditSubmitting] = useState(false)
   const [pubkey, setPubkey] = useState<{ publicKey: string; fingerprint: string } | null>(null)
   const [copied, setCopied] = useState(false)
@@ -485,6 +487,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
     setEditType(r.type)
     setEditGateway(r.is_gateway)
     setEditAgentOnly(r.agent_only)
+    setEditFirmwareTarget(r.firmware_target ?? '')
     setError(null)
   }
 
@@ -503,6 +506,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
           type: editType,
           gateway: editGateway,
           agent_only: editAgentOnly,
+          firmware_target: editFirmwareTarget.trim(),
         }),
       })
       if (res.status === 409) {
@@ -794,6 +798,21 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
                   <Switch checked={editAgentOnly} onCheckedChange={setEditAgentOnly} />
                   {t('settings.routers.agentOnly')}
                 </label>
+              </div>
+              <div>
+                <label htmlFor="firmware-target" className="mb-1 block text-caption font-medium uppercase tracking-[0.06em] text-text-muted">
+                  {t('settings.routers.firmwareTarget')}
+                </label>
+                <input
+                  id="firmware-target"
+                  type="text"
+                  value={editFirmwareTarget}
+                  onChange={(e) => setEditFirmwareTarget(e.target.value)}
+                  placeholder={t('settings.routers.firmwareTargetPlaceholder')}
+                  aria-label={t('settings.routers.firmwareTarget')}
+                  className="w-full rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+                />
+                <p className="mt-1 text-caption leading-relaxed text-text-muted">{t('settings.routers.firmwareTargetHint')}</p>
               </div>
               {error && <p className="text-caption text-danger">{error}</p>}
               <div className="flex justify-end gap-2">

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -623,6 +623,27 @@ auto-rollback). Los módulos concretos se agrupan por riesgo en Fases 18-20.
 | 17.9 | DAWN + 802.11r (write) | 20 | Alto |
 | 17.10 | Batman-adv mesh | 20 | Muy alto |
 | 17.11 | DPI (nDPI / ntopng) | 20 | Alto |
+| 17.12 | **Firmware update in-app (labs)** | 20 | Alto |
+
+### 🔥 17.12 — Firmware update in-app (labs) (23-Ago-2026)
+
+Actualización de firmware de los routers desde la app, **como funcionalidad
+labs** (mismo patrón que la orquestación: badge "labs" en el nav, opt-in vía
+flag). **Activable hoy mismo** aunque aún no esté la vista completa de gestión;
+el paso previo (detección de firmware desactualizado: alerta + campo en
+routers + impacto leve en salud) vive en el issue #241.
+
+- **Detección (ya modelada)**: `Router.firmware` se puebla en live desde
+  `board.Release.Description` (live.go:777); la demo ya modela
+  `FirmwareUpdated`/`FirmwareAvailable` (demo_extras.go:38-41) y una alerta de
+  firmware (demo_dataset.go:153). Fuente del "última versión": a decidir
+  (feed estable OpenWrt, API de fabricante GL.iNet o target configurable).
+- **Aplicación**: reutiliza el motor plan→apply→state de la Fase 10 con
+  snapshot + healthcheck + auto-rollback: descarga de imagen oficial con
+  verificación de checksum, `sysupgrade` vía agente, y recuperación si se
+  pierde conectividad.
+- **Riesgo**: Alto (un fallo puede dejar el router incomunicado); por eso
+  arranca como labs y no entra en el canal stable hasta beta-testing.
 
 **Prerrequisitos comunes** (se estabilizan al implementar 17.1 como spike):
 - Instalador de paquetes unificado: `opkg` (24.10), `apk` (25.12), binario

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -798,6 +798,9 @@ func (l *Live) buildRouter(p *routerPolled, history []histPoint) Router {
 	if p.cfg.FirmwareTarget != "" {
 		r.FirmwareTarget = p.cfg.FirmwareTarget
 	}
+	if p.cfg.AgentOnly {
+		r.AgentOnly = true
+	}
 	if outdatedFw {
 		r.FirmwareOutdated = true
 		// Alerta no urgente (category system); el engine aplica dedup 5 min.

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -705,6 +705,19 @@ func (l *Live) pollRouter(ctx context.Context, cfg RouterConfig) (*routerPolled,
 	}, nil
 }
 
+// firmwareOutdated decide si el firmware instalado no cumple el target
+// configurado por el admin (issue #241). Comparación tolerante e
+// insensible a mayúsculas: el target debe aparecer (Contains) dentro de la
+// descripción del firmware ("OpenWrt 25.12.5 r33051..." contiene "25.12.5").
+// Sin target ("" tras trim) → false (no hay comprobación).
+func firmwareOutdated(installed, target string) bool {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return false
+	}
+	return !strings.Contains(strings.ToLower(strings.TrimSpace(installed)), strings.ToLower(target))
+}
+
 // buildRouter construye el Router del contrato (index.js:221-249).
 func (l *Live) buildRouter(p *routerPolled, history []histPoint) Router {
 	l.mu.Lock()
@@ -737,6 +750,12 @@ func (l *Live) buildRouter(p *routerPolled, history []histPoint) Router {
 	}
 	if p.ram > 90 {
 		health -= 15
+	}
+	// issue #241: firmware fuera del target configurado penaliza la salud.
+	outdatedFw := false
+	if p.cfg.FirmwareTarget != "" && p.board != nil && firmwareOutdated(p.board.Release.Description, p.cfg.FirmwareTarget) {
+		health -= 5
+		outdatedFw = true
 	}
 	if health < 0 {
 		health = 0
@@ -775,6 +794,21 @@ func (l *Live) buildRouter(p *routerPolled, history []histPoint) Router {
 	}
 	if p.board != nil {
 		r.Firmware = p.board.Release.Description
+	}
+	if p.cfg.FirmwareTarget != "" {
+		r.FirmwareTarget = p.cfg.FirmwareTarget
+	}
+	if outdatedFw {
+		r.FirmwareOutdated = true
+		// Alerta no urgente (category system); el engine aplica dedup 5 min.
+		l.engine.Emit(AlertEvent{
+			ID:       fmt.Sprintf("alert-firmware-%s-%d", p.cfg.ID, time.Now().UnixMilli()),
+			Category: alerts.CatSystem, Urgent: false,
+			Severity:    "warn",
+			Title:       "Firmware desactualizado",
+			Description: fmt.Sprintf("%s: firmware %q no coincide con el target %q", name, r.Firmware, p.cfg.FirmwareTarget),
+			Time:        "ahora mismo", RouterID: p.cfg.ID,
+		})
 	}
 	if p.temp > 65 {
 		r.HotMetric = "temp"

--- a/server-go/internal/adapters/live_firmware_test.go
+++ b/server-go/internal/adapters/live_firmware_test.go
@@ -1,0 +1,133 @@
+package adapters
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFirmwareOutdated cubre la comparación pura (issue #241): Contains
+// normalizado en minúsculas sobre la descripción del firmware.
+func TestFirmwareOutdated(t *testing.T) {
+	cases := []struct {
+		name      string
+		installed string
+		target    string
+		want      bool
+	}{
+		{"sin target", "OpenWrt 23.05.5", "", false},
+		{"target solo espacios", "OpenWrt 23.05.5", "   ", false},
+		{"coincide exacto", "23.05.5", "23.05.5", false},
+		{"coincide dentro de descripción", "OpenWrt 25.12.5 r33051-abc", "25.12.5", false},
+		{"coincide sin distinguir mayúsculas", "OpenWrt 25.12.5", "OPENWRT 25.12.5", false},
+		{"no coincide", "OpenWrt 23.05.5", "24.10.1", true},
+		{"instalado vacío", "", "24.10.1", true},
+		{"target con espacios alrededor", "OpenWrt 23.05.5", " 23.05.5 ", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := firmwareOutdated(c.installed, c.target); got != c.want {
+				t.Fatalf("firmwareOutdated(%q, %q) = %v, esperaba %v", c.installed, c.target, got, c.want)
+			}
+		})
+	}
+}
+
+// boardWithDesc construye un BoardInfo con la descripción de firmware dada.
+func boardWithDesc(desc string) *BoardInfo {
+	b := &BoardInfo{}
+	b.Release.Description = desc
+	return b
+}
+
+// TestBuildRouterFirmwareTarget cubre la integración en buildRouter: flag
+// FirmwareOutdated, FirmwareTarget, penalización de salud y alerta CatSystem.
+func TestBuildRouterFirmwareTarget(t *testing.T) {
+	// Target no coincide → flag, health -5 y alerta no urgente.
+	l := NewLive(nil, nil, []RouterConfig{
+		{ID: "r1", Host: "192.168.8.1", IsGateway: true},
+	}, nil)
+	p := &routerPolled{
+		cfg:   RouterConfig{ID: "r1", Name: "Salón", Host: "192.168.8.2", FirmwareTarget: "25.12.5"},
+		board: boardWithDesc("OpenWrt 23.05.5 r20134-abc"),
+	}
+	r := l.buildRouter(p, nil)
+	if !r.FirmwareOutdated {
+		t.Fatalf("FirmwareOutdated debería ser true: %+v", r)
+	}
+	if r.FirmwareTarget != "25.12.5" {
+		t.Fatalf("FirmwareTarget=%q, esperaba 25.12.5", r.FirmwareTarget)
+	}
+	if r.Firmware != "OpenWrt 23.05.5 r20134-abc" {
+		t.Fatalf("Firmware=%q", r.Firmware)
+	}
+	if r.Health != 95 {
+		t.Fatalf("Health=%d, esperaba 95 (100-5)", r.Health)
+	}
+	list := l.AlertsEngine().List()
+	if len(list) != 1 {
+		t.Fatalf("alertas=%d, esperaba 1", len(list))
+	}
+	ev := list[0]
+	if ev.Category != "system" || ev.Urgent || ev.Severity != "warn" || ev.RouterID != "r1" {
+		t.Fatalf("alerta mal formada: %+v", ev)
+	}
+	if ev.Title != "Firmware desactualizado" {
+		t.Fatalf("Title=%q", ev.Title)
+	}
+	if !strings.Contains(ev.Description, "25.12.5") || !strings.Contains(ev.Description, "23.05.5") {
+		t.Fatalf("Description=%q", ev.Description)
+	}
+
+	// Target coincide → sin flag, health intacto, sin alerta nueva.
+	l2 := NewLive(nil, nil, []RouterConfig{{ID: "g", Host: "192.168.8.1", IsGateway: true}}, nil)
+	p2 := &routerPolled{
+		cfg:   RouterConfig{ID: "r2", Name: "Estudio", Host: "192.168.8.3", FirmwareTarget: "23.05.5"},
+		board: boardWithDesc("OpenWrt 23.05.5 r20134-abc"),
+	}
+	r2 := l2.buildRouter(p2, nil)
+	if r2.FirmwareOutdated {
+		t.Fatalf("FirmwareOutdated no debería marcarse: %+v", r2)
+	}
+	if r2.FirmwareTarget != "23.05.5" {
+		t.Fatalf("FirmwareTarget=%q", r2.FirmwareTarget)
+	}
+	if r2.Health != 100 {
+		t.Fatalf("Health=%d, esperaba 100", r2.Health)
+	}
+	if n := len(l2.AlertsEngine().List()); n != 0 {
+		t.Fatalf("alertas=%d, esperaba 0", n)
+	}
+
+	// Sin target → sin flag y sin alerta.
+	l3 := NewLive(nil, nil, []RouterConfig{{ID: "g", Host: "192.168.8.1", IsGateway: true}}, nil)
+	p3 := &routerPolled{
+		cfg:   RouterConfig{ID: "r3", Name: "Patio", Host: "192.168.8.4"},
+		board: boardWithDesc("OpenWrt 23.05.5"),
+	}
+	r3 := l3.buildRouter(p3, nil)
+	if r3.FirmwareOutdated || r3.FirmwareTarget != "" {
+		t.Fatalf("sin target no debería marcar nada: %+v", r3)
+	}
+	if n := len(l3.AlertsEngine().List()); n != 0 {
+		t.Fatalf("alertas=%d, esperaba 0", n)
+	}
+}
+
+// TestBuildRouterFirmwareSinBoard: target sin board (sin firmware leído) no
+// debe marcar outdated ni emitir (evita falsos positivos en sondeo parcial).
+func TestBuildRouterFirmwareSinBoard(t *testing.T) {
+	l := NewLive(nil, nil, []RouterConfig{{ID: "g", Host: "192.168.8.1", IsGateway: true}}, nil)
+	p := &routerPolled{
+		cfg: RouterConfig{ID: "r4", Name: "Salón", Host: "192.168.8.2", FirmwareTarget: "25.12.5"},
+	}
+	r := l.buildRouter(p, nil)
+	if r.FirmwareOutdated {
+		t.Fatalf("sin board no debería marcar outdated: %+v", r)
+	}
+	if r.FirmwareTarget != "25.12.5" {
+		t.Fatalf("FirmwareTarget debería reflejar el config aun sin board: %+v", r)
+	}
+	if n := len(l.AlertsEngine().List()); n != 0 {
+		t.Fatalf("alertas=%d, esperaba 0", n)
+	}
+}

--- a/server-go/internal/adapters/types.go
+++ b/server-go/internal/adapters/types.go
@@ -129,6 +129,12 @@ type Router struct {
 	IP         string    `json:"ip"`
 	MAC        string    `json:"mac,omitempty"`      // ausente si no se conoce (undefined)
 	Firmware   string    `json:"firmware,omitempty"` // ausente si no se conoce
+	// FirmwareTarget: versión objetivo configurada por el admin (issue #241).
+	// Ausente si no está configurado (sin comprobación).
+	FirmwareTarget string `json:"firmwareTarget,omitempty"`
+	// FirmwareOutdated: true si hay target y el firmware instalado no lo
+	// cumple (live buildRouter). Ausente en el resto de casos.
+	FirmwareOutdated bool `json:"firmwareOutdated,omitempty"`
 	Status     string    `json:"status"`             // "online"|"warn"|"offline"
 	Health     int       `json:"health"`
 	CPU        *int      `json:"cpu"`
@@ -598,6 +604,9 @@ type RouterConfig struct {
 	IsGateway bool   `json:"is_gateway"`
 	AgentOnly bool   `json:"agent_only"`
 	CreatedAt int64  `json:"created_at"` // epoch ms
+	// FirmwareTarget: versión objetivo configurada por el admin (issue #241).
+	// "" = sin comprobar (el live no emite aviso de firmware).
+	FirmwareTarget string `json:"firmware_target,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/server-go/internal/adapters/types.go
+++ b/server-go/internal/adapters/types.go
@@ -135,6 +135,10 @@ type Router struct {
 	// FirmwareOutdated: true si hay target y el firmware instalado no lo
 	// cumple (live buildRouter). Ausente en el resto de casos.
 	FirmwareOutdated bool `json:"firmwareOutdated,omitempty"`
+	// AgentOnly: el router está configurado para funcionar SOLO con agente
+	// (sin SSH). El frontend lo usa para marcar "agente no instalado" cuando
+	// no hay agente registrado (certeza: el router no es sondeable por SSH).
+	AgentOnly bool `json:"agentOnly,omitempty"`
 	Status     string    `json:"status"`             // "online"|"warn"|"offline"
 	Health     int       `json:"health"`
 	CPU        *int      `json:"cpu"`

--- a/server-go/internal/agentbin/agentbin.go
+++ b/server-go/internal/agentbin/agentbin.go
@@ -14,6 +14,19 @@ import (
 	"io/fs"
 )
 
+// EmbeddedAgentVersion es la versión del binario de agente que el servidor
+// embebe y sirve por GET /api/agents/{slug}/binary. Se usa para calcular el
+// campo updateAvailable de GET /api/agents: un agente cuya versión reportada
+// difiere de esta constante tiene una actualización pendiente.
+//
+// IMPORTANTE (mantener en sync): este valor DEBE coincidir con la versión que
+// reporta el binario embebido, es decir, main.Version de
+// agent/cmd/netpulse-agent tal y como lo construye el CI. Los workflows
+// release.yml y go.yml inyectan `-X main.Version=<AGENT_VERSION>` en los
+// binarios de agentbin; ese AGENT_VERSION y esta constante deben bumpearse
+// juntos en el mismo commit al publicar una versión nueva del agente.
+const EmbeddedAgentVersion = "0.1.0"
+
 //go:embed agents/*
 var agentsFS embed.FS
 

--- a/server-go/internal/agentbin/agentbin.go
+++ b/server-go/internal/agentbin/agentbin.go
@@ -17,15 +17,14 @@ import (
 // EmbeddedAgentVersion es la versión del binario de agente que el servidor
 // embebe y sirve por GET /api/agents/{slug}/binary. Se usa para calcular el
 // campo updateAvailable de GET /api/agents: un agente cuya versión reportada
-// difiere de esta constante tiene una actualización pendiente.
+// difiere de esta versión tiene una actualización pendiente.
 //
-// IMPORTANTE (mantener en sync): este valor DEBE coincidir con la versión que
-// reporta el binario embebido, es decir, main.Version de
-// agent/cmd/netpulse-agent tal y como lo construye el CI. Los workflows
-// release.yml y go.yml inyectan `-X main.Version=<AGENT_VERSION>` en los
-// binarios de agentbin; ese AGENT_VERSION y esta constante deben bumpearse
-// juntos en el mismo commit al publicar una versión nueva del agente.
-const EmbeddedAgentVersion = "0.1.0"
+// Es una `var` (no const) porque el CI la inyecta con ldflags
+// (`-X ...agentbin.EmbeddedAgentVersion=$AGENT_VERSION`) usando el MISMO
+// valor que fija `main.Version` del agente, de modo que la constante del
+// server siempre coincide con la versión real de los binarios embebidos.
+// En desarrollo (sin ldflags) queda en el default 0.1.0.
+var EmbeddedAgentVersion = "0.1.0"
 
 //go:embed agents/*
 var agentsFS embed.FS

--- a/server-go/internal/auth/middleware.go
+++ b/server-go/internal/auth/middleware.go
@@ -47,14 +47,16 @@ func WriteError(w http.ResponseWriter, status int, code string, message ...strin
 // /api/health, /api/auth/login, /api/ingest/agent (auth Bearer por token
 // de equipo), /api/agents/pair (pairing token de un solo uso, Fase 9 R3),
 // /api/agents/{slug}/binary (auth Bearer por token de agente,
-// Fase 6.2) y /api/agents/{slug}/stream (SSE bidireccional, Fase 7.3).
+// Fase 6.2), /api/agents/{slug}/stream (SSE bidireccional, Fase 7.3),
+// /api/agents/{slug}/apply-result y /api/agents/{slug}/upgrade-result
+// (reporte del agente, auth Bearer).
 // Fallo → 401 {error:'unauthorized'}.
 func RequireAuth(d *db.DB, secret string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 		if !strings.HasPrefix(path, "/api/") || path == "/api/health" || path == "/api/auth/login" ||
 			path == "/api/ingest/agent" || path == "/api/agents/pair" ||
-			(strings.HasPrefix(path, "/api/agents/") && (strings.HasSuffix(path, "/binary") || strings.HasSuffix(path, "/stream") || strings.HasSuffix(path, "/apply-result"))) {
+			(strings.HasPrefix(path, "/api/agents/") && (strings.HasSuffix(path, "/binary") || strings.HasSuffix(path, "/stream") || strings.HasSuffix(path, "/apply-result") || strings.HasSuffix(path, "/upgrade-result"))) {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/server-go/internal/db/db.go
+++ b/server-go/internal/db/db.go
@@ -331,6 +331,8 @@ func Open(dataDir string, opts ...OpenOption) (*DB, error) {
 	migrate(sqldb, "routers", "agent_only", "ALTER TABLE routers ADD COLUMN agent_only INTEGER NOT NULL DEFAULT 0")
 	// issue #196: bridgeMAC persistido del router (exclusión de "desconocido").
 	migrate(sqldb, "routers", "mac", "ALTER TABLE routers ADD COLUMN mac TEXT")
+	// issue #241: target de firmware por router (string libre; NULL/"" = sin comprobar).
+	migrate(sqldb, "routers", "firmware_target", "ALTER TABLE routers ADD COLUMN firmware_target TEXT")
 
 	// Si no hubo migración Node (instalación fresca creada por Go), marca la
 	// DB para que el siguiente arranque no dispare una "migración" espuria

--- a/server-go/internal/httpapi/agent.go
+++ b/server-go/internal/httpapi/agent.go
@@ -342,6 +342,10 @@ type agentListItem struct {
 	LastSeen *int64 `json:"lastSeen"` // unix SEGUNDOS; null si nunca empujó
 	Version  string `json:"version,omitempty"`
 	Fresh    bool   `json:"fresh"`
+	// UpdateAvailable: true si el agente reportó una versión distinta de la
+	// del binario embebido (agentbin.EmbeddedAgentVersion) → hay upgrade
+	// disponible vía POST /api/agents/{slug}/upgrade (Fase 6.3, issue #243).
+	UpdateAvailable bool `json:"updateAvailable"`
 }
 
 // handleAgentsList: slugs con token + last_seen + versión.
@@ -363,6 +367,9 @@ func (s *server) handleAgentsList(w http.ResponseWriter, _ *http.Request) {
 						ts := seen.Unix()
 						item.LastSeen = &ts
 						item.Version = version
+						// Fase 6.3 (issue #243): upgrade disponible si el agente
+						// reporta una versión distinta del binario embebido.
+						item.UpdateAvailable = version != "" && version != agentbin.EmbeddedAgentVersion
 					}
 					_, item.Fresh = s.agents.Fresh(slug)
 				}

--- a/server-go/internal/httpapi/agent.go
+++ b/server-go/internal/httpapi/agent.go
@@ -453,6 +453,175 @@ func (s *server) handleAgentRearm(w http.ResponseWriter, r *http.Request) {
 }
 
 // ---------------------------------------------------------------------------
+// POST /api/agents/{slug}/reinstall — #246: reinstalar el agente en el router
+// vía SSH (recupera un agente borrado por update de firmware/desinstalación).
+// Replica el flujo de install-agent.sh sin depender del PC del admin:
+//   1. Verifica slug + router en la tabla routers.
+//   2. Rota el token (genera uno nuevo en claro y persiste su hash en kv).
+//   3. Ejecuta por SSH: detecta arch, descarga el binario del propio server
+//      (GET /api/agents/{slug}/binary con el token nuevo), lo instala,
+//      escribe /etc/netpulse-agent.env, instala el init procd y lo arranca.
+//   4. Espera a que el agente vuelva a empujar (misma lógica que el rearm).
+// ---------------------------------------------------------------------------
+
+type reinstallResponse struct {
+	Slug      string `json:"slug"`
+	Token     string `json:"token"` // en claro UNA vez, para reutilizar en el router
+	Installed bool   `json:"installed"`
+	Recovered bool   `json:"recovered"` // llegó un push nuevo tras la instalación
+	Message   string `json:"message,omitempty"`
+}
+
+func (s *server) handleAgentReinstall(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("slug")
+	if !agentSlugRe.MatchString(slug) {
+		writeError(w, http.StatusNotFound, "not_found")
+		return
+	}
+	if s.db == nil || s.pool == nil {
+		writeError(w, http.StatusServiceUnavailable, "ssh_unavailable", "el servidor no tiene pool SSH")
+		return
+	}
+
+	// Router del slug (tabla routers; mismo host que usa el rearm).
+	host := ""
+	for _, rc := range routerstore.ListRouters(s.db.DB) {
+		if rc.ID == slug {
+			host = rc.Host
+			break
+		}
+	}
+	if host == "" {
+		writeError(w, http.StatusConflict, "router_unknown", "no hay router con ese slug en la tabla routers")
+		return
+	}
+
+	// Rotar el token (el env del router se reescribe con el nuevo).
+	token, err := newAgentToken()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "token_error")
+		return
+	}
+	if _, err := s.db.Exec(
+		"INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+		agentTokenKey(slug), hashAgentToken(token)); err != nil {
+		writeError(w, http.StatusInternalServerError, "token_error")
+		return
+	}
+
+	// URL base del server (para que el router descargue el binario). Mismo
+	// esquema que agentInstallLine: http en LAN, https si la request es segura.
+	scheme := "http"
+	if auth.IsSecureRequest(r) {
+		scheme = "https"
+	}
+	serverURL := scheme + "://" + r.Host
+
+	// Script de instalación (replica install-agent.sh vía SSH, sin scp).
+	script := reinstallScript(host, slug, token, serverURL)
+
+	before := time.Now()
+	var prevSeen time.Time
+	if s.agents != nil {
+		if seen, _, ok := s.agents.Info(slug); ok {
+			prevSeen = seen
+		}
+	}
+
+	if _, err := s.pool.Run(host, script, 60*time.Second); err != nil {
+		writeError(w, http.StatusBadGateway, "ssh_failed", err.Error())
+		return
+	}
+
+	// Esperar a que el agente vuelva a empujar (poll 2s hasta 40s).
+	recovered := false
+	deadline := time.Now().Add(40 * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(2 * time.Second)
+		if s.agents == nil {
+			break
+		}
+		if seen, _, ok := s.agents.Info(slug); ok && seen.After(prevSeen) && seen.After(before.Add(-5*time.Second)) {
+			recovered = true
+			break
+		}
+	}
+
+	writeJSON(w, http.StatusOK, reinstallResponse{
+		Slug: slug, Token: token, Installed: true, Recovered: recovered,
+		Message: map[bool]string{true: "agente instalado y empujando", false: "agente instalado; aún no ha empujado en 40 s"}[recovered],
+	})
+}
+
+// reinstallScript construye el script POSIX sh que se ejecuta en el router.
+func reinstallScript(host, slug, token, serverURL string) string {
+	return `#!/bin/sh
+set -e
+INIT=/etc/init.d/netpulse-agent
+BIN=/usr/sbin/netpulse-agent
+ENV_FILE=/etc/netpulse-agent.env
+SERVER="` + serverURL + `"
+SLUG="` + slug + `"
+TOKEN="` + token + `"
+
+# Detectar arquitectura del router
+ARCH=$(uname -m)
+case "$ARCH" in
+	aarch64|arm64) GOARCH=arm64 ;;
+	armv7l|armv7)  GOARCH=armv7 ;;
+	*) echo "arch no soportado: $ARCH"; exit 20 ;;
+esac
+
+# Parar servicio previo si existe (el proceso vivo mantiene el binario abierto)
+[ -f "$INIT" ] && $INIT stop >/dev/null 2>&1 || true
+
+# Descargar el binario del propio server (auth por token)
+if command -v curl >/dev/null 2>&1; then
+	curl -fsSL --connect-timeout 10 -H "Authorization: Bearer $TOKEN" "$SERVER/api/agents/$SLUG/binary?arch=$GOARCH" -o /tmp/netpulse-agent.new
+else
+	wget -q -O /tmp/netpulse-agent.new --header="Authorization: Bearer $TOKEN" "$SERVER/api/agents/$SLUG/binary?arch=$GOARCH"
+fi
+chmod 0755 /tmp/netpulse-agent.new
+mv /tmp/netpulse-agent.new "$BIN"
+chmod 0755 "$BIN"
+
+# Config (chmod 600)
+cat > "$ENV_FILE" <<EOF
+# netpulse-agent — config (generado por reinstall)
+NETPULSE_SERVER=$SERVER
+NETPULSE_SLUG=$SLUG
+NETPULSE_TOKEN=$TOKEN
+EOF
+chmod 600 "$ENV_FILE"
+
+# Init script procd (respawn)
+cat > "$INIT" <<'INITEOF'
+#!/bin/sh /etc/rc.common
+# netpulse-agent — agente nativo NetPulse para OpenWrt
+START=99
+STOP=10
+USE_PROCD=1
+
+BIN=/usr/sbin/netpulse-agent
+[ -x "$BIN" ] || BIN=/tmp/netpulse-agent
+
+start_service() {
+    procd_open_instance netpulse-agent
+    procd_set_param command "$BIN"
+    procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_set_param file /etc/netpulse-agent.env
+    procd_close_instance
+}
+INITEOF
+chmod 0755 "$INIT"
+$INIT enable
+$INIT restart
+`
+}
+
+// ---------------------------------------------------------------------------
 // POST /api/agents/{slug}/refresh — Fase 7.3: enviar comando refresh al
 // agente vía SSE para que haga un sondeo inmediato. Admin solo.
 // ---------------------------------------------------------------------------

--- a/server-go/internal/httpapi/config.go
+++ b/server-go/internal/httpapi/config.go
@@ -87,6 +87,8 @@ type routerInput struct {
 	Type      string  `json:"type"`
 	Gateway   bool    `json:"gateway"`
 	AgentOnly bool    `json:"agent_only"`
+	// FirmwareTarget: versión objetivo del firmware (issue #241; opcional).
+	FirmwareTarget *string `json:"firmware_target"`
 }
 
 // validateHost replica hostSchema (trim, 1..253, regex). Devuelve el valor
@@ -142,6 +144,10 @@ func (s *server) handleAddConfigRouter(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid_input", "Invalid enum value. Expected 'glinet' | 'openwrt' | 'managed-switch' | 'external'")
 		return
 	}
+	var firmwareTarget string
+	if in.FirmwareTarget != nil {
+		firmwareTarget = strings.TrimSpace(*in.FirmwareTarget)
+	}
 	for _, rt := range routerstore.ListRouters(s.db.DB) {
 		if rt.Host == host {
 			writeError(w, http.StatusConflict, "duplicate_host", "Ya hay un router con "+host)
@@ -150,6 +156,7 @@ func (s *server) handleAddConfigRouter(w http.ResponseWriter, r *http.Request) {
 	}
 	created, err := routerstore.AddRouter(s.db.DB, routerstore.AddInput{
 		Name: name, Host: host, Type: typ, IsGateway: in.Gateway, AgentOnly: in.AgentOnly,
+		FirmwareTarget: firmwareTarget,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error")
@@ -218,9 +225,15 @@ func (s *server) handleUpdateConfigRouter(w http.ResponseWriter, r *http.Request
 	}
 	gw := in.Gateway
 	ao := in.AgentOnly
+	var firmwareTarget *string
+	if in.FirmwareTarget != nil {
+		v := strings.TrimSpace(*in.FirmwareTarget)
+		firmwareTarget = &v
+	}
 	updated, ok := routerstore.UpdateRouter(s.db.DB, id, routerstore.UpdateInput{
 		Name: name, Host: host, Type: typ,
 		IsGateway: &gw, AgentOnly: &ao,
+		FirmwareTarget: firmwareTarget,
 	})
 	if !ok {
 		writeError(w, http.StatusNotFound, "not_found")

--- a/server-go/internal/httpapi/config.go
+++ b/server-go/internal/httpapi/config.go
@@ -25,6 +25,7 @@ var hostRe = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 // issue #7); la lista de routers es de lectura y queda tras RequireAuth.
 func (s *server) registerConfigRoutes(mux *http.ServeMux) {
 	mux.Handle("GET /api/config/sshkey", auth.RequireAdmin(http.HandlerFunc(s.handleGetSSHKey)))
+	mux.Handle("POST /api/config/sshkey/rotate", auth.RequireAdmin(http.HandlerFunc(s.handleRotateSSHKey)))
 	mux.Handle("GET /api/config/discover", auth.RequireAdmin(http.HandlerFunc(s.handleDiscover)))
 	mux.HandleFunc("GET /api/config/routers", s.handleListConfigRouters)
 	mux.Handle("POST /api/config/routers", auth.RequireAdmin(http.HandlerFunc(s.handleAddConfigRouter)))
@@ -49,6 +50,24 @@ func (s *server) handleGetSSHKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, key)
+}
+
+// POST /api/config/sshkey/rotate — rota el par ed25519 del servidor (#242).
+// Respalda el par actual (keyPath.bak.<epoch>) y genera uno nuevo; devuelve
+// la nueva pública + fingerprint para reautorizarla en los routers. La clave
+// vieja deja de funcionar de inmediato: exige confirmación explícita del admin
+// (la UI pide escribir la palabra de confirmación).
+func (s *server) handleRotateSSHKey(w http.ResponseWriter, r *http.Request) {
+	key, err := sshkey.RotateKeypair(s.cfg.SSHKeyPath)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "rotate_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"publicKey":   key.PublicKey,
+		"fingerprint": key.Fingerprint,
+		"warning":     "The previous key is no longer valid. Re-authorize this public key on every router before rotating again.",
+	})
 }
 
 // GET /api/config/discover?force=1 — escaneo de la LAN (cacheado 60 s).

--- a/server-go/internal/httpapi/config_test.go
+++ b/server-go/internal/httpapi/config_test.go
@@ -271,3 +271,51 @@ func TestConfigRoutersUpdate(t *testing.T) {
 		t.Errorf("agent_only: %v", rt["agent_only"])
 	}
 }
+
+// TestConfigRoutersFirmwareTarget cubre firmware_target (issue #241):
+// alta con target, PUT que lo actualiza y persistencia en la lista.
+func TestConfigRoutersFirmwareTarget(t *testing.T) {
+	srv := makeTestServer(t)
+	_, cookie, _ := loginCookie(t, srv.URL, "admin", "test1234")
+
+	// POST con firmware_target → 201 y el router devuelto lo lleva.
+	res := doReq(t, "POST", srv.URL+"/api/config/routers", cookie,
+		`{"name":"rt1","host":"192.168.8.10","type":"openwrt","firmware_target":"25.12.5"}`)
+	if res.StatusCode != 201 {
+		t.Fatalf("POST router: %d", res.StatusCode)
+	}
+	body := readJSON(t, res)
+	router := body["router"].(map[string]any)
+	if router["firmware_target"] != "25.12.5" {
+		t.Fatalf("firmware_target tras alta: %v", router)
+	}
+
+	// PUT cambia firmware_target → 200 y el campo cambia.
+	res = doReq(t, "PUT", srv.URL+"/api/config/routers/rt1", cookie,
+		`{"host":"192.168.8.10","firmware_target":"24.10.1"}`)
+	if res.StatusCode != 200 {
+		t.Fatalf("PUT firmware_target: %d", res.StatusCode)
+	}
+	body = readJSON(t, res)
+	rt := body["router"].(map[string]any)
+	if rt["firmware_target"] != "24.10.1" {
+		t.Fatalf("firmware_target tras PUT: %v", rt)
+	}
+
+	// GET persiste el valor en la lista.
+	res = doReq(t, "GET", srv.URL+"/api/config/routers", cookie, "")
+	if res.StatusCode != 200 {
+		t.Fatalf("GET routers: %d", res.StatusCode)
+	}
+	body = readJSON(t, res)
+	found := ""
+	for _, r := range body["routers"].([]any) {
+		rm := r.(map[string]any)
+		if rm["id"] == "rt1" {
+			found, _ = rm["firmware_target"].(string)
+		}
+	}
+	if found != "24.10.1" {
+		t.Fatalf("firmware_target persistido=%q, esperaba 24.10.1", found)
+	}
+}

--- a/server-go/internal/httpapi/config_test.go
+++ b/server-go/internal/httpapi/config_test.go
@@ -141,6 +141,44 @@ func TestConfigRoutersCRUD(t *testing.T) {
 	}
 }
 
+// TestRotateSSHKey cubre POST /api/config/sshkey/rotate (#242):
+//   - 403 sin admin
+//   - 200 y la nueva pública difiere de la anterior (cuando había clave)
+//   - la respuesta incluye publicKey + fingerprint
+func TestRotateSSHKey(t *testing.T) {
+	srv := makeTestServer(t)
+	_, cookie, _ := loginCookie(t, srv.URL, "admin", "test1234")
+
+	// Sin admin → 403.
+	res := doReq(t, "POST", srv.URL+"/api/config/sshkey/rotate", "", "")
+	if res.StatusCode != 403 && res.StatusCode != 401 {
+		t.Fatalf("rotate sin admin: %d (esperaba 403)", res.StatusCode)
+	}
+
+	// Clave previa (puede no existir en el DATA_DIR de test).
+	prev := ""
+	res = doReq(t, "GET", srv.URL+"/api/config/sshkey", cookie, "")
+	if res.StatusCode == 200 {
+		prev = readJSON(t, res)["publicKey"].(string)
+	}
+
+	res = doReq(t, "POST", srv.URL+"/api/config/sshkey/rotate", cookie, "")
+	if res.StatusCode != 200 {
+		t.Fatalf("rotate: %d", res.StatusCode)
+	}
+	body := readJSON(t, res)
+	pub, ok := body["publicKey"].(string)
+	if !ok || pub == "" {
+		t.Fatalf("rotate: sin publicKey: %v", body)
+	}
+	if _, ok := body["fingerprint"].(string); !ok {
+		t.Fatalf("rotate: sin fingerprint: %v", body)
+	}
+	if prev != "" && prev == pub {
+		t.Fatalf("rotate: la clave no cambió (prev==new)")
+	}
+}
+
 // TestConfigRoutersUpdate cubre PUT /api/config/routers/{id}:
 //   - 404 si no existe
 //   - editar name (200, campo cambiado)

--- a/server-go/internal/httpapi/rearm_api_test.go
+++ b/server-go/internal/httpapi/rearm_api_test.go
@@ -296,3 +296,58 @@ func TestRearmSinPool503(t *testing.T) {
 		t.Fatalf("quiero 503 ssh_unavailable, tuve %d (%s)", status, body)
 	}
 }
+
+// TestAgentReinstall — #246: POST /api/agents/{slug}/reinstall.
+// Casos: 404 slug inválido, 409 sin router en tabla routers, 200 instalado
+// (el fakeSSH ejecuta el script; sin push de vuelta → recovered=false),
+// y rotación del token (el token en la respuesta difiere del previo).
+func TestAgentReinstall(t *testing.T) {
+	pool := &fakeSSH{}
+	ts := makeRearmTestServer(t, pool, 50*time.Millisecond)
+
+	// 404 slug inválido
+	res := doReq(t, "POST", ts.URL+"/api/agents/BAD%20slug/reinstall", ts.cookie, "")
+	if res.StatusCode != 404 {
+		t.Fatalf("slug inválido: %d", res.StatusCode)
+	}
+
+	// 409 sin router en la tabla (slug "nonexistent" sin token ni router)
+	res = doReq(t, "POST", ts.URL+"/api/agents/nonexistent/reinstall", ts.cookie, "")
+	if res.StatusCode != 409 {
+		t.Fatalf("sin router: %d (esperaba 409)", res.StatusCode)
+	}
+
+	// Token previo de "patio" (el router existe en makeRearmTestServer)
+	status, prevToken := createRearmToken(t, ts, "patio")
+	if status != 201 {
+		t.Fatalf("crear token: %d", status)
+	}
+
+	// 200 instalado: el fakeSSH "ejecuta" el script → Installed=true.
+	res = doReq(t, "POST", ts.URL+"/api/agents/patio/reinstall", ts.cookie, "")
+	if res.StatusCode != 200 {
+		t.Fatalf("reinstall: %d", res.StatusCode)
+	}
+	var body struct {
+		Installed bool   `json:"installed"`
+		Recovered bool   `json:"recovered"`
+		Token     string `json:"token"`
+		Message   string `json:"message"`
+	}
+	data, _ := io.ReadAll(res.Body)
+	_ = json.Unmarshal(data, &body)
+	if !body.Installed {
+		t.Fatalf("reinstall: installed=false (%s)", body.Message)
+	}
+	if body.Token == "" {
+		t.Fatalf("reinstall: sin token nuevo")
+	}
+	if prevToken != "" && body.Token == prevToken {
+		t.Fatalf("reinstall: el token no rotó (prev==new)")
+	}
+
+	// El script SSH se ejecutó en el router (algún comando al host 192.168.1.4).
+	if pool.count() == 0 {
+		t.Fatalf("reinstall: no se ejecutó ningún comando SSH")
+	}
+}

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -184,6 +184,10 @@ func NewHandler(d Deps) http.Handler {
 	mux.Handle("DELETE /api/agents/{slug}", auth.RequireAdmin(http.HandlerFunc(s.handleAgentsDelete)))
 	// Fase 5 (Plan B): rearme del servicio procd del agente vía SSH.
 	mux.Handle("POST /api/agents/{slug}/rearm", auth.RequireAdmin(http.HandlerFunc(s.handleAgentRearm)))
+	// #246: reinstalación completa del agente en el router (binario, env,
+	// servicio procd) vía SSH — recupera un agente borrado por una
+	// actualización de firmware o una desinstalación manual.
+	mux.Handle("POST /api/agents/{slug}/reinstall", auth.RequireAdmin(http.HandlerFunc(s.handleAgentReinstall)))
 	// Fase 6.2: servir binario del agente desde el propio servidor (sin GitHub).
 	// Auth por token de agente (Bearer), igual que la ingesta — el one-liner de
 	// instalación incluye el token y se ejecuta en el router, sin sesión admin.

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -188,6 +188,9 @@ func NewHandler(d Deps) http.Handler {
 	// Auth por token de agente (Bearer), igual que la ingesta — el one-liner de
 	// instalación incluye el token y se ejecuta en el router, sin sesión admin.
 	mux.HandleFunc("GET /api/agents/{slug}/binary", s.handleAgentBinary)
+	// Fase 6.3 (issue #243): el agente reporta el resultado del self-upgrade.
+	// Auth por token de agente (Bearer), igual que binary/apply-result.
+	mux.HandleFunc("POST /api/agents/{slug}/upgrade-result", s.handleAgentUpgradeResult)
 	// Fase 7.3: SSE bidireccional agente↔servidor. El agente mantiene una
 	// conexión SSE abierta; el servidor envía comandos (refresh, etc.).
 	// Auth por token de agente (Bearer), igual que ingesta y binary.
@@ -195,6 +198,8 @@ func NewHandler(d Deps) http.Handler {
 		mux.HandleFunc("GET /api/agents/{slug}/stream", s.agentHub.HandleStream)
 		// Forzar refresh del agente vía SSE (admin; útil para depuración y futuro UI)
 		mux.Handle("POST /api/agents/{slug}/refresh", auth.RequireAdmin(http.HandlerFunc(s.handleAgentRefresh)))
+		// Self-update del agente vía SSE (admin; Fase 6.3, issue #243).
+		mux.Handle("POST /api/agents/{slug}/upgrade", auth.RequireAdmin(http.HandlerFunc(s.handleAgentUpgrade)))
 	}
 
 	// --- Fase 9 R3: Pairing / adopción de agentes ---

--- a/server-go/internal/httpapi/upgrade.go
+++ b/server-go/internal/httpapi/upgrade.go
@@ -1,0 +1,86 @@
+// upgrade.go — Fase 6.3 (issue #243): self-update del agente usando el binario
+// que ya sirve el servidor (GET /api/agents/{slug}/binary).
+//
+//	POST /api/agents/{slug}/upgrade        — admin: envía el comando "upgrade"
+//	                                         al agente vía SSE para que descargue
+//	                                         el binario embebido, lo intercambie
+//	                                         y reinicie su servicio procd.
+//	POST /api/agents/{slug}/upgrade-result — el agente reporta el resultado
+//	                                         (auth por token de agente).
+package httpapi
+
+import (
+	"log"
+	"net/http"
+)
+
+// upgradeResult es el cuerpo que el agente envía a upgrade-result tras
+// intentar el auto-upgrade.
+type upgradeResult struct {
+	Slug  string `json:"slug"`
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}
+
+// handleAgentUpgrade (admin): ordena a un agente conectado que se actualice
+// descargando el binario embebido del propio servidor.
+//
+//	Códigos: 404 slug desconocido (sin token), 409 agente no conectado por SSE,
+//	         202 comando enviado, 503 sin AgentHub.
+func (s *server) handleAgentUpgrade(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("slug")
+	if !agentSlugRe.MatchString(slug) {
+		writeError(w, http.StatusNotFound, "not_found")
+		return
+	}
+	if s.agentHub == nil {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "SSE agentHub no configurado")
+		return
+	}
+	// 404 si el slug no tiene token registrado (agente desconocido).
+	if !s.agentTokenExists(slug) {
+		writeError(w, http.StatusNotFound, "not_found")
+		return
+	}
+	// El agente conoce su propia arquitectura (runtime.GOARCH); no hace falta
+	// pasársela. Data vacía {}.
+	if !s.agentHub.Send(slug, "upgrade", map[string]any{}) {
+		writeError(w, http.StatusConflict, "agent_not_connected",
+			"el agente "+slug+" no está conectado por SSE")
+		return
+	}
+	writeJSON(w, http.StatusAccepted, map[string]any{"ok": true})
+}
+
+// handleAgentUpgradeResult: el agente reporta el resultado del auto-upgrade.
+// Auth por token de agente (Bearer), igual que binary/stream/apply-result.
+func (s *server) handleAgentUpgradeResult(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("slug")
+	token := bearerToken(r)
+	if !s.checkAgentToken(slug, token) {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	var body upgradeResult
+	if !readJSONBody(r, &body) {
+		writeError(w, http.StatusBadRequest, "invalid_body")
+		return
+	}
+	if body.OK {
+		log.Printf("[netpulse] upgrade: agente %s actualizado correctamente", slug)
+	} else {
+		log.Printf("[netpulse] upgrade: agente %s falló: %s", slug, body.Error)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// agentTokenExists informa de si hay un token registrado para el slug
+// (independientemente de si el agente ha empujado o no).
+func (s *server) agentTokenExists(slug string) bool {
+	if s.db == nil {
+		return false
+	}
+	var value string
+	err := s.db.QueryRow("SELECT value FROM kv WHERE key = ?", agentTokenKey(slug)).Scan(&value)
+	return err == nil
+}

--- a/server-go/internal/httpapi/upgrade_api_test.go
+++ b/server-go/internal/httpapi/upgrade_api_test.go
@@ -1,0 +1,312 @@
+// upgrade_api_test.go — Fase 6.3 (issue #243): self-update del agente.
+// Contrato de POST /api/agents/{slug}/upgrade (admin) y
+// POST /api/agents/{slug}/upgrade-result (Bearer del agente), y del campo
+// updateAvailable de GET /api/agents.
+package httpapi_test
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/adapters"
+	"github.com/gnacho/netpulse/server-go/internal/auth"
+	"github.com/gnacho/netpulse/server-go/internal/config"
+	"github.com/gnacho/netpulse/server-go/internal/db"
+	"github.com/gnacho/netpulse/server-go/internal/httpapi"
+	"github.com/gnacho/netpulse/server-go/internal/sse"
+)
+
+type upgradeTestServer struct {
+	*httptest.Server
+	db     *db.DB
+	agents *adapters.AgentRegistry
+	hub    *sse.AgentHub
+	cookie string
+}
+
+// makeUpgradeTestServer: app real con registry + AgentHub (checkToken contra
+// kv, como producción). El AgentHub habilita stream/refresh/upgrade.
+func makeUpgradeTestServer(t *testing.T) *upgradeTestServer {
+	t.Helper()
+	auth.SetTrustProxy(true)
+	t.Cleanup(func() { auth.SetTrustProxy(false) })
+	dataDir := t.TempDir()
+	cfg, err := config.Load(map[string]string{
+		"AUTH_USER": "admin", "AUTH_PASS": "test1234",
+		"DEMO_MODE": "0", "DATA_DIR": dataDir, "NODE_ENV": "test",
+	}, dataDir)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	d, err := db.Open(dataDir)
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	secret, err := auth.EnsureSessionSecret(d, cfg)
+	if err != nil {
+		t.Fatalf("secret: %v", err)
+	}
+	if err := auth.EnsureUsers(d, cfg); err != nil {
+		t.Fatalf("users: %v", err)
+	}
+	reg := adapters.NewAgentRegistry(90 * time.Second)
+	hub := sse.NewAgentHub(func(slug, token string) bool {
+		if token == "" || d == nil {
+			return false
+		}
+		var stored string
+		if err := d.QueryRow("SELECT value FROM kv WHERE key = ?", "agent.token."+slug).Scan(&stored); err != nil {
+			return false
+		}
+		sum := sha256.Sum256([]byte(token))
+		return subtle.ConstantTimeCompare([]byte(hex.EncodeToString(sum[:])), []byte(stored)) == 1
+	})
+	handler := httpapi.NewHandler(httpapi.Deps{
+		Config: cfg, DB: d, Adapter: adapters.NewDemo(),
+		Hub:     sse.NewHub(d, cfg.MaxSSEClients, func() any { return nil }),
+		Secret:  secret, Agents: reg, AgentHub: hub, Started: time.Now(),
+	})
+	srv := httptest.NewServer(handler)
+	status, cookie, _ := loginCookie(t, srv.URL, "admin", "test1234")
+	if status != 204 {
+		t.Fatalf("login: %d", status)
+	}
+	ts := &upgradeTestServer{Server: srv, db: d, agents: reg, hub: hub, cookie: cookie}
+	t.Cleanup(func() {
+		srv.Close()
+		d.Close()
+	})
+	return ts
+}
+
+// createUpgradeToken crea el token de un slug vía API (sesión admin).
+func createUpgradeToken(t *testing.T, ts *upgradeTestServer, slug string) (int, string) {
+	t.Helper()
+	req, _ := http.NewRequest("POST", ts.URL+"/api/agents", strings.NewReader(`{"slug":"`+slug+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Cookie", "session="+ts.cookie)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/agents: %v", err)
+	}
+	defer res.Body.Close()
+	var body struct {
+		Token string `json:"token"`
+	}
+	data, _ := io.ReadAll(res.Body)
+	_ = json.Unmarshal(data, &body)
+	return res.StatusCode, body.Token
+}
+
+// postUpgrade hace POST /api/agents/{slug}/upgrade con la cookie dada.
+func postUpgrade(t *testing.T, ts *upgradeTestServer, slug, cookie string) (int, map[string]any) {
+	t.Helper()
+	req, _ := http.NewRequest("POST", ts.URL+"/api/agents/"+slug+"/upgrade", nil)
+	if cookie != "" {
+		req.Header.Set("Cookie", "session="+cookie)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /upgrade: %v", err)
+	}
+	defer res.Body.Close()
+	var body map[string]any
+	_ = json.NewDecoder(res.Body).Decode(&body)
+	return res.StatusCode, body
+}
+
+// upgradeIngest hace un push de agente (mismo contrato que rearmIngest).
+func upgradeIngest(t *testing.T, ts *upgradeTestServer, token, payload string) {
+	t.Helper()
+	req, _ := http.NewRequest("POST", ts.URL+"/api/ingest/agent", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-For", "10.9.9.1")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+		mac := hmac.New(sha256.New, []byte(token))
+		mac.Write([]byte(payload))
+		req.Header.Set("X-Agent-Signature", hex.EncodeToString(mac.Sum(nil)))
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != 202 {
+		t.Fatalf("ingest: got %d want 202", res.StatusCode)
+	}
+}
+
+// upgradePayload construye un payload válido con la versión dada.
+func upgradePayload(version string) string {
+	return fmt.Sprintf(`{"router":"patio","ts":%d,"version":%q,"data":{"system":{"sysinfo":{"uptime":100,"load":[0,0,0],"memory":{"total":100,"free":50,"buffered":0,"available":50}},"cpu":10,"temp":40},"wireless":{"clients":{}},"dhcp":{"leases":[]},"fdb":{"macs":{}}}}`, time.Now().Unix(), version)
+}
+
+// openStream registra una conexión SSE falsa del agente en el hub usando un
+// ResponseRecorder (sin servidor HTTP real, para no disparar la carrera
+// finishRequest de net/http). Devuelve cancel + done para detener el handler.
+func openStream(t *testing.T, ts *upgradeTestServer, slug, token string) (cancel context.CancelFunc, done chan struct{}) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, ts.URL+"/api/agents/"+slug+"/stream", nil).WithContext(ctx)
+	req.SetPathValue("slug", slug)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	done = make(chan struct{})
+	go func() {
+		ts.hub.HandleStream(rec, req)
+		close(done)
+	}()
+	// Margen para que el hub registre la conexión antes del POST.
+	time.Sleep(200 * time.Millisecond)
+	return cancel, done
+}
+
+func TestUpgradeSinSesion401(t *testing.T) {
+	ts := makeUpgradeTestServer(t)
+	status, body := postUpgrade(t, ts, "patio", "")
+	if status != 401 || body["error"] != "unauthorized" {
+		t.Fatalf("sin sesión: got %d %v", status, body)
+	}
+}
+
+func TestUpgradeNoAdmin403(t *testing.T) {
+	ts := makeUpgradeTestServer(t)
+	// Crear usuario no-admin y loguear con él.
+	req, _ := http.NewRequest("POST", ts.URL+"/api/users", strings.NewReader(`{"username":"ana","password":"secreto12345"}`))
+	req.Header.Set("Cookie", "session="+ts.cookie)
+	res, _ := http.DefaultClient.Do(req)
+	res.Body.Close()
+	_, anaCookie, _ := loginCookie(t, ts.URL, "ana", "secreto12345")
+	status, body := postUpgrade(t, ts, "patio", anaCookie)
+	if status != 403 || body["error"] != "forbidden" {
+		t.Fatalf("no-admin: got %d %v", status, body)
+	}
+}
+
+func TestUpgradeSlugDesconocido404(t *testing.T) {
+	ts := makeUpgradeTestServer(t)
+	// Sin token registrado → 404 (distinto del 409 de "no conectado").
+	status, body := postUpgrade(t, ts, "noexiste", ts.cookie)
+	if status != 404 || body["error"] != "not_found" {
+		t.Fatalf("slug desconocido: got %d %v", status, body)
+	}
+}
+
+func TestUpgradeNoConectado409(t *testing.T) {
+	ts := makeUpgradeTestServer(t)
+	if st, _ := createUpgradeToken(t, ts, "patio"); st != 201 {
+		t.Fatalf("create: %d", st)
+	}
+	status, body := postUpgrade(t, ts, "patio", ts.cookie)
+	if status != 409 || body["error"] != "agent_not_connected" {
+		t.Fatalf("no conectado: got %d %v", status, body)
+	}
+}
+
+func TestUpgradeConectado202(t *testing.T) {
+	ts := makeUpgradeTestServer(t)
+	st, tok := createUpgradeToken(t, ts, "patio")
+	if st != 201 || tok == "" {
+		t.Fatalf("create: %d", st)
+	}
+	cancel, done := openStream(t, ts, "patio", tok)
+
+	status, body := postUpgrade(t, ts, "patio", ts.cookie)
+	if status != 202 || body["ok"] != true {
+		t.Fatalf("conectado: got %d %v", status, body)
+	}
+	if len(body) != 1 {
+		t.Fatalf("body con claves extra: %v", body)
+	}
+	cancel()
+	<-done
+}
+
+func TestUpgradeResultBearer(t *testing.T) {
+	ts := makeUpgradeTestServer(t)
+	st, tok := createUpgradeToken(t, ts, "patio")
+	if st != 201 || tok == "" {
+		t.Fatalf("create: %d", st)
+	}
+
+	post := func(token, body string) int {
+		req, _ := http.NewRequest("POST", ts.URL+"/api/agents/patio/upgrade-result", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("upgrade-result: %v", err)
+		}
+		defer res.Body.Close()
+		return res.StatusCode
+	}
+
+	// Sin token → 401 (bypass de RequireAuth, pero el handler exige Bearer).
+	if got := post("", `{"ok":true}`); got != 401 {
+		t.Fatalf("sin token: got %d want 401", got)
+	}
+	// Token inválido → 401.
+	if got := post("deadbeef", `{"ok":true}`); got != 401 {
+		t.Fatalf("token malo: got %d want 401", got)
+	}
+	// Token válido, body ok → 200.
+	if got := post(tok, `{"ok":true}`); got != 200 {
+		t.Fatalf("ok válido: got %d want 200", got)
+	}
+	// Token válido, body con error → 200 (se loguea).
+	if got := post(tok, `{"ok":false,"error":"swap failed"}`); got != 200 {
+		t.Fatalf("error válido: got %d want 200", got)
+	}
+	// Body no-JSON → 400.
+	if got := post(tok, `not-json`); got != 400 {
+		t.Fatalf("body roto: got %d want 400", got)
+	}
+}
+
+// TestAgentsListUpdateAvailable: el campo updateAvailable refleja si la versión
+// reportada por el agente difiere del binario embebido (agentbin.EmbeddedAgentVersion).
+func TestAgentsListUpdateAvailable(t *testing.T) {
+	ts := makeUpgradeTestServer(t)
+	st, tok := createUpgradeToken(t, ts, "patio")
+	if st != 201 {
+		t.Fatalf("create: %d", st)
+	}
+
+	agentItem := func() map[string]any {
+		res := get(t, ts.URL, "/api/agents", ts.cookie)
+		body := readJSON(t, res)
+		for _, a := range body["agents"].([]any) {
+			if m, _ := a.(map[string]any); m["slug"] == "patio" {
+				return m
+			}
+		}
+		t.Fatalf("patio ausente: %v", body)
+		return nil
+	}
+
+	// Push con versión == EmbeddedAgentVersion (0.1.0) → updateAvailable=false.
+	upgradeIngest(t, ts, tok, upgradePayload("0.1.0"))
+	if patio := agentItem(); patio["updateAvailable"] != false {
+		t.Fatalf("versión 0.1.0 debe dar updateAvailable=false: %v", patio)
+	}
+
+	// Push con versión distinta → updateAvailable=true.
+	upgradeIngest(t, ts, tok, upgradePayload("9.9.9"))
+	if patio := agentItem(); patio["updateAvailable"] != true {
+		t.Fatalf("versión 9.9.9 debe dar updateAvailable=true: %v", patio)
+	}
+}

--- a/server-go/internal/routerstore/routerstore.go
+++ b/server-go/internal/routerstore/routerstore.go
@@ -27,7 +27,7 @@ const probeTimeout = 4 * time.Second
 // ListRouters devuelve la tabla routers ordenada is_gateway DESC,
 // created_at ASC, con is_gateway como booleano.
 func ListRouters(db *sql.DB) []adapters.RouterConfig {
-	rows, err := db.Query("SELECT id, name, host, type, is_gateway, agent_only, created_at FROM routers ORDER BY is_gateway DESC, created_at ASC")
+	rows, err := db.Query("SELECT id, name, host, type, is_gateway, agent_only, firmware_target, created_at FROM routers ORDER BY is_gateway DESC, created_at ASC")
 	if err != nil {
 		return []adapters.RouterConfig{}
 	}
@@ -36,11 +36,12 @@ func ListRouters(db *sql.DB) []adapters.RouterConfig {
 	for rows.Next() {
 		var r adapters.RouterConfig
 		var gw, ao int
-		var name sql.NullString
-		if err := rows.Scan(&r.ID, &name, &r.Host, &r.Type, &gw, &ao, &r.CreatedAt); err != nil {
+		var name, ft sql.NullString
+		if err := rows.Scan(&r.ID, &name, &r.Host, &r.Type, &gw, &ao, &ft, &r.CreatedAt); err != nil {
 			continue
 		}
 		r.Name = name.String
+		r.FirmwareTarget = ft.String
 		r.IsGateway = gw == 1
 		r.AgentOnly = ao == 1
 		out = append(out, r)
@@ -119,6 +120,8 @@ type AddInput struct {
 	Type      string // default "openwrt"
 	IsGateway bool
 	AgentOnly bool
+	// FirmwareTarget: versión objetivo (issue #241). "" = sin comprobar.
+	FirmwareTarget string
 }
 
 // AddRouter inserta un router (si IsGateway, el resto pierde el flag —
@@ -152,8 +155,8 @@ func AddRouter(db *sql.DB, in AddInput) (adapters.RouterConfig, error) {
 		ao = 1
 	}
 	if _, err := tx.Exec(
-		"INSERT INTO routers (id, name, host, type, is_gateway, agent_only, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-		id, name, in.Host, in.Type, gw, ao, now,
+		"INSERT INTO routers (id, name, host, type, is_gateway, agent_only, firmware_target, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+		id, name, in.Host, in.Type, gw, ao, in.FirmwareTarget, now,
 	); err != nil {
 		return adapters.RouterConfig{}, err
 	}
@@ -186,6 +189,8 @@ type UpdateInput struct {
 	Type      *string
 	IsGateway *bool
 	AgentOnly *bool
+	// FirmwareTarget: versión objetivo (issue #241). nil = no tocar; "" = limpiar.
+	FirmwareTarget *string
 }
 
 // UpdateRouter actualiza un router existente por id. Si IsGateway pasa a true,
@@ -238,6 +243,10 @@ func UpdateRouter(db *sql.DB, id string, in UpdateInput) (adapters.RouterConfig,
 		}
 		sets = append(sets, "agent_only = ?")
 		args = append(args, ao)
+	}
+	if in.FirmwareTarget != nil {
+		sets = append(sets, "firmware_target = ?")
+		args = append(args, *in.FirmwareTarget)
 	}
 	if len(sets) > 0 {
 		args = append(args, id)

--- a/server-go/internal/sshkey/sshkey.go
+++ b/server-go/internal/sshkey/sshkey.go
@@ -5,11 +5,13 @@
 package sshkey
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 )
 
 // BaseArgs replica sshBaseArgs (src/sshkey.js:16-24): los args SSH comunes.
@@ -85,4 +87,30 @@ func GetPublicKey(keyPath string) *PublicKey {
 		}
 	}
 	return &PublicKey{PublicKey: pub, Fingerprint: fp}
+}
+
+// RotateKeypair regenera el par de claves (issue #242): respalda el par actual
+// como <keyPath>.bak.<epoch> y genera uno nuevo. known_hosts NO se toca (las
+// host keys de los routers son independientes del par del cliente). Devuelve
+// la nueva clave pública para reautorizarla en los routers. Si el par actual
+// no existe, simplemente genera uno (sin backup).
+func RotateKeypair(keyPath string) (*PublicKey, error) {
+	// Backup del par actual si existe.
+	if _, err := os.Stat(keyPath); err == nil {
+		bak := fmt.Sprintf("%s.bak.%d", keyPath, time.Now().Unix())
+		if err := os.Rename(keyPath, bak); err != nil {
+			return nil, &ExecError{What: "rotate-backup", Err: err}
+		}
+		if _, err := os.Stat(keyPath + ".pub"); err == nil {
+			_ = os.Rename(keyPath+".pub", bak+".pub")
+		}
+	}
+	if err := EnsureKeypair(keyPath); err != nil {
+		return nil, err
+	}
+	key := GetPublicKey(keyPath)
+	if key == nil {
+		return nil, &ExecError{What: "rotate-public-key", Err: os.ErrNotExist}
+	}
+	return key, nil
 }


### PR DESCRIPTION
## Qué incluye

Cierra el bloque de auditoría comparativa vs ac-client: 4 features entrelazadas
(compárten ficheros: agent, SSE, httpapi, Settings/translation), por eso van en
un solo PR:

- **#241** — Detección de firmware desactualizado: `firmware_target` configurable
  por router (Ajustes), comparación `Contains` case-insensitive en el adapter
  live, alerta no urgente (system), badge ámbar en la tarjeta y salud -5.
- **#242** — Rotación del par ed25519 SSH del servidor con confirmación
  (`POST /api/config/sshkey/rotate`, backup automático, botón en Ajustes).
- **#243** — Self-update del agente: `updateAvailable` en `/api/agents`,
  `POST /api/agents/{slug}/upgrade` (evento SSE), el agente descarga el binario
  del server, swap atómico y reinicio procd; botón "Actualizar agente".
- **#246** — Reinstall del agente desde la app vía SSH (`POST /api/agents/{slug}/reinstall`):
  rota token, descarga binario, instala env + init procd; botón junto a LuCI/SSH
  en el detalle (rojo si el agente está caído o no instalado).
- ROADMAP: Fase 17.12 "Firmware update in-app (labs)".

## Detalles técnicos

- `agentbin.EmbeddedAgentVersion` ahora es `var` inyectada por ldflags con el
  mismo valor que `main.Version` del agente (go.yml / release.yml /
  .goreleaser.yaml), única fuente de verdad para `updateAvailable`.
- Exponemos `router.agentOnly` en el view-model: badge "Agente no instalado"
  (rojo) cuando un router agent-only no tiene agente, frente a "Agente caído"
  (rojo) cuando está registrado pero no responde.
- Fix: copiar el comando SSH al portapapeles en LAN HTTP (fallback execCommand).

## Validación

Deployado y verificado en producción (CT 226): self-upgrade de un AP real
(2.10.2-243 → 2.10.2-244), reinstall completo tras borrar el agente, y
`updateAvailable` coherente con la versión embebida.

Closes #241, #242, #243, #246
