### PR TITLE
test(updater): fix flaky apply deadline under -race

### DIFF
--- a/server-go/internal/updater/updater_helpers_test.go
+++ b/server-go/internal/updater/updater_helpers_test.go
@@ -41,7 +41,7 @@ func writeSlowScript(t *testing.T, root string) {
 // waitDone espera a que el update acabe (updating false o step done).
 func waitDone(t *testing.T, u *Updater) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(30 * time.Second)
 	for {
 		st := u.Status()
 		if m, ok := st.Updating.(progress); ok && m.Step == "done" {

--- a/server-go/internal/updater/updater_test.go
+++ b/server-go/internal/updater/updater_test.go
@@ -153,7 +153,7 @@ func TestApplyYaEnCursoYScript(t *testing.T) {
 	if u.Apply() {
 		t.Fatal("apply duplicado debería ser false")
 	}
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(30 * time.Second)
 	for {
 		st := u.Status()
 		if m, ok := st.Updating.(progress); ok && m.Step == "done" {


### PR DESCRIPTION
Fixes #259.

Raise the apply-wait deadline from 5s to 30s in the updater tests. The apply performs git clone/fetch/merge; under -race on a loaded machine 5s is not enough wall-clock, causing intermittent failures with no code defect. Verified: 3x `go test -race ./internal/updater/ -count=2` all ok.