### PR TITLE
backlog sweep: backend fixes, frontend, demo, features, orchestration WireGuard

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -2,3 +2,4 @@ c6ae504f95ae416450b2ca884db80c2112bdb614:server-go/internal/db/migrate_node_test
 d699083e78374c3508a80a84487c59b4ff458390:server-go/internal/db/migrate_node_test.go:generic-api-key:37
 85ca49bc95c9dbc422d58d4bf7d5b29ee67397ba:server-go/internal/httpapi/push.go:generic-api-key:51
 39727b9dfc1773882a7f0388f9db21fedb6a4bc7:server-go/internal/httpapi/migrate_e2e_test.go:generic-api-key:34
+c4cd4538a3187d7fa8e0b0fe2bdd5d95aafe245c:server-go/internal/httpapi/migrate_e2e_test.go:generic-api-key:34

--- a/agent/executor/executor.go
+++ b/agent/executor/executor.go
@@ -22,7 +22,7 @@ import (
 
 // Op es una operación allowlistedada que el ejecutor puede aplicar.
 type Op struct {
-	Kind string            `json:"kind"` // uci_set|uci_delete|uci_add_list|uci_commit|service|install
+	Kind string            `json:"kind"` // uci_set|uci_delete|uci_add_list|uci_commit|service|install|wg_check
 	Args map[string]string `json:"args"`
 	Desc string            `json:"desc"` // descripción humana para el diff
 }
@@ -286,6 +286,18 @@ var allowlist = map[string]opSpec{
 		},
 		configs: func(a map[string]string) []string { return nil },
 	},
+	// wg_check: healthcheck del módulo WireGuard (10.3). Ejecuta
+	// `wg show <interface>`; exit 0 si el túnel está arriba en el kernel,
+	// exit 1 si no existe o está caído. Al final del plan (tras el reload de
+	// red), una fallo aquí significa que el apply aisló el túnel → el executor
+	// restaura los snapshots (rollback real, ver Apply).
+	"wg_check": {
+		required: map[string]*regexp.Regexp{"interface": reSection},
+		build: func(a map[string]string) (string, []string) {
+			return "wg", []string{"show", a["interface"]}
+		},
+		configs: func(a map[string]string) []string { return nil },
+	},
 }
 
 // tcpCheckBudget / tcpCheckRetry controlan los reintentos del Kind tcp_check.
@@ -375,6 +387,17 @@ func (e *Executor) Apply(ops []Op) ApplyResult {
 			_, code = e.run.Run(cmd, cmdArgs...)
 		}
 		if code != 0 {
+			if op.Kind == "wg_check" {
+				// Healthcheck del módulo WireGuard: el túnel no levantó tras el
+				// apply. Rollback real: restaurar los snapshots UCI (uci import)
+				// y relanzar la red con la config previa.
+				for cfg, snap := range snapshots {
+					e.run.Run("sh", "-c", fmt.Sprintf("echo '%s' | uci import", snap))
+					e.run.Run("uci", "commit", cfg)
+				}
+				e.run.Run("/etc/init.d/network", "reload")
+				return ApplyResult{Status: "rolled_back", Op: op.Desc, Error: "wg_check_failed", Snapshot: strings.Join(affected, ","), DurationMs: ms(e.now(), start)}
+			}
 			// Revert staged changes y salir.
 			e.revertStaged(affected)
 			return ApplyResult{Status: "failed", Op: op.Desc, Error: fmt.Sprintf("%s exit %d", op.Kind, code), DurationMs: ms(e.now(), start)}

--- a/agent/executor/executor_test.go
+++ b/agent/executor/executor_test.go
@@ -450,6 +450,52 @@ func TestApplyHealthcheckFailRollsBack(t *testing.T) {
 	}
 }
 
+// TestValidateWgCheck (10.3): el healthcheck del túnel valida interface y
+// rechaza metachars shell.
+func TestValidateWgCheck(t *testing.T) {
+	if err := Validate(Op{Kind: "wg_check", Args: map[string]string{"interface": "wg0"}}); err != nil {
+		t.Fatalf("valid wg_check rejected: %v", err)
+	}
+	if err := Validate(Op{Kind: "wg_check", Args: map[string]string{"interface": "wg0; rm -rf /"}}); err == nil {
+		t.Fatal("wg_check with shell metachars should be rejected")
+	}
+	if err := Validate(Op{Kind: "wg_check", Args: map[string]string{}}); err == nil {
+		t.Fatal("wg_check missing interface should be rejected")
+	}
+}
+
+// TestApplyWgCheckFailRollsBack (10.3): si `wg show wg0` falla tras el apply,
+// el executor restaura los snapshots y relanza la red (rollback real), en vez
+// de devolver un simple "failed".
+func TestApplyWgCheckFailRollsBack(t *testing.T) {
+	fr := newFakeRunner()
+	fr.responses["wg show wg0"] = 1 // el túnel no levantó tras el reload
+
+	e := &Executor{run: fr, now: time.Now, gwTarget: "192.168.1.1"}
+	ops := []Op{
+		{Kind: "uci_set_named", Args: map[string]string{"config": "network", "section": "wg0", "type": "interface"}, Desc: "Create interface"},
+		{Kind: "uci_set", Args: map[string]string{"config": "network", "section": "wg0", "option": "proto", "value": "wireguard"}, Desc: "Set proto"},
+		{Kind: "uci_commit", Args: map[string]string{"config": "network"}, Desc: "Commit"},
+		{Kind: "service", Args: map[string]string{"name": "network", "action": "reload"}, Desc: "Reload network"},
+		{Kind: "wg_check", Args: map[string]string{"interface": "wg0"}, Desc: "Check tunnel up"},
+	}
+
+	res := e.Apply(ops)
+	if res.Status != "rolled_back" {
+		t.Fatalf("expected rolled_back, got %s (error=%s)", res.Status, res.Error)
+	}
+	if res.Error != "wg_check_failed" {
+		t.Fatalf("error should be wg_check_failed, got %s", res.Error)
+	}
+	got := strings.Join(fr.calls, "\n")
+	if !strings.Contains(got, "uci import") {
+		t.Error("should have restored the snapshot (uci import) on wg_check failure")
+	}
+	if !strings.Contains(got, "/etc/init.d/network reload") {
+		t.Error("should have reloaded network after restoring the snapshot")
+	}
+}
+
 func TestAffectedConfigsDedup(t *testing.T) {
 	ops := []Op{
 		{Kind: "uci_set", Args: map[string]string{"config": "dhcp", "section": "s1", "option": "o1", "value": "v1"}},

--- a/agent/probe/local.go
+++ b/agent/probe/local.go
@@ -91,6 +91,7 @@ func (p *Prober) Build(ctx context.Context, router, version string) *Payload {
 	pl.Data.DHCP = p.probeDHCP(ctx)
 	pl.Data.FDB = p.probeFDB(ctx)
 	pl.Data.Dawn = p.probeDawn(ctx)
+	pl.Data.LuCI = p.probeLuCI(ctx)
 	return pl
 }
 
@@ -272,6 +273,16 @@ func (p *Prober) probeFDB(ctx context.Context) *FDBData {
 		fd.Ports = []EthPort{}
 	}
 	return fd
+}
+
+// probeLuCI: etiquetas de puertos/VLANs de LuCI (issue #258), si el router
+// las define en /etc/config/luci. Best-effort: sin fichero/sección → nil.
+func (p *Prober) probeLuCI(ctx context.Context) *LuCILabels {
+	out := p.runBest(ctx, CmdLuCILabels, 0)
+	if out == "" {
+		return nil
+	}
+	return ParseLuCILabels(out)
 }
 
 // probeDawn: lee el estado de DAWN (roaming/band-steering, Fase 14) vía

--- a/agent/probe/payload.go
+++ b/agent/probe/payload.go
@@ -21,6 +21,9 @@ type PayloadData struct {
 	DHCP     *DHCPData     `json:"dhcp,omitempty"`
 	FDB      *FDBData      `json:"fdb,omitempty"`
 	Dawn     *DawnData     `json:"dawn,omitempty"` // Fase 14: DAWN roaming (solo si instalado)
+	// LuCI: etiquetas de puertos/VLANs del router (issue #258), si están
+	// definidas en /etc/config/luci.
+	LuCI *LuCILabels `json:"luci,omitempty"`
 }
 
 // SystemData: salud del equipo + tráfico + latencias.

--- a/agent/probe/probe.go
+++ b/agent/probe/probe.go
@@ -68,6 +68,11 @@ const (
 	CmdUbusSystemBoard = "ubus call system board"
 	CmdUbusSystemInfo  = "ubus call system info"
 	CmdUbusWireless    = "ubus call network.wireless status"
+	// CmdLuCILabels: etiquetas de puertos/VLANs de LuCI (issue #258). OpenWrt
+	// snapshots añaden `config switchvlan 'port_labels'` y `'vlan_labels'` en
+	// /etc/config/luci con nombres amigables para la topología. Se lee el
+	// fichero crudo (uci show luci sería más ruidoso: todo el paquete).
+	CmdLuCILabels = "cat /etc/config/luci 2>/dev/null"
 )
 
 // ---------------------------------------------------------------------------
@@ -584,6 +589,66 @@ func ParseBridgeFdb(out string) map[string]string {
 		}
 	}
 	return m
+}
+
+// LuCILabels: etiquetas de puertos y VLANs de LuCI (issue #258). OpenWrt
+// snapshots las definen en /etc/config/luci como secciones switchvlan:
+//
+//	config switchvlan 'port_labels'
+//		option lan1 'Router/Fritzbox'
+//	config switchvlan 'vlan_labels'
+//		option 1 'LAN'
+//
+// PortLabels mapea interfaz (lan1…) → etiqueta; VlanLabels mapea id de
+// VLAN → etiqueta.
+type LuCILabels struct {
+	PortLabels map[string]string `json:"portLabels,omitempty"`
+	VlanLabels map[string]string `json:"vlanLabels,omitempty"`
+}
+
+var (
+	luciSectionRe = regexp.MustCompile(`^config\s+(\S+)\s+['"]?([A-Za-z0-9_]+)['"]?`)
+	luciOptionRe  = regexp.MustCompile(`^option\s+(\S+)\s+['"]?([^'"]*)['"]?$`)
+)
+
+// ParseLuCILabels parsea /etc/config/luci y extrae las secciones
+// port_labels/vlan_labels. Devuelve nil si no hay ninguna etiqueta.
+func ParseLuCILabels(out string) *LuCILabels {
+	var labels LuCILabels
+	var section string
+	for _, raw := range strings.Split(out, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if m := luciSectionRe.FindStringSubmatch(line); m != nil {
+			section = m[2]
+			continue
+		}
+		if section != "port_labels" && section != "vlan_labels" {
+			continue
+		}
+		if m := luciOptionRe.FindStringSubmatch(line); m != nil {
+			if m[2] == "" {
+				continue
+			}
+			if section == "port_labels" {
+				if labels.PortLabels == nil {
+					labels.PortLabels = map[string]string{}
+				}
+				labels.PortLabels[m[1]] = m[2]
+			} else {
+				if labels.VlanLabels == nil {
+					labels.VlanLabels = map[string]string{}
+				}
+				labels.VlanLabels[m[1]] = m[2]
+			}
+		}
+	}
+	if len(labels.PortLabels) == 0 && len(labels.VlanLabels) == 0 {
+		return nil
+	}
+	return &labels
 }
 
 var nonDigitRe = regexp.MustCompile(`\D`)

--- a/agent/probe/probe_test.go
+++ b/agent/probe/probe_test.go
@@ -193,6 +193,34 @@ func TestParseFdbBridgeFdb(t *testing.T) {
 
 // TestParseFdbExcluyeWireless — #253: los puertos inalámbricos (phy*-ap*,
 // wlan*, bat*) no deben entrar como clientes cableados.
+func TestParseLuCILabels(t *testing.T) {
+	out := `config switchvlan 'port_labels'
+	option lan1 'Router/Fritzbox'
+	option lan2 'Garage door'
+config switchvlan 'vlan_labels'
+	option 1 'LAN'
+	option 2 'WAN'
+config language 'main'
+	option lang 'es'
+`
+	labels := ParseLuCILabels(out)
+	if labels == nil {
+		t.Fatal("con etiquetas debería devolver datos")
+	}
+	if labels.PortLabels["lan1"] != "Router/Fritzbox" || labels.PortLabels["lan2"] != "Garage door" {
+		t.Fatalf("port_labels: %+v", labels.PortLabels)
+	}
+	if labels.VlanLabels["1"] != "LAN" || labels.VlanLabels["2"] != "WAN" {
+		t.Fatalf("vlan_labels: %+v", labels.VlanLabels)
+	}
+	if ParseLuCILabels("config language 'main'\n\toption lang 'es'\n") != nil {
+		t.Fatal("sin port_labels/vlan_labels → nil")
+	}
+	if ParseLuCILabels("") != nil {
+		t.Fatal("vacío → nil")
+	}
+}
+
 func TestParseFdbExcluyeWireless(t *testing.T) {
 	fdb := ParseBridgeFdb("==PORTS==\n0x1 lan1\n0x5 phy0-ap0\n==MACS==\n1 aa:bb:cc:dd:ee:01\n5 ff:ee:dd:cc:bb:aa\n")
 	if _, ok := fdb["FF:EE:DD:CC:BB:AA"]; ok {

--- a/app/index.html
+++ b/app/index.html
@@ -18,35 +18,11 @@
       rel="stylesheet"
     />
     <title>NetPulse - Tu red, de un vistazo</title>
-    <style>
-      /* Splash oscuro mientras carga el bundle (PWA) */
-      #root:empty {
-        background: #070b12;
-      }
-      html {
-        background: #070b12;
-      }
-    </style>
+    <link rel="stylesheet" href="/src/splash.css" />
+    <script src="/boot.js"></script>
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <script>
-      // Red de seguridad (bug pantalla negra tras update): si el bundle no
-      // carga, #root queda vacío (el splash CSS pinta negro). Tras 8 s se
-      // recarga UNA vez (guard en sessionStorage evita bucles); si vuelve a
-      // fallar, mensaje en vez de recargar.
-      window.setTimeout(function () {
-        var r = document.getElementById('root')
-        if (!r || r.childElementCount > 0) { sessionStorage.removeItem('np-blank'); return }
-        if (!sessionStorage.getItem('np-blank')) {
-          sessionStorage.setItem('np-blank', '1')
-          location.reload()
-        } else {
-          r.textContent = 'La app no pudo cargar (¿actualización en curso?). Recarga la página.'
-          r.style.cssText = 'padding:2rem;text-align:center;color:#98a2b3;font-family:Inter,system-ui,sans-serif;font-size:14px'
-        }
-      }, 8000)
-    </script>
   </body>
 </html>

--- a/app/public/boot.js
+++ b/app/public/boot.js
@@ -1,0 +1,15 @@
+// Red de seguridad (bug pantalla negra tras update): si el bundle no
+// carga, #root queda vacío (el splash CSS pinta negro). Tras 8 s se
+// recarga UNA vez (guard en sessionStorage evita bucles); si vuelve a
+// fallar, mensaje en vez de recargar.
+window.setTimeout(function () {
+  var r = document.getElementById('root')
+  if (!r || r.childElementCount > 0) { sessionStorage.removeItem('np-blank'); return }
+  if (!sessionStorage.getItem('np-blank')) {
+    sessionStorage.setItem('np-blank', '1')
+    location.reload()
+  } else {
+    r.textContent = 'La app no pudo cargar (¿actualización en curso?). Recarga la página.'
+    r.style.cssText = 'padding:2rem;text-align:center;color:#98a2b3;font-family:Inter,system-ui,sans-serif;font-size:14px'
+  }
+}, 8000)

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1183,5 +1183,12 @@
         "disabled": "Disabled"
       }
     }
+  },
+  "installPrompt": {
+    "title": "Install NetPulse as an app?",
+    "desc": "Launch it from your home screen, no browser bar.",
+    "iosDesc": "On iOS: open the Share menu and choose Add to Home Screen.",
+    "install": "Install",
+    "later": "Not now"
   }
 }

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1115,7 +1115,8 @@
       "adguard": "AdGuard Home",
       "guestwifi": "Guest WiFi",
       "ddns": "DDNS",
-      "sqm": "QoS (SQM)"
+      "sqm": "QoS (SQM)",
+      "wireguard": "WireGuard"
     },
     "warn": {
       "managed_by_firmware": "This router ships a vendor AdGuard Home (GL.iNet). NetPulse won't manage it to avoid breaking its UI: configure it from the router's own interface.",
@@ -1181,6 +1182,24 @@
       "method": {
         "enabled": "Enabled",
         "disabled": "Disabled"
+      }
+    },
+    "wireguard": {
+      "allowNonGateway": "Allow WireGuard on non-gateway routers",
+      "nonGatewayWarning": "The WireGuard tunnel can live on any router with WireGuard configured. Peer management is not limited to the gateway.",
+      "interface": "Interface",
+      "adminPeer": "Admin pubkey (never removed)",
+      "adminPeerPlaceholder": "Base64 public key of your own peer (anti-lockout)",
+      "peers": "Tunnel peers",
+      "addPeer": "Add peer",
+      "removePeer": "Remove peer",
+      "peerName": "Name",
+      "peerPubkey": "Public key",
+      "peerAllowedIps": "Allowed IPs",
+      "peersHint": "Peers present on the router that are not in this list are removed. A peer whose public key matches the admin's is always kept.",
+      "method": {
+        "active": "Tunnel active",
+        "inactive": "Tunnel inactive"
       }
     }
   }

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -313,7 +313,8 @@
     "topologyDesc": "Visual network map",
     "collapse": "Collapse menu",
     "expand": "Expand menu",
-    "orchestration": "Orchestration"
+    "orchestration": "Orchestration",
+    "agents": "Agents"
   },
   "roaming": {
     "subtitle": "Roaming and WiFi mesh status",
@@ -572,7 +573,30 @@
     "upgradeAllTitle": "Update all agents?",
     "upgradeCancel": "Cancel",
     "upgradeFailed": "No response — reinstall from router detail",
-    "upgradeProgressFailed": "{{failed}} agent(s) did not respond ({{done}}/{{total}} updated)"
+    "upgradeProgressFailed": "{{failed}} agent(s) did not respond ({{done}}/{{total}} updated)",
+    "agents": {
+      "subtitle": "{{total}} agent(s) · {{down}} not reporting",
+      "empty": "No registered agents.",
+      "colDevice": "Device",
+      "colStatus": "Status",
+      "colLastSeen": "Last push",
+      "colVersion": "Version",
+      "colActions": "Actions",
+      "never": "never",
+      "reinstall": "Reinstall",
+      "reinstalling": "Reinstalling…",
+      "reinstalled": "Reinstalled",
+      "reinstallRetry": "Retry",
+      "reinstallTip": "Reinstall the agent on this router (binary, config and service) via SSH. Use this if the agent was removed by a firmware update or manual uninstall.",
+      "reinstallConfirm": "Reinstall the agent on {{router}}? The current agent (if any) will be replaced and its token rotated.",
+      "reinstallDone": "Agent reinstalled and reporting again.",
+      "reinstallPending": "Agent installed; waiting for it to report (up to 40s).",
+      "reinstallFail": "Reinstall failed",
+      "copyCmd": "Copy command",
+      "copyCmdTip": "Generates the manual install one-liner (fallback for routers without SSH). The token rotates on every generation.",
+      "copied": "Command copied",
+      "cmdFail": "Could not generate the command"
+    }
   },
   "reports": {
     "availability": "Availability",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1183,5 +1183,12 @@
         "disabled": "Desactivado"
       }
     }
+  },
+  "installPrompt": {
+    "title": "¿Instalar NetPulse como app?",
+    "desc": "Acceso directo desde tu pantalla de inicio y sin barra del navegador.",
+    "iosDesc": "En iOS: abre el menú Compartir y elige Añadir a pantalla de inicio.",
+    "install": "Instalar",
+    "later": "Ahora no"
   }
 }

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -313,7 +313,8 @@
     "topologyDesc": "Mapa visual de la red",
     "collapse": "Plegar menú",
     "expand": "Desplegar menú",
-    "orchestration": "Orquestación"
+    "orchestration": "Orquestación",
+    "agents": "Agentes"
   },
   "roaming": {
     "subtitle": "Estado del roaming y la malla WiFi",
@@ -572,7 +573,30 @@
     "upgradeAllTitle": "¿Actualizar todos los agentes?",
     "upgradeCancel": "Cancelar",
     "upgradeFailed": "Sin respuesta — reinstala desde el detalle",
-    "upgradeProgressFailed": "{{failed}} agente(s) sin respuesta ({{done}}/{{total}} actualizados)"
+    "upgradeProgressFailed": "{{failed}} agente(s) sin respuesta ({{done}}/{{total}} actualizados)",
+    "agents": {
+      "subtitle": "{{total}} agente(s) · {{down}} sin reportar",
+      "empty": "Sin agentes registrados.",
+      "colDevice": "Equipo",
+      "colStatus": "Estado",
+      "colLastSeen": "Último push",
+      "colVersion": "Versión",
+      "colActions": "Acciones",
+      "never": "nunca",
+      "reinstall": "Reinstalar",
+      "reinstalling": "Reinstalando…",
+      "reinstalled": "Reinstalado",
+      "reinstallRetry": "Reintentar",
+      "reinstallTip": "Reinstala el agente en este router (binario, config y servicio) vía SSH. Úsalo si el agente fue borrado por una actualización de firmware o una desinstalación manual.",
+      "reinstallConfirm": "¿Reinstalar el agente en {{router}}? El agente actual (si lo hay) será sustituido y su token rotado.",
+      "reinstallDone": "Agente reinstalado y empujando de nuevo.",
+      "reinstallPending": "Agente instalado; esperando a que empuje (hasta 40 s).",
+      "reinstallFail": "Fallo al reinstalar",
+      "copyCmd": "Copiar comando",
+      "copyCmdTip": "Genera el one-liner de instalación manual (fallback para routers sin SSH). El token se rota en cada generación.",
+      "copied": "Comando copiado",
+      "cmdFail": "No se pudo generar el comando"
+    }
   },
   "reports": {
     "availability": "Disponibilidad",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1115,7 +1115,8 @@
       "adguard": "AdGuard Home",
       "guestwifi": "WiFi invitados",
       "ddns": "DDNS",
-      "sqm": "QoS (SQM)"
+      "sqm": "QoS (SQM)",
+      "wireguard": "WireGuard"
     },
     "warn": {
       "managed_by_firmware": "Este router trae un AdGuard Home del fabricante (GL.iNet). NetPulse no lo gestiona para no romper su UI: configúralo desde la interfaz del router.",
@@ -1181,6 +1182,24 @@
       "method": {
         "enabled": "Activado",
         "disabled": "Desactivado"
+      }
+    },
+    "wireguard": {
+      "allowNonGateway": "Permitir WireGuard en routers no-gateway",
+      "nonGatewayWarning": "El túnel WireGuard puede vivir en cualquier router con WireGuard configurado. La gestión de peers no está limitada al gateway.",
+      "interface": "Interfaz",
+      "adminPeer": "Pubkey del admin (no se borra)",
+      "adminPeerPlaceholder": "Clave pública base64 de tu propio peer (anti-lockout)",
+      "peers": "Peers del túnel",
+      "addPeer": "Añadir peer",
+      "removePeer": "Quitar peer",
+      "peerName": "Nombre",
+      "peerPubkey": "Public key",
+      "peerAllowedIps": "Allowed IPs",
+      "peersHint": "Los peers presentes en el router que no estén en esta lista se borran. El peer cuyo public key coincida con la del admin se conserva siempre.",
+      "method": {
+        "active": "Túnel activo",
+        "inactive": "Túnel inactivo"
       }
     }
   }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -6,6 +6,7 @@ import Home from '@/pages/Home'
 import Login from '@/pages/Login'
 import Routers from '@/pages/Routers'
 import RouterDetail from '@/pages/RouterDetail'
+import Agents from '@/pages/Agents'
 import Devices from '@/pages/Devices'
 import Topology from '@/pages/Topology'
 import Alerts from '@/pages/Alerts'
@@ -36,6 +37,7 @@ export default function App() {
         <Route index element={<Home />} />
         <Route path="routers" element={<Routers />} />
         <Route path="routers/:id" element={<RouterDetail />} />
+        <Route path="agents" element={<Agents />} />
         <Route path="devices" element={<Devices />} />
         <Route path="topology" element={<Topology />} />
         <Route path="alerts" element={<Alerts />} />

--- a/app/src/components/InstallPrompt.tsx
+++ b/app/src/components/InstallPrompt.tsx
@@ -1,0 +1,161 @@
+/**
+ * NetPulse — InstallPrompt (issue #172)
+ *
+ * Snackbar descartable que sugiere instalar NetPulse como PWA tras el primer
+ * login autenticado de cada usuario en este navegador. Sigue las mejores
+ * prácticas de web.dev / Chrome DevRel:
+ *
+ *  - Solo se muestra cuando el navegador lo soporta: `beforeinstallprompt`
+ *    disparado (Chromium: Chrome/Edge/Android) o iOS Safari (instrucciones
+ *    manuales de "Añadir a pantalla de inicio").
+ *  - Nunca cuando la app ya corre en modo instalado
+ *    (`display-mode: standalone` / `navigator.standalone`).
+ *  - `preventDefault()` sobre `beforeinstallprompt`: lanzamos nosotros el
+ *    prompt (evita duplicar la mini-infobar nativa de Chrome).
+ *  - Descarte recordado por usuario (localStorage): el botón "Ahora no" o un
+ *    rechazo del diálogo nativo evita re-promocionar.
+ *  - Auto-cierre tras ~8 s si se ignora; no se vuelve a mostrar en la misma
+ *    sesión, sí en una visita futura (cambio de relación).
+ */
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { AnimatePresence, motion } from 'framer-motion'
+import { Download } from 'lucide-react'
+import { useAuth } from '@/data/AuthContext'
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>
+}
+
+const AUTO_HIDE_MS = 8000
+const SHOW_DELAY_MS = 1200
+
+function isStandalone(): boolean {
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    (navigator as unknown as { standalone?: boolean }).standalone === true
+  )
+}
+
+function isIOS(): boolean {
+  return (
+    /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+  )
+}
+
+export default function InstallPrompt() {
+  const { t } = useTranslation()
+  const auth = useAuth()
+  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(null)
+  const [installed, setInstalled] = useState<boolean>(() => isStandalone())
+  const [visible, setVisible] = useState(false)
+  const shownRef = useRef(false)
+  const hideTimer = useRef<number | undefined>(undefined)
+
+  const dismissedKey = `netpulse-install-prompt-dismissed-${auth?.user ?? 'guest'}`
+
+  // Captura el evento de instalación (Chromium) y lo que ocurra al instalar.
+  useEffect(() => {
+    const onPrompt = (e: Event) => {
+      e.preventDefault()
+      setDeferred(e as BeforeInstallPromptEvent)
+    }
+    const onInstalled = () => {
+      setInstalled(true)
+      setVisible(false)
+      localStorage.setItem(dismissedKey, '1')
+    }
+    window.addEventListener('beforeinstallprompt', onPrompt)
+    window.addEventListener('appinstalled', onInstalled)
+    return () => {
+      window.removeEventListener('beforeinstallprompt', onPrompt)
+      window.removeEventListener('appinstalled', onInstalled)
+      window.clearTimeout(hideTimer.current)
+    }
+    // dismissedKey cambia de sesión en sesión; el listener se re-registra para
+    // el usuario correcto.
+  }, [dismissedKey])
+
+  // Muestra el snackbar tras el primer login: con soporte real, sin instalar
+  // y sin descarte previo. Una vez por sesión de navegación.
+  const canInstall = deferred !== null || isIOS()
+  useEffect(() => {
+    if (!visible || installed) return
+    hideTimer.current = window.setTimeout(() => setVisible(false), AUTO_HIDE_MS)
+    return () => window.clearTimeout(hideTimer.current)
+  }, [visible, installed])
+
+  useEffect(() => {
+    if (installed || shownRef.current || localStorage.getItem(dismissedKey) === '1' || !canInstall) return
+    shownRef.current = true
+    const delay = window.setTimeout(() => setVisible(true), SHOW_DELAY_MS)
+    return () => window.clearTimeout(delay)
+  }, [canInstall, installed, dismissedKey])
+
+  const install = async () => {
+    if (!deferred) return
+    setVisible(false)
+    await deferred.prompt()
+    const { outcome } = await deferred.userChoice
+    // Instalado, o rechazado el diálogo nativo: no re-promocionar.
+    localStorage.setItem(dismissedKey, '1')
+    setDeferred(null)
+    if (outcome === 'accepted') setInstalled(true)
+  }
+
+  const dismiss = () => {
+    localStorage.setItem(dismissedKey, '1')
+    setVisible(false)
+  }
+
+  return (
+    <AnimatePresence>
+      {visible && !installed && (
+        <motion.div
+          role="dialog"
+          aria-label={t('installPrompt.title')}
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 8 }}
+          transition={{ duration: 0.22, ease: 'easeOut' }}
+          className="fixed bottom-20 left-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 md:bottom-6"
+        >
+          <div className="rounded-xl border border-border-strong bg-elevated p-4 shadow-xl">
+            <div className="flex items-start gap-3">
+              <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-accent/15 text-accent">
+                <Download className="h-4 w-4" strokeWidth={2} />
+              </span>
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-text-primary">{t('installPrompt.title')}</p>
+                <p className="mt-0.5 text-caption text-text-muted">
+                  {isIOS() ? t('installPrompt.iosDesc') : t('installPrompt.desc')}
+                </p>
+              </div>
+            </div>
+            <div className="mt-3 flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={dismiss}
+                className="flex h-8 items-center rounded-lg px-3 text-caption font-medium text-text-secondary transition-colors hover:bg-hover hover:text-text-primary"
+              >
+                {t('installPrompt.later')}
+              </button>
+              {deferred && (
+                <button
+                  type="button"
+                  onClick={() => void install()}
+                  className="flex h-8 items-center gap-1.5 rounded-lg bg-accent px-3 text-caption font-semibold text-canvas transition-opacity hover:opacity-90"
+                >
+                  <Download className="h-3.5 w-3.5" strokeWidth={2} />
+                  {t('installPrompt.install')}
+                </button>
+              )}
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import type { MouseEvent } from 'react'
+import { flushSync } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { Link, NavLink, Outlet, useLocation, useNavigate } from 'react-router'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -30,6 +32,7 @@ import { ThemeToggle } from '@/components/ThemeToggle'
 import { UpdateBanner } from '@/components/UpdateBanner'
 import { UpdateConfirmToast } from '@/components/UpdateConfirmToast'
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
+import { useIsMobile } from '@/hooks/use-mobile'
 import { cn, exitDemo } from '@/lib/utils'
 
 // ---------------------------------------------------------------------------
@@ -481,7 +484,7 @@ function MobileHeader() {
     }
   }
   return (
-    <header className="sticky top-0 z-30 flex h-14 items-center justify-between border-b border-border bg-canvas/80 px-4 backdrop-blur-md md:hidden pt-safe">
+    <header className="[view-transition-name:netpulse-header] sticky top-0 z-30 flex h-14 items-center justify-between border-b border-border bg-canvas/80 px-4 backdrop-blur-md md:hidden pt-safe">
       <Logo onClick={scrollTopIfActive('/')} />
       <div className="flex items-center gap-3">
         <Link to="/" aria-label={t('topbar.networkHealth100', { score: healthScore.score })}>
@@ -507,6 +510,14 @@ function MobileHeader() {
 // ---------------------------------------------------------------------------
 
 const TAB_ITEMS = NAV_ITEMS.filter((i) => ['/', '/routers', '/devices', '/alerts'].includes(i.to))
+
+/** Orden completo de vistas (para la dirección del deslizamiento móvil). */
+const NAV_ORDER: { to: string }[] = NAV_ITEMS
+
+function navIndex(path: string): number {
+  const active = (to: string) => (to === '/' ? path === '/' : path.startsWith(to))
+  return NAV_ORDER.findIndex(({ to }) => active(to))
+}
 
 function MoreSheet() {
   const { t } = useTranslation()
@@ -576,6 +587,7 @@ function MoreSheet() {
 function TabBar() {
   const { t } = useTranslation()
   const location = useLocation()
+  const navigate = useNavigate()
   const reduceMotion = () =>
     typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
   const scrollTopIfActive = (to: string) => () => {
@@ -583,9 +595,37 @@ function TabBar() {
       window.scrollTo({ top: 0, behavior: reduceMotion() ? 'auto' : 'smooth' })
     }
   }
+  /* Navegación móvil con deslizamiento (#187): el modo declarativo
+   * (BrowserRouter) no soporta la prop viewTransition de react-router (solo
+   * RouterProvider), así que interceptamos el click y envolvemos la navegación
+   * en document.startViewTransition (con flushSync, igual que hace react-router
+   * internamente). La dirección se marca en <html data-nav-dir> antes del
+   * snapshot; el shell (header + bottom nav) queda estático vía CSS. */
+  const handleMobileNav = (to: string) => (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault()
+    const from = navIndex(location.pathname)
+    const target = navIndex(to)
+    if (target !== -1 && from !== target) {
+      try {
+        document.documentElement.dataset.navDir = from === -1 || target > from ? 'forward' : 'back'
+      } catch {
+        /* sin dataset */
+      }
+      scrollTopIfActive(to)()
+      const doNavigate = () => navigate(to)
+      if (typeof document.startViewTransition === 'function') {
+        document.startViewTransition(() => flushSync(doNavigate))
+      } else {
+        doNavigate()
+      }
+    } else {
+      scrollTopIfActive(to)()
+      navigate(to, { replace: true })
+    }
+  }
   return (
     <nav
-      className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-elevated/90 backdrop-blur-md md:hidden"
+      className="[view-transition-name:netpulse-nav] fixed inset-x-0 bottom-0 z-40 border-t border-border bg-elevated/90 backdrop-blur-md md:hidden"
       aria-label={t('nav.mainNav')}
     >
       <div className="flex h-16 items-stretch px-2 pb-[env(safe-area-inset-bottom)]">
@@ -594,7 +634,7 @@ function TabBar() {
             key={item.to}
             to={item.to}
             end={item.end}
-            onClick={scrollTopIfActive(item.to)}
+            onClick={handleMobileNav(item.to)}
             className={({ isActive }) =>
               cn(
                 'flex h-full min-w-[56px] flex-1 flex-col items-center justify-center gap-1 rounded-xl transition-colors',
@@ -648,6 +688,7 @@ function Shell() {
   const location = useLocation()
   const key = useMemo(() => location.pathname, [location.pathname])
   const { isDemo } = useNetPulse()
+  const isMobile = useIsMobile()
   const [collapsed, setCollapsed] = useState(() => localStorage.getItem('netpulse-sidebar-collapsed') === '1')
 
   // Cada cambio de ruta resetea el scroll al principio (no hay ScrollRestoration).
@@ -669,7 +710,7 @@ function Shell() {
       <div className={collapsed ? 'md:pl-16 lg:pl-16' : 'md:pl-16 lg:pl-[232px]'}>
         <Topbar />
         <MobileHeader />
-        <main className="mx-auto w-full max-w-[1400px] px-4 pb-24 pt-4 md:px-6 md:pb-10 md:pt-6">
+        <main className="[view-transition-name:netpulse-content] mx-auto w-full max-w-[1400px] px-4 pb-24 pt-4 md:px-6 md:pb-10 md:pt-6">
           {isDemo && <DemoBanner />}
           <UpdateBanner />
           {/* Confirmación post-update (issue #161): toast al cargar si el
@@ -679,17 +720,26 @@ function Shell() {
               coger un deploy nuevo sin reabrir la app. Solo actúa en touch y
               con scroll arriba; no interfiere con carruseles/tablas. */}
           <PullToRefresh>
-            <AnimatePresence mode="wait">
-              <motion.div
-                key={key}
-                initial={{ opacity: 0, y: 8 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -4 }}
-                transition={{ duration: 0.2, ease: 'easeOut' }}
-              >
+            {/* En móvil usamos view transitions para el deslizamiento entre
+                vistas (#187): el fade/y de framer-motion se desactiva porque su
+                estado inicial (opacity 0) quedaría congelado en el snapshot. */}
+            {isMobile ? (
+              <div>
                 <Outlet />
-              </motion.div>
-            </AnimatePresence>
+              </div>
+            ) : (
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={key}
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -4 }}
+                  transition={{ duration: 0.2, ease: 'easeOut' }}
+                >
+                  <Outlet />
+                </motion.div>
+              </AnimatePresence>
+            )}
           </PullToRefresh>
         </main>
       </div>

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -25,6 +25,7 @@ import { useNetPulse } from '@/data/DataProvider'
 import { DashboardProvider, useDashboard } from '@/hooks/useDashboard'
 import { CommandPalette } from '@/components/CommandPalette'
 import { HealthRing } from '@/components/HealthRing'
+import InstallPrompt from '@/components/InstallPrompt'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import { UpdateBanner } from '@/components/UpdateBanner'
 import { UpdateConfirmToast } from '@/components/UpdateConfirmToast'
@@ -694,6 +695,7 @@ function Shell() {
       </div>
       <TabBar />
       <CommandPalette />
+      <InstallPrompt />
     </div>
   )
 }

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import PullToRefresh from '@/components/PullToRefresh'
 import {
   BarChart3,
   Bell,
+  Bot,
   Bug,
   ChevronsLeft,
   ChevronsRight,
@@ -48,6 +49,7 @@ interface NavItem {
 const NAV_ITEMS: NavItem[] = [
   { to: '/', labelKey: 'nav.overview', icon: LayoutDashboard, end: true },
   { to: '/routers', labelKey: 'nav.routers', icon: RouterIcon },
+  { to: '/agents', labelKey: 'nav.agents', icon: Bot },
   { to: '/devices', labelKey: 'nav.devices', icon: MonitorSmartphone },
   { to: '/topology', labelKey: 'nav.topology', icon: Waypoints },
   { to: '/roaming', labelKey: 'nav.roaming', icon: Wifi },
@@ -67,6 +69,7 @@ const PAGE_TITLE_KEYS: [RegExp, string][] = [
   [/^\/$/, 'nav.overview'],
   [/^\/routers\/[^/]+/, 'nav.routerDetail'],
   [/^\/routers/, 'nav.routers'],
+  [/^\/agents/, 'nav.agents'],
   [/^\/devices/, 'nav.devices'],
   [/^\/topology/, 'nav.topology'],
   [/^\/roaming/, 'nav.roaming'],

--- a/app/src/components/topology/LegendCard.tsx
+++ b/app/src/components/topology/LegendCard.tsx
@@ -212,7 +212,7 @@ export function LegendSheet({ model }: { model: TopologyModel }) {
   const dragged = useRef(false)
   return (
     <motion.div
-      className="absolute inset-x-0 bottom-0 z-10 rounded-t-2xl border-t border-border-strong bg-elevated/95 backdrop-blur-md lg:hidden"
+      className="pointer-events-auto absolute inset-x-0 bottom-0 z-10 rounded-t-2xl border-t border-border-strong bg-elevated/95 backdrop-blur-md lg:hidden"
       style={{ height: SHEET_H }}
       onPointerDown={(e) => e.stopPropagation()}
       initial={false}

--- a/app/src/components/topology/LinksTable.tsx
+++ b/app/src/components/topology/LinksTable.tsx
@@ -128,7 +128,7 @@ export function LinksTable({ model, hoverLink, onHoverLink }: LinksTableProps) {
               <th scope="col" className="pb-2 pr-4 font-medium">{t('topology.links.colSpeed')}</th>
               <th scope="col" className="pb-2 pr-4 font-medium">{t('devices.colSignal')}</th>
               <th scope="col" className="pb-2 pr-4 font-medium">{t('routers.colStatus')}</th>
-              <th scope="col" className="pb-2 font-medium">
+              <th scope="col" className="relative pb-2 font-medium">
                 <span className="sr-only">{t('topology.links.throughput')}</span>
               </th>
             </tr>

--- a/app/src/components/topology/TopologyMap.tsx
+++ b/app/src/components/topology/TopologyMap.tsx
@@ -20,6 +20,12 @@ import { cn } from '@/lib/utils'
 import type { ChipNode, DistNodeView, RouterNode, TopologyModel } from './model'
 import { COLOR, VB_H, VB_W, bandColor, linkColor, statusColor } from './model'
 
+/** Nombre preferente de un puerto: la etiqueta LuCI si existe, si no el id
+ * físico (issue #258). */
+export function portName(port: string | undefined, label: string | undefined): string {
+  return label || port || '—'
+}
+
 // ---------------------------------------------------------------------------
 // API imperativa expuesta a la página (botones de zoom del header)
 // ---------------------------------------------------------------------------
@@ -235,10 +241,10 @@ function TooltipCard({
             <StatusPill tone="accent" label="LLDP" />
           </div>
           <div className="mt-0.5 text-caption text-text-muted">
-            {[tip.node.ip, tip.node.port].filter(Boolean).join(' · ')}
+            {[tip.node.ip, portName(tip.node.port, tip.node.portLabel)].filter(Boolean).join(' · ')}
           </div>
           <div className="mt-2 grid grid-cols-2 gap-1.5">
-            <MiniStat label={t('topology.dist.port', { router: routerName(tip.node.routerId) })} value={tip.node.port} />
+            <MiniStat label={t('topology.dist.port', { router: routerName(tip.node.routerId) })} value={portName(tip.node.port, tip.node.portLabel)} />
             <MiniStat label={t('topology.dist.macs')} value={String(tip.node.macCount)} />
           </div>
           {tip.node.lldp && (
@@ -261,7 +267,7 @@ function TooltipCard({
           </div>
           <div className="mt-0.5 text-caption text-text-muted">{t('topology.dist.noIp')}</div>
           <div className="mt-2 grid grid-cols-2 gap-1.5">
-            <MiniStat label={t('topology.dist.port', { router: routerName(tip.node.routerId) })} value={tip.node.port} />
+            <MiniStat label={t('topology.dist.port', { router: routerName(tip.node.routerId) })} value={portName(tip.node.port, tip.node.portLabel)} />
             <MiniStat label={t('topology.dist.macs')} value={String(tip.node.macCount)} />
           </div>
           <div className="mt-2 text-caption leading-snug text-text-secondary">
@@ -315,7 +321,7 @@ function ChipTooltip({
         <div className="grid grid-cols-2 gap-1.5">
           <MiniStat
             label={chip.wired ? t('topology.port') : t('topology.signal')}
-            value={chip.wired ? (d.port ?? '—') : `${d.signalDbm ?? '—'} dBm`}
+            value={chip.wired ? portName(d.port ?? undefined, d.portLabel) : `${d.signalDbm ?? '—'} dBm`}
             hot={!chip.wired && chip.weak}
           />
           <MiniStat label={t('topology.traffic')} value={`${d.trafficMbps} Mbps`} />
@@ -334,7 +340,7 @@ function ChipTooltip({
       {chip.isCt && (
         <div className="mt-2 text-caption leading-snug text-text-secondary">
           {ctHost
-            ? t('topology.ct.noteIn', { host: ctHost.name, port: ctHost.port ?? '—' })
+            ? t('topology.ct.noteIn', { host: ctHost.name, port: portName(ctHost.port ?? undefined, ctHost.portLabel) })
             : t('topology.ct.note')}
         </div>
       )}
@@ -1256,12 +1262,12 @@ export function TopologyMap({ model, apiRef, showLabels, flow, hoverLink, onHove
             dv.node.kind === 'managed' ? (
               <LabelText key={dv.id} x={dv.x} y={dv.y - 34} anchor="middle" delay={(2.15 + i * 0.03) * T}
                 reduce={reduce ?? false} title={dv.node.name ?? t('topology.dist.managed')}
-                sub={`${[dv.node.ip ?? 'LLDP', dv.node.port].join(' · ')}`}
+                sub={`${[dv.node.ip ?? 'LLDP', portName(dv.node.port, dv.node.portLabel)].join(' · ')}`}
                 subColor={COLOR.accent} />
             ) : (
               <LabelText key={dv.id} x={dv.x} y={dv.y - 34} anchor="middle" delay={(2.15 + i * 0.03) * T}
                 reduce={reduce ?? false} title={t('topology.dist.title')}
-                sub={`${t('topology.dist.inferred')} · ${dv.node.port}`} />
+                sub={`${t('topology.dist.inferred')} · ${portName(dv.node.port, dv.node.portLabel)}`} />
             ),
           )}
           {/* Hosts hipervisores (badge +N ya en el chip; etiqueta con puerto y nº CTs) */}
@@ -1271,7 +1277,7 @@ export function TopologyMap({ model, apiRef, showLabels, flow, hoverLink, onHove
             return (
               <LabelText key={hostId} x={host.x} y={host.y - 38} anchor="middle" delay={(2.18 + i * 0.03) * T}
                 reduce={reduce ?? false} title={host.device.name}
-                sub={`${t('topology.host.hypervisor')} · ${host.device.port ?? ''} · ${ctCountByHost.get(hostId) ?? 0} CT`} />
+                sub={`${t('topology.host.hypervisor')} · ${portName(host.device.port ?? undefined, host.device.portLabel)} · ${ctCountByHost.get(hostId) ?? 0} CT`} />
             )
           })}
           {/* Peers */}
@@ -1395,8 +1401,8 @@ const DistNodeGroup = memo(function DistNodeGroup({
       tabIndex={0}
       aria-label={
         managed
-          ? `${dv.node.name ?? t('topology.dist.managed')}, LLDP, ${dv.node.ip ?? ''} ${dv.node.port}`
-          : `${t('topology.dist.title')}, ${t('topology.dist.inferred')}, ${dv.node.port}`
+          ? `${dv.node.name ?? t('topology.dist.managed')}, LLDP, ${dv.node.ip ?? ''} ${portName(dv.node.port, dv.node.portLabel)}`
+          : `${t('topology.dist.title')}, ${t('topology.dist.inferred')}, ${portName(dv.node.port, dv.node.portLabel)}`
       }
       animate={{ opacity }}
       transition={{ duration: 0.2 }}

--- a/app/src/components/topology/model.ts
+++ b/app/src/components/topology/model.ts
@@ -1275,7 +1275,7 @@ export function buildTopologyModel({ routers, devices, wan, wireguard, distribut
     if (dv.node.kind === 'managed') {
       backhauls.push({
         id: `dist-${dv.id}`, a: rn.router.name,
-        b: [dv.node.name, dv.node.ip, 'LLDP', dv.node.port].filter(Boolean).join(' · '),
+        b: [dv.node.name, dv.node.ip, 'LLDP', dv.node.portLabel ?? dv.node.port].filter(Boolean).join(' · '),
         kind: 'dist', type: 'topology.links.managedSwitch',
         speed: '1 Gbps', signal: '<1 ms',
         tone: 'ok', statusLabel: 'common.status.online',
@@ -1284,7 +1284,7 @@ export function buildTopologyModel({ routers, devices, wan, wireguard, distribut
     } else {
       backhauls.push({
         id: `dist-${dv.id}`, a: rn.router.name,
-        b: '', bKey: 'topology.links.inferredSwitch', bVars: { port: dv.node.port },
+        b: '', bKey: 'topology.links.inferredSwitch', bVars: { port: dv.node.portLabel ?? dv.node.port },
         kind: 'dist', type: 'common.cable',
         speed: '1 Gbps', signal: '<1 ms',
         tone: 'ok', statusLabel: 'common.status.online',
@@ -1299,7 +1299,7 @@ export function buildTopologyModel({ routers, devices, wan, wireguard, distribut
     if (!host || !rn) continue
     backhauls.push({
       id: `wired-${host.id}`, a: rn.router.name,
-      b: `${host.name} · ${dn.port} · ${ctCountByHost.get(host.id) ?? 0} CT`,
+      b: `${host.name} · ${dn.portLabel ?? dn.port} · ${ctCountByHost.get(host.id) ?? 0} CT`,
       kind: 'wired', type: 'topology.links.hypervisorCable',
       speed: '—', signal: '—',
       tone: 'ok', statusLabel: 'common.status.online',

--- a/app/src/components/topology/model.ts
+++ b/app/src/components/topology/model.ts
@@ -210,7 +210,7 @@ const GATEWAY_COORD = { x: 500, y: 250, r: 40, label: { x: 446, y: 312, anchor: 
 const AP_RADIUS = 32
 const AP_ARC_CENTER = 90
 const AP_ARC_HALF = 70
-const AP_BASE_Y = 560
+const AP_BASE_Y = 545
 
 function apCoords(n: number, total: number): { x: number; y: number; r: number; label: { x: number; y: number; anchor: 'end' | 'start' } } {
   let angle: number
@@ -219,7 +219,7 @@ function apCoords(n: number, total: number): { x: number; y: number; r: number; 
   } else {
     angle = AP_ARC_CENTER - AP_ARC_HALF + (2 * AP_ARC_HALF * n) / (total - 1)
   }
-  const x = Math.round(GATEWAY_COORD.x + 305 * Math.cos(rad(angle)))
+  const x = Math.round(GATEWAY_COORD.x + 280 * Math.cos(rad(angle)))
   const y = Math.round(AP_BASE_Y + 25 * Math.sin(rad(angle - AP_ARC_CENTER)))
   const isLeft = x < GATEWAY_COORD.x
   return {
@@ -244,45 +244,45 @@ const WG_PATHS = [
  *  topoAPRingCap (40) del server — deben coincidir para que GW_RING_VISIBLE
  *  no corte antes de tiempo. */
 const GATEWAY_RINGS = [
-  { r: 92, cap: 8 },
-  { r: 130, cap: 14 },
-  { r: 168, cap: 18 },
-  { r: 200, cap: 20 },
+  { r: 84, cap: 8 },
+  { r: 116, cap: 14 },
+  { r: 148, cap: 18 },
+  { r: 180, cap: 20 },
 ]
 const AP_RINGS = [
-  { r: 84, cap: 8 },
-  { r: 124, cap: 14 },
-  { r: 162, cap: 18 },
+  { r: 78, cap: 8 },
+  { r: 112, cap: 14 },
+  { r: 148, cap: 18 },
 ]
 /** Abanicos cableados: gateway tiene sector este (switch inferido) y oeste */
 const GW_EAST_FAN: [number, number] = [336, 24] // wrap (a1 < a0)
 const GW_WEST_FAN: [number, number] = [150, 210]
 const AP_WIRED_FAN: [number, number] = [150, 210]
-const DIST_FAN_RADIUS = 120
+const DIST_FAN_RADIUS = 112
 /** distnodes: hasta DIST_FAN_MAX hijos en abanico de 136°; con más, el arco
  *  de radio fijo los amontona (issue #5 bug 2: 8 bocas tras un switch en el
  *  mismo puerto) → anillos concéntricos alrededor del círculo dashed. */
 const DIST_FAN_MAX = 5
 const DIST_RINGS = [
-  { r: 70, cap: 8 },
-  { r: 116, cap: 14 },
+  { r: 66, cap: 8 },
+  { r: 110, cap: 14 },
 ]
-const HUB_FAN_RADIUS = 100
+const HUB_FAN_RADIUS = 96
 /** device-hubs (switch gestionado): con más de HUB_FAN_MAX hijos, el abanico
  *  fijo de 90° a r=HUB_FAN_RADIUS los apiña (muchos puertos en el mismo
  *  switch) → anillos concéntricos, igual que los distnodes. */
 const HUB_FAN_MAX = 8
 const HUB_RINGS = [
-  { r: 62, cap: 6 },
-  { r: 100, cap: 12 },
+  { r: 58, cap: 6 },
+  { r: 94, cap: 12 },
 ]
-const ROUTER_FAN_RADIUS = 185
+const ROUTER_FAN_RADIUS = 176
 /** Hosts hipervisores del gateway: lejos (su grid de CTs necesita espacio) */
-const HYPERVISOR_FAN_RADIUS = 260
+const HYPERVISOR_FAN_RADIUS = 244
 /** Host hipervisor de un switch/AP (no-gateway): radio desde su switch/AP.
  *  > ROUTER_FAN_RADIUS para quedar fuera del abanico de cableados directos;
  *  el resolver de colisiones lo acomoda si algún vecino está demasiado cerca. */
-const HUB_HOST_RADIUS = 240
+const HUB_HOST_RADIUS = 224
 /** Grid de CTs bajo el host hipervisor */
 const CT_COLS = 5
 const CT_DX = 46
@@ -347,6 +347,53 @@ function widestGapCenterInView(
     if (inView(a)) return a
   }
   return fallback
+}
+
+/** Hueco angular más grande entre `points` cuya posición a `radius` del origen
+ *  caiga DENTRO de uno de los arcos permitidos `allowed` y del viewport.
+ *  El host hipervisor de un AP/switch usa esta variante: el cable que sale del
+ *  AP hacia el host no debe cruzar sus clientes wifi, así que el host se
+ *  restringe a los arcos que el AP ya excluye del wifi (hacia el gateway y el
+ *  fan cableado). Si ningún hueco cae en un arco permitido, se prueba el centro
+ *  de cada arco y, en última instancia, el hueco más grande (issue #141). */
+function widestGapCenterInArcs(
+  origin: { x: number; y: number },
+  points: { x: number; y: number }[],
+  radius: number,
+  allowed: [number, number][],
+  m = 30,
+): number {
+  if (points.length === 0) return 0
+  const angles = points.map((p) => angleTo(origin.x, origin.y, p.x, p.y)).sort((a, b) => a - b)
+  const gaps: { start: number; gap: number }[] = []
+  for (let i = 0; i < angles.length; i++) {
+    const start = angles[i]!
+    const next = angles[(i + 1) % angles.length]! + (i === angles.length - 1 ? 360 : 0)
+    gaps.push({ start, gap: next - start })
+  }
+  gaps.sort((a, b) => b.gap - a.gap)
+  const inView = (a: number) => {
+    const p = pos(origin.x, origin.y, a, radius)
+    return p.x >= m && p.x <= VB_W - m && p.y >= m && p.y <= VB_H - m
+  }
+  const inAllowed = (a: number) =>
+    allowed.some(([s, e]) => {
+      const a2 = norm(a)
+      return s <= e ? a2 >= s && a2 <= e : a2 >= s || a2 <= e
+    })
+  for (const g of gaps) {
+    const center = norm(g.start + g.gap / 2)
+    if (inAllowed(center) && inView(center)) return center
+  }
+  for (const [s, e] of allowed) {
+    const span = e >= s ? e - s : e + 360 - s
+    const center = norm(s + span / 2)
+    if (inView(center)) return center
+  }
+  for (const a of [90, 180, 270, 0, 135, 225]) {
+    if (inAllowed(a) && inView(a)) return a
+  }
+  return gaps[0] ? norm(gaps[0].start + gaps[0].gap / 2) : 0
 }
 
 /** arcos libres = [0,360) menos exclusiones (intervalos sin wrap) */
@@ -589,7 +636,7 @@ export function buildTopologyModel({ routers, devices, wan, wireguard, distribut
   const switchAnchor = gatewayNode
     ? (() => {
         const others = [...apNodes, internetNode].map((p) => ({ x: p.x, y: p.y }))
-        const r = GATEWAY_RINGS[GATEWAY_RINGS.length - 1]!.r + 120
+        const r = GATEWAY_RINGS[GATEWAY_RINGS.length - 1]!.r + 100
         const a = widestGapCenterInView(gatewayNode, others, r)
         return { x: Math.round(gatewayNode.x + r * Math.cos(rad(a))), y: Math.round(gatewayNode.y + r * Math.sin(rad(a))), angle: a }
       })()
@@ -743,7 +790,16 @@ export function buildTopologyModel({ routers, devices, wan, wireguard, distribut
         if (other.id !== node.id) neighbors.push(other)
       }
       for (const dv of distNodes) neighbors.push(dv)
-      const gapAngle = widestGapCenterInView(node, neighbors, HUB_HOST_RADIUS)
+      // El cable del host no debe cruzar los clientes wifi del propio AP/switch:
+      // el host se restringe a los arcos que el wifi ya excluye (hacia el
+      // gateway y el fan cableado), donde este router no tiene clientes (issue
+      // #141). En su interior se elige el hueco angular más grande.
+      const hostArcs: [number, number][] = []
+      if (gatewayNode) {
+        hostArcs.push(...arcAround(angleTo(node.x, node.y, gatewayNode.x, gatewayNode.y), 27))
+      }
+      hostArcs.push([AP_WIRED_FAN[0] - 10, AP_WIRED_FAN[1] + 10])
+      const gapAngle = widestGapCenterInArcs(node, neighbors, HUB_HOST_RADIUS, hostArcs)
       fanLayout(farWestItems, node, HUB_HOST_RADIUS, gapAngle - 20, gapAngle + 20)
       placed.push(...restItems, ...farWestItems)
       fanArcByRouter.set(node.id, [[AP_WIRED_FAN[0] - 8, AP_WIRED_FAN[1] + 8]])
@@ -809,7 +865,7 @@ export function buildTopologyModel({ routers, devices, wan, wireguard, distribut
     for (let guard = 0; guard < 8 && placed < wifi.length; guard++) {
       const last = rings[rings.length - 1]!
       const cap = rings[rings.length - 1]!.cap + 2
-      rings.push({ r: last.r + 40, cap: Math.max(extraCap(last.r + 40), cap) })
+      rings.push({ r: last.r + 34, cap: Math.max(extraCap(last.r + 34), cap) })
       // re-colocar desde el principio (las posiciones parciales se recalcular)
       wifi.forEach((c) => { c.x = 0; c.y = 0 })
       placed = ringLayoutCount(wifi, node, rings, excludes)

--- a/app/src/data/DataProvider.tsx
+++ b/app/src/data/DataProvider.tsx
@@ -39,6 +39,9 @@ import { VM_SUPPORTED } from '@/data/types'
 import {
   adguard as mockAdGuard,
   alerts as mockAlerts,
+  DEMO_HEALTH_EN,
+  DEMO_NAME_EN,
+  DEMO_ROLE_EN,
   devices as mockDevices,
   deviceTotals as mockDeviceTotals,
   distributionNodes as mockDistributionNodes,
@@ -48,6 +51,7 @@ import {
   wan as mockWan,
   wireguard as mockWireguard,
 } from '@/data/mock'
+import i18n from '@/i18n'
 import {
   countUnreadAlerts,
   loadDemoAlertsConfig,
@@ -167,22 +171,69 @@ export interface NetPulseApi extends NetPulseData {
 // Estado inicial = mock canónico (primer paint idéntico al mockup)
 // ---------------------------------------------------------------------------
 
-function initialBundle(): NetPulseData {
-  return {
-    health: mockHealth,
-    wan: mockWan,
-    traffic: mockTraffic,
-    adguard: mockAdGuard,
-    wireguard: mockWireguard,
-    routers: mockRouters,
-    devices: mockDevices,
-    deviceTotals: mockDeviceTotals,
-    distributionNodes: mockDistributionNodes,
-    topDevices: [...mockDevices].sort((a, b) => b.trafficMbps - a.trafficMbps).slice(0, 5),
-    alerts: mockAlerts,
-    unreadAlerts: mockAlerts.filter((a) => !a.read).length,
-    vm: VM_SUPPORTED,
+/** Canon ES por id: permite restaurar el castellano al volver de EN → ES. */
+const CANON_ROUTER_BY_ID = new Map(mockRouters.map((r) => [r.id, r]))
+const CANON_DEVICE_BY_ID = new Map(mockDevices.map((d) => [d.id, d]))
+
+/**
+ * Traduce los textos propios del canon demo (ES) al idioma activo (issue #238).
+ * SOLO modo demo: en live los nombres llegan del backend y no se tocan.
+ * Idempotente: el ES se restaura siempre desde el canon, nunca del estado
+ * previo, así un EN → ES → EN no degrada datos.
+ */
+function localizeDemoBundle(prev: NetPulseData, lang: string): NetPulseData {
+  const en = lang.startsWith('en')
+  const nameOf = <T extends { id: string; name: string }>(item: T, canonById: Map<string, T>): string => {
+    const esName = canonById.get(item.id)?.name ?? item.name
+    return en ? (DEMO_NAME_EN[item.id] ?? esName) : esName
   }
+  const routers = prev.routers.map((r) => {
+    const esRole = CANON_ROUTER_BY_ID.get(r.id)?.role ?? r.role
+    return {
+      ...r,
+      name: nameOf(r, CANON_ROUTER_BY_ID),
+      role: en ? (DEMO_ROLE_EN[esRole] ?? esRole) : esRole,
+    }
+  })
+  const devices = prev.devices.map((d) => ({ ...d, name: nameOf(d, CANON_DEVICE_BY_ID) }))
+  const deviceNameById = new Map(devices.map((d) => [d.id, d.name]))
+  const health: HealthScore = {
+    ...prev.health,
+    caption: en ? (DEMO_HEALTH_EN[prev.health.caption] ?? prev.health.caption) : mockHealth.caption,
+    note: en ? (DEMO_HEALTH_EN[prev.health.note] ?? prev.health.note) : mockHealth.note,
+    breakdown: prev.health.breakdown.map((b, i) => ({
+      ...b,
+      label: en ? (DEMO_HEALTH_EN[b.label] ?? b.label) : (mockHealth.breakdown[i]?.label ?? b.label),
+    })),
+  }
+  return {
+    ...prev,
+    routers,
+    devices,
+    health,
+    topDevices: prev.topDevices.map((d) => ({ ...d, name: deviceNameById.get(d.id) ?? d.name })),
+  }
+}
+
+function initialBundle(): NetPulseData {
+  return localizeDemoBundle(
+    {
+      health: mockHealth,
+      wan: mockWan,
+      traffic: mockTraffic,
+      adguard: mockAdGuard,
+      wireguard: mockWireguard,
+      routers: mockRouters,
+      devices: mockDevices,
+      deviceTotals: mockDeviceTotals,
+      distributionNodes: mockDistributionNodes,
+      topDevices: [...mockDevices].sort((a, b) => b.trafficMbps - a.trafficMbps).slice(0, 5),
+      alerts: mockAlerts,
+      unreadAlerts: mockAlerts.filter((a) => !a.read).length,
+      vm: VM_SUPPORTED,
+    },
+    i18n.language,
+  )
 }
 
 /**
@@ -577,6 +628,22 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
       window.clearInterval(agentsPollId)
     }
   }, [applyOverview])
+
+  // -- idioma del dataset demo (issue #238) ------------------------------------
+  // En demo, los textos propios del canon (nombres de routers/devices, roles,
+  // salud) se traducen al idioma activo. En live los datos vienen del backend
+  // y no se tocan.
+  useEffect(() => {
+    const onLang = (lang: string) => {
+      if (modeRef.current === 'live') return
+      setBundle((prev) => localizeDemoBundle(prev, lang))
+    }
+    onLang(i18n.language)
+    i18n.on('languageChanged', onLang)
+    return () => {
+      i18n.off('languageChanged', onLang)
+    }
+  }, [])
 
   // -- API pública --------------------------------------------------------------
 

--- a/app/src/data/DataProvider.tsx
+++ b/app/src/data/DataProvider.tsx
@@ -161,6 +161,13 @@ export interface NetPulseApi extends NetPulseData {
    * falló (demo siempre null).
    */
   reinstallAgent: (slug: string) => Promise<{ recovered: boolean; token?: string; error?: string } | null>
+  /**
+   * #245: POST /api/agents — crea/rota el token del agente y devuelve el
+   * one-liner de instalación manual (fallback para routers sin SSH desde el
+   * server). El token rota en cada llamada (se muestra UNA vez); el comando
+   * ya lleva el token nuevo. null si falló (demo siempre null).
+   */
+  createAgentInstall: (slug: string) => Promise<{ install: string } | null>
 }
 
 // ---------------------------------------------------------------------------
@@ -778,6 +785,24 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
     }
   }, [])
 
+  const createAgentInstall = useCallback(async (slug: string): Promise<{ install: string } | null> => {
+    if (modeRef.current !== 'live') return null
+    try {
+      const res = await fetch('/api/agents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slug }),
+        signal: AbortSignal.timeout(30_000),
+      })
+      if (res.status === 401) redirectLogin()
+      if (!res.ok) return null
+      const json = (await res.json()) as { install?: string }
+      return json.install ? { install: json.install } : null
+    } catch {
+      return null
+    }
+  }, [])
+
   const getRouterDetail = useCallback(async (id: string): Promise<RouterDetailData | null> => {
     if (modeRef.current === 'live') {
       const res = await fetch(`/api/routers/${encodeURIComponent(id)}`)
@@ -883,8 +908,9 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
       upgradeAgent,
       upgradeAllAgents,
       reinstallAgent,
+      createAgentInstall,
     }),
-    [bundle, connectionStatus, agents, isDemo, refresh, lastSnapshotAt, requestServerRefresh, getRouterDetail, getDevices, getAlerts, alertsConfig, setAlertConfig, markAlertsRead, markAllAlertsRead, rearmAgent, upgradeAgent, upgradeAllAgents, reinstallAgent],
+    [bundle, connectionStatus, agents, isDemo, refresh, lastSnapshotAt, requestServerRefresh, getRouterDetail, getDevices, getAlerts, alertsConfig, setAlertConfig, markAlertsRead, markAllAlertsRead, rearmAgent, upgradeAgent, upgradeAllAgents, reinstallAgent, createAgentInstall],
   )
 
   return <NetPulseContext.Provider value={value}>{children}</NetPulseContext.Provider>

--- a/app/src/data/mock.ts
+++ b/app/src/data/mock.ts
@@ -78,6 +78,69 @@ export const wan: WanInfo = canon.wan
 export const healthScore = canon.health as unknown as HealthScore
 
 // ---------------------------------------------------------------------------
+// Nombres propios del canon demo en inglés (issue #238)
+// El canon Go (demo-canon.json) es ES y NO se edita a mano. DataProvider
+// traduce estos textos al idioma activo SOLO en modo demo (en live los
+// nombres vienen del backend y nunca se tocan). Si el canon Go añade un
+// nombre en castellano, hay que mapearlo aquí o saldrá en ES con la UI en EN.
+// ---------------------------------------------------------------------------
+
+/** id de router/device → nombre EN. Los no mapeados son neutros ("Patio", "Gateway"). */
+export const DEMO_NAME_EN: Record<string, string> = {
+  // routers
+  living: 'Living Room',
+  estudio: 'Study',
+  // devices
+  'imac-salon': 'iMac Living Room',
+  'tv-salon-cable': 'Living Room TV (wired)',
+  'tv-samsung': 'Samsung TV',
+  'portatil-trabajo': 'Work laptop',
+  'portatil-invitado': 'Guest laptop',
+  'portatil-antiguo': 'Old laptop',
+  'macbook-viejo': 'Old MacBook',
+  'pc-invitado': 'Guest PC',
+  'iphone-ana': "Ana's iPhone",
+  'iphone-trabajo': 'Work iPhone',
+  'bombilla-1': 'Living room bulb 1',
+  'bombilla-2': 'Living room bulb 2',
+  'bombilla-3': 'Floor lamp bulb',
+  'bombilla-4': 'Entrance bulb',
+  'bombilla-5': 'Hallway bulb',
+  'bombilla-6': 'Kitchen bulb',
+  'camara-garaje': 'Garage camera',
+  'camara-jardin': 'Garden camera',
+  'camara-porche': 'Porch camera',
+  'timbre-nest': 'Nest doorbell',
+  'robot-aspirador': 'Robot vacuum',
+  'enchufe-lavadora': 'Washing machine plug',
+  'enchufe-ventilador': 'Fan plug',
+  'enchufe-calefactor': 'Heater plug',
+  'macbook-pro': "Marc's MacBook Pro",
+  'pc-sobremesa': 'Desktop PC',
+  'sensor-riego': 'Irrigation sensor',
+  'impresora-hp': 'HP printer',
+  'receptor-denon': 'Denon receiver',
+  'receptor-av': 'AV receiver',
+  'hue-hub': 'Philips Hue Hub',
+}
+
+/** `role` del router (texto libre ES) → EN. roleBadge ya se traduce con roleLabel(). */
+export const DEMO_ROLE_EN: Record<string, string> = {
+  'Gateway principal': 'Main gateway',
+  'Punto de acceso': 'Access point',
+  'AP exterior': 'Outdoor AP',
+}
+
+/** Textos libres de salud del canon (caption/note/breakdown) → EN. */
+export const DEMO_HEALTH_EN: Record<string, string> = {
+  'Puntuación de salud de la red': 'Network health score',
+  'Penalizado por la temperatura del Patio.': 'Penalized by the Patio temperature.',
+  'temp. Patio': 'Patio temp.',
+  'cobertura Patio': 'Patio coverage',
+  'canal 2.4 GHz congestionado': 'congested 2.4 GHz channel',
+}
+
+// ---------------------------------------------------------------------------
 // Tráfico WAN — series por rango (valle nocturno 5–15, pico tarde 300–412,
 // pico de subida 21:14 = backup NAS 96 Mbps)
 // ---------------------------------------------------------------------------

--- a/app/src/data/types.ts
+++ b/app/src/data/types.ts
@@ -177,6 +177,12 @@ export interface Device {
   sparkline: number[]
   /** Puerto físico del router/switch donde se aprende la MAC (cableados; FDB). */
   port?: string | null
+  /**
+   * Nombre amigable del puerto definido en LuCI (issue #258, `config
+   * switchvlan 'port_labels'` en /etc/config/luci). La app lo muestra como
+   * nombre preferente sobre `port` cuando existe.
+   */
+  portLabel?: string
   /** Datos LLDP cuando el vecino se anuncia (switch gestionado identificado). */
   lldp?: LldpInfo | null
   /**
@@ -206,6 +212,8 @@ export interface DistributionNode {
   routerId: string
   /** Puerto físico del router donde cuelga (lan3…). */
   port: string
+  /** Nombre amigable del puerto definido en LuCI (issue #258); preferente sobre `port`. */
+  portLabel?: string
   /** MACs aprendidas en ese puerto (FDB). */
   macCount: number
   /** Hypervisor: id del Device host (Proxmox…), si existe como cliente. */

--- a/app/src/i18n.ts
+++ b/app/src/i18n.ts
@@ -10,6 +10,12 @@ if (!savedLang || savedLang === 'auto') {
   localStorage.removeItem('i18nextLng')
 }
 
+// Builds con idioma forzado (demo pública, VITE_FORCE_LANG=en): si el
+// visitante nunca eligió idioma, arrancar en el forzado en vez de seguir al
+// navegador. Una elección explícita en Ajustes (es/en/auto) siempre gana.
+const forcedLang = import.meta.env.VITE_FORCE_LANG as 'es' | 'en' | undefined
+const initialLng = !savedLang && forcedLang ? forcedLang : (localStorage.getItem('i18nextLng') ?? undefined)
+
 i18n
   .use(HttpBackend)
   .use(LanguageDetector)
@@ -18,7 +24,8 @@ i18n
     // Sin elección previa NO se fija idioma: el LanguageDetector resuelve
     // desde el navegador (orden localStorage → navigator). 'en' queda solo
     // como fallback para locales no soportados. (issue #3)
-    lng: localStorage.getItem('i18nextLng') ?? undefined,
+    // Excepción: builds con VITE_FORCE_LANG (demo pública, issue #237).
+    lng: initialLng,
     fallbackLng: 'en',
     supportedLngs: ['es', 'en'],
     nonExplicitSupportedLngs: true,

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -241,3 +241,75 @@
     scroll-behavior: auto !important;
   }
 }
+
+/* Transición móvil entre vistas: el contenido (<main>) se desliza y el shell
+ * (header móvil + bottom nav) permanece estático. Se capturan como grupos de
+ * view-transition PROPIO (netpulse-header/netpulse-nav) para no depender de
+ * cómo el navegador capture el grupo root con position:fixed (falla en
+ * dispositivos). */
+@media (max-width: 767px) {
+  main {
+    view-transition-name: netpulse-content;
+  }
+  /* El shell queda estático: anulamos las 4 animaciones UA de cada grupo
+   * (group/image-pair arrancan en opacity 0 en la hoja UA del navegador). */
+  ::view-transition-group(root),
+  ::view-transition-image-pair(root),
+  ::view-transition-old(root),
+  ::view-transition-new(root),
+  ::view-transition-group(netpulse-header),
+  ::view-transition-image-pair(netpulse-header),
+  ::view-transition-old(netpulse-header),
+  ::view-transition-new(netpulse-header),
+  ::view-transition-group(netpulse-nav),
+  ::view-transition-image-pair(netpulse-nav),
+  ::view-transition-old(netpulse-nav),
+  ::view-transition-new(netpulse-nav) {
+    animation: none;
+  }
+  html[data-nav-dir='forward']::view-transition-old(netpulse-content) {
+    animation: netpulse-vt-out-left 0.3s ease-in-out both;
+  }
+  html[data-nav-dir='forward']::view-transition-new(netpulse-content) {
+    animation: netpulse-vt-in-right 0.3s ease-in-out both;
+  }
+  html[data-nav-dir='back']::view-transition-old(netpulse-content) {
+    animation: netpulse-vt-out-right 0.3s ease-in-out both;
+  }
+  html[data-nav-dir='back']::view-transition-new(netpulse-content) {
+    animation: netpulse-vt-in-left 0.3s ease-in-out both;
+  }
+}
+
+@keyframes netpulse-vt-out-left {
+  to {
+    transform: translateX(-24%);
+    opacity: 0.7;
+  }
+}
+@keyframes netpulse-vt-in-right {
+  from {
+    transform: translateX(24%);
+    opacity: 0.7;
+  }
+}
+@keyframes netpulse-vt-out-right {
+  to {
+    transform: translateX(24%);
+    opacity: 0.7;
+  }
+}
+@keyframes netpulse-vt-in-left {
+  from {
+    transform: translateX(-24%);
+    opacity: 0.7;
+  }
+}
+
+/* Reducir animaciones para las view transitions (SO) */
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
+}

--- a/app/src/pages/Agents.tsx
+++ b/app/src/pages/Agents.tsx
@@ -1,0 +1,274 @@
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router'
+import { Check, Clipboard, RotateCcw } from 'lucide-react'
+import { motion, useReducedMotion } from 'framer-motion'
+import { useNetPulse } from '@/data/DataProvider'
+import { useAuth } from '@/data/AuthContext'
+import type { AgentInfo, Router } from '@/data/types'
+import { relTimeFromTs } from '@/i18n'
+import { AgentBadge } from '@/components/routers/AgentBadge'
+import { AgentRearmButton } from '@/components/routers/AgentRearmButton'
+import { cn } from '@/lib/utils'
+
+/**
+ * Página `/agents` — vista de agentes nativos (issue #245: recuperar un
+ * agente caído desde la app). Lista cada agente registrado con su estado
+ * (fresco / caído-stale / no instalado) y last-seen, y para admin expone las
+ * acciones de recuperación:
+ *   - Rearmar (canal rearm existente): preferente cuando el proceso vive pero
+ *     no reporta (heartbeat stale) — NO reinstala en seco.
+ *   - Reinstalar (POST /api/agents/{slug}/reinstall, #246): despliega el
+ *     agente vía SSH desde el server, con estados de progreso.
+ *   - Copiar comando de instalación: one-liner manual como fallback para
+ *     routers sin SSH.
+ */
+
+function isOpenWrtType(t: string | undefined): boolean {
+  return t === undefined || t === '' || t === 'glinet' || t === 'openwrt'
+}
+
+async function copyText(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+  } catch {
+    /* fallback abajo */
+  }
+  try {
+    const ta = document.createElement('textarea')
+    ta.value = text
+    ta.setAttribute('readonly', '')
+    ta.style.position = 'fixed'
+    ta.style.opacity = '0'
+    document.body.appendChild(ta)
+    ta.select()
+    const ok = document.execCommand('copy')
+    document.body.removeChild(ta)
+    return ok
+  } catch {
+    return false
+  }
+}
+
+type ReinstallState = 'idle' | 'busy' | 'done' | 'fail'
+type CopyState = 'idle' | 'busy' | 'done' | 'fail'
+
+/** Fila de un agente con sus acciones de recuperación (estado local). */
+function AgentRow({ agent, router }: { agent?: AgentInfo; router: Router | undefined }) {
+  const { t } = useTranslation()
+  const { reinstallAgent, createAgentInstall } = useNetPulse()
+  const auth = useAuth()
+  const [reinstallState, setReinstallState] = useState<ReinstallState>('idle')
+  const [reinstallMsg, setReinstallMsg] = useState('')
+  const [copyState, setCopyState] = useState<CopyState>('idle')
+
+  const isOpenWrt = isOpenWrtType(router?.type)
+  const isStale = agent !== undefined && !agent.fresh
+  const isMissing = agent === undefined && router?.agentOnly === true
+  const canRecover = isOpenWrt && (isStale || isMissing) && auth?.role === 'admin'
+
+  const slug = agent?.slug ?? router?.id ?? ''
+  const lastSeen = agent?.lastSeen ? relTimeFromTs(agent.lastSeen) ?? t('routers.agents.never') : t('routers.agents.never')
+
+  const reinstall = async () => {
+    if (reinstallState === 'busy') return
+    if (!window.confirm(t('routers.agents.reinstallConfirm', { router: router?.name ?? slug }))) return
+    setReinstallState('busy')
+    setReinstallMsg('')
+    const res = await reinstallAgent(slug)
+    if (res && !res.error) {
+      setReinstallState('done')
+      setReinstallMsg(res.recovered ? t('routers.agents.reinstallDone') : t('routers.agents.reinstallPending'))
+    } else {
+      setReinstallState('fail')
+      setReinstallMsg(res?.error ?? t('routers.agents.reinstallFail'))
+    }
+    window.setTimeout(() => setReinstallState('idle'), 8000)
+  }
+
+  const copyCmd = async () => {
+    if (copyState === 'busy') return
+    setCopyState('busy')
+    const res = await createAgentInstall(slug)
+    const ok = res ? await copyText(res.install) : false
+    setCopyState(ok ? 'done' : 'fail')
+    window.setTimeout(() => setCopyState('idle'), 4000)
+  }
+
+  return (
+    <motion.tr
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, ease: 'easeOut' }}
+      className="border-b border-border/60 last:border-0"
+    >
+      <td className="py-3 pr-3">
+        <div className="flex min-w-0 items-center gap-2.5">
+          {router ? (
+            <Link
+              to={`/routers/${router.id}`}
+              className="font-medium text-text-primary transition-colors hover:text-accent"
+            >
+              {router.name}
+            </Link>
+          ) : (
+            <span className="font-medium text-text-primary">{slug}</span>
+          )}
+          <span className="font-mono text-caption text-text-muted">{slug}</span>
+        </div>
+      </td>
+      <td className="py-3 pr-3">
+        <AgentBadge agent={agent} agentOnly={router?.agentOnly} deviceType={router?.type} />
+      </td>
+      <td className="py-3 pr-3">
+        <span className="font-mono text-caption text-text-secondary">{lastSeen}</span>
+      </td>
+      <td className="py-3 pr-3">
+        <span className="font-mono text-caption text-text-secondary">{agent?.version ? `v${agent.version}` : '—'}</span>
+      </td>
+      <td className="py-3">
+        <div className="flex flex-wrap items-center gap-2">
+          {/* Rearm: canal preferente para heartbeat stale (proceso vivo) */}
+          {agent && <AgentRearmButton agent={agent} />}
+          {canRecover && (
+            <button
+              type="button"
+              onClick={() => void reinstall()}
+              disabled={reinstallState === 'busy'}
+              title={t('routers.agents.reinstallTip')}
+              className={cn(
+                'inline-flex h-8 items-center gap-1.5 rounded-lg border px-2.5 text-caption font-semibold transition-colors disabled:opacity-50',
+                reinstallState === 'done'
+                  ? 'border-ok/40 bg-ok/10 text-ok'
+                  : reinstallState === 'fail'
+                    ? 'border-danger/40 bg-danger/10 text-danger'
+                    : 'border-border text-text-secondary hover:border-accent/40 hover:text-accent',
+              )}
+            >
+              <RotateCcw className={cn('h-3.5 w-3.5', reinstallState === 'busy' && 'animate-spin')} strokeWidth={1.75} />
+              {reinstallState === 'busy'
+                ? t('routers.agents.reinstalling')
+                : reinstallState === 'done'
+                  ? t('routers.agents.reinstalled')
+                  : reinstallState === 'fail'
+                    ? t('routers.agents.reinstallRetry')
+                    : t('routers.agents.reinstall')}
+            </button>
+          )}
+          {canRecover && (
+            <button
+              type="button"
+              onClick={() => void copyCmd()}
+              disabled={copyState === 'busy'}
+              title={t('routers.agents.copyCmdTip')}
+              className={cn(
+                'inline-flex h-8 items-center gap-1.5 rounded-lg border border-border px-2.5 text-caption font-semibold text-text-secondary transition-colors hover:border-accent/40 hover:text-accent disabled:opacity-50',
+                copyState === 'done' && 'border-ok/40 bg-ok/10 text-ok',
+                copyState === 'fail' && 'border-danger/40 bg-danger/10 text-danger',
+              )}
+            >
+              {copyState === 'busy' ? (
+                <Clipboard className="h-3.5 w-3.5 animate-pulse" strokeWidth={1.75} />
+              ) : copyState === 'done' ? (
+                <Check className="h-3.5 w-3.5" strokeWidth={1.75} />
+              ) : (
+                <Clipboard className="h-3.5 w-3.5" strokeWidth={1.75} />
+              )}
+              {copyState === 'done'
+                ? t('routers.agents.copied')
+                : copyState === 'fail'
+                  ? t('routers.agents.cmdFail')
+                  : t('routers.agents.copyCmd')}
+            </button>
+          )}
+        </div>
+        {reinstallMsg && reinstallState !== 'idle' && (
+          <p className={cn('mt-1.5 text-caption', reinstallState === 'fail' ? 'text-danger' : 'text-text-muted')}>
+            {reinstallMsg}
+          </p>
+        )}
+      </td>
+    </motion.tr>
+  )
+}
+
+/** Vista de agentes (issue #245): registrados + routers agent-only sin agente. */
+export default function Agents() {
+  const { t } = useTranslation()
+  const reduce = useReducedMotion()
+  const { agents, routers } = useNetPulse()
+
+  // Filas: agentes registrados (por slug) + routers agent-only sin agente.
+  const rows = useMemo(() => {
+    const agentBySlug = new Map(agents.map((a) => [a.slug, a]))
+    const routerBySlug = new Map(routers.map((r) => [r.id, r]))
+    const out: { agent?: AgentInfo; router?: Router }[] = agents.map((a) => ({
+      agent: a,
+      router: routerBySlug.get(a.slug),
+    }))
+    for (const r of routers) {
+      if (r.agentOnly && !agentBySlug.has(r.id) && isOpenWrtType(r.type)) {
+        out.push({ router: r })
+      }
+    }
+    return out
+  }, [agents, routers])
+
+  const down = rows.filter(({ agent }) => (agent ? !agent.fresh : true)).length
+  const total = rows.length
+
+  return (
+    <div className="space-y-4 md:space-y-5">
+      <header>
+        <motion.nav
+          initial={reduce ? false : { opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.25, ease: 'easeOut' }}
+          aria-label={t('common.breadcrumb')}
+          className="font-mono text-caption text-text-muted"
+        >
+          <Link to="/" className="transition-colors hover:text-accent">{t('common.home')}</Link>
+          <span className="mx-1.5">/</span>
+          <span className="text-text-secondary">{t('nav.agents')}</span>
+        </motion.nav>
+        <motion.div
+          initial={reduce ? false : { opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.25, ease: 'easeOut', delay: 0.06 }}
+          className="mt-1.5"
+        >
+          <h1 className="font-display text-h1 text-text-primary">{t('nav.agents')}</h1>
+          <p className="text-caption text-text-muted">{t('routers.agents.subtitle', { total, down })}</p>
+        </motion.div>
+      </header>
+
+      <section className="rounded-2xl border border-border bg-surface p-5 md:p-6">
+        {rows.length === 0 ? (
+          <p className="py-8 text-center text-sm text-text-secondary">{t('routers.agents.empty')}</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="pb-2.5 pr-3 text-label font-medium uppercase text-text-muted">{t('routers.agents.colDevice')}</th>
+                  <th className="pb-2.5 pr-3 text-label font-medium uppercase text-text-muted">{t('routers.agents.colStatus')}</th>
+                  <th className="pb-2.5 pr-3 text-label font-medium uppercase text-text-muted">{t('routers.agents.colLastSeen')}</th>
+                  <th className="pb-2.5 pr-3 text-label font-medium uppercase text-text-muted">{t('routers.agents.colVersion')}</th>
+                  <th className="pb-2.5 text-label font-medium uppercase text-text-muted">{t('routers.agents.colActions')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map(({ agent, router }) => (
+                  <AgentRow key={agent?.slug ?? router?.id ?? ''} agent={agent} router={router} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/app/src/pages/Orchestration.tsx
+++ b/app/src/pages/Orchestration.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router'
 import { motion } from 'framer-motion'
-import { ChevronRight, CheckCircle2, AlertCircle, Loader2, Wand2, ShieldAlert } from 'lucide-react'
+import { ChevronRight, CheckCircle2, AlertCircle, Loader2, Wand2, ShieldAlert, Plus, X } from 'lucide-react'
 import { useNetPulse } from '@/data/DataProvider'
 import { useAuth } from '@/data/AuthContext'
 
-type Module = 'adguard' | 'guestwifi' | 'ddns' | 'sqm'
+type Module = 'adguard' | 'guestwifi' | 'ddns' | 'sqm' | 'wireguard'
 
 interface Op {
   kind: string
@@ -34,6 +34,8 @@ const methodLabel = (module: Module, method: string) => {
     case 'binary': return `${base}.binary`
     case 'enabled': return `${base}.enabled`
     case 'disabled': return `${base}.disabled`
+    case 'active': return `${base}.active`
+    case 'inactive': return `${base}.inactive`
     default: return ''
   }
 }
@@ -70,6 +72,10 @@ export default function Orchestration() {
   const [sqScript, setSqScript] = useState('piece_of_cake.qos')
   const [sqLinklayer, setSqLinklayer] = useState('ethernet')
   const [sqOverhead, setSqOverhead] = useState('44')
+  // WireGuard (10.3): interfaz + peers del túnel + pubkey del admin (anti-lockout).
+  const [wgInterface, setWgInterface] = useState('wg0')
+  const [wgPeers, setWgPeers] = useState([{ name: '', publicKey: '', allowedIps: '' }])
+  const [wgAdminPeer, setWgAdminPeer] = useState('')
 
   // issue #120: todos los módulos son gateway-only por defecto. El toggle
   // "advanced" permite un router no-gateway (con warning + checks).
@@ -126,10 +132,23 @@ export default function Orchestration() {
           qdisc: sqQdisc, script: sqScript, linklayer: sqLinklayer, overhead: sqOverhead,
           allowNonGateway,
         }
+      case 'wireguard':
+        return {
+          interface: wgInterface,
+          peers: wgPeers
+            .filter((p) => p.publicKey.trim() !== '')
+            .map((p) => ({ name: p.name, publicKey: p.publicKey.trim(), allowedIps: p.allowedIps.trim() })),
+          adminPeerPubkey: wgAdminPeer.trim(),
+        }
       default:
         return { enabled: agEnabled, port: agPort, upstreamDns: agDns, allowNonGateway }
     }
   }
+
+  const updateWgPeer = (i: number, field: 'name' | 'publicKey' | 'allowedIps') => (e: ChangeEvent<HTMLInputElement>) => {
+    setWgPeers((prev) => prev.map((p, idx) => (idx === i ? { ...p, [field]: e.target.value } : p)))
+  }
+  const removeWgPeer = (i: number) => () => setWgPeers((prev) => prev.filter((_, idx) => idx !== i))
 
   const createPlan = async () => {
     stopApplyPoll()
@@ -227,7 +246,7 @@ export default function Orchestration() {
 
       {/* Selector de módulo */}
       <div className="flex flex-wrap gap-2">
-        {(['adguard', 'guestwifi', 'ddns', 'sqm'] as Module[]).map((m) => (
+        {(['adguard', 'guestwifi', 'ddns', 'sqm', 'wireguard'] as Module[]).map((m) => (
           <button
             key={m}
             type="button"
@@ -512,6 +531,85 @@ export default function Orchestration() {
                   </label>
                 </>
               )}
+            </>
+          )}
+
+          {module === 'wireguard' && (
+            <>
+              <label className="flex flex-col gap-1">
+                <span className="text-caption font-medium text-text-secondary">{t('orchestration.wireguard.interface')}</span>
+                <input
+                  type="text"
+                  value={wgInterface}
+                  onChange={(e) => setWgInterface(e.target.value)}
+                  className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary"
+                />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="text-caption font-medium text-text-secondary">{t('orchestration.wireguard.adminPeer')}</span>
+                <input
+                  type="text"
+                  value={wgAdminPeer}
+                  onChange={(e) => setWgAdminPeer(e.target.value)}
+                  placeholder={t('orchestration.wireguard.adminPeerPlaceholder')}
+                  className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary"
+                />
+              </label>
+
+              <div className="lg:col-span-4">
+                <div className="flex items-center justify-between">
+                  <span className="text-caption font-medium text-text-secondary">{t('orchestration.wireguard.peers')}</span>
+                  <button
+                    type="button"
+                    onClick={() => setWgPeers((prev) => [...prev, { name: '', publicKey: '', allowedIps: '' }])}
+                    className="inline-flex items-center gap-1 rounded-md bg-accent-soft px-2.5 py-1 text-xs font-medium text-accent transition-colors hover:bg-accent-soft/70"
+                  >
+                    <Plus className="h-3.5 w-3.5" strokeWidth={1.75} />
+                    {t('orchestration.wireguard.addPeer')}
+                  </button>
+                </div>
+                {wgPeers.map((p, i) => (
+                  <div key={i} className="mt-2 grid items-end gap-2 sm:grid-cols-[1fr_2fr_1.5fr_auto]">
+                    <label className="flex flex-col gap-1">
+                      <span className="text-caption text-text-muted">{t('orchestration.wireguard.peerName')}</span>
+                      <input
+                        type="text"
+                        value={p.name}
+                        onChange={updateWgPeer(i, 'name')}
+                        className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1">
+                      <span className="text-caption text-text-muted">{t('orchestration.wireguard.peerPubkey')}</span>
+                      <input
+                        type="text"
+                        value={p.publicKey}
+                        onChange={updateWgPeer(i, 'publicKey')}
+                        className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1">
+                      <span className="text-caption text-text-muted">{t('orchestration.wireguard.peerAllowedIps')}</span>
+                      <input
+                        type="text"
+                        value={p.allowedIps}
+                        onChange={updateWgPeer(i, 'allowedIps')}
+                        placeholder="10.0.0.2/32,10.0.1.0/24"
+                        className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary"
+                      />
+                    </label>
+                    <button
+                      type="button"
+                      onClick={removeWgPeer(i)}
+                      aria-label={t('orchestration.wireguard.removePeer')}
+                      className="inline-flex items-center justify-center rounded-lg border border-border p-2 text-text-secondary transition-colors hover:text-rose-500"
+                    >
+                      <X className="h-4 w-4" strokeWidth={1.75} />
+                    </button>
+                  </div>
+                ))}
+                <p className="mt-2 text-xs text-text-muted">{t('orchestration.wireguard.peersHint')}</p>
+              </div>
             </>
           )}
         </div>

--- a/app/src/pages/Topology.tsx
+++ b/app/src/pages/Topology.tsx
@@ -236,8 +236,14 @@ export default function Topology() {
         >
           {zoomControls}
         </div>
-        {/* ③ Leyenda como bottom sheet en móvil */}
-        <LegendSheet model={model} />
+        {/* ③ Leyenda como bottom sheet en móvil. Se recorta a la sección del
+            mapa (wrapper overflow-hidden): la sección no puede llevar
+            overflow-hidden porque recortaría los tooltips (#88). Sin este
+            recorte, el sheet cerrado (trasladado y:236) cuelga por debajo del
+            mapa y tapa la tabla de enlaces (#183). */}
+        <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-2xl">
+          <LegendSheet model={model} />
+        </div>
       </section>
 
 

--- a/app/src/splash.css
+++ b/app/src/splash.css
@@ -1,0 +1,7 @@
+/* Splash oscuro mientras carga el bundle (PWA) */
+#root:empty {
+  background: #070b12;
+}
+html {
+  background: #070b12;
+}

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,7 +1,27 @@
 import path from "path"
 import react from "@vitejs/plugin-react"
-import { defineConfig } from "vite"
+import { defineConfig, type Plugin } from "vite"
 import { VitePWA } from "vite-plugin-pwa"
+
+// Tracker GoatCounter SOLO en el build de la demo pública (issue #240):
+//   VITE_GC_COUNT=https://stats.netpulse.cloudless.club npm run build
+// Los builds normales NO lo llevan: una instalación self-hosted nunca debe
+// llamar a casa. Los hits se registran con prefijo /demo en el mismo site
+// que la landing ("/" = landing, "/demo/..." = demo).
+const gcCount = process.env.VITE_GC_COUNT?.replace(/\/$/, "")
+
+function goatcounterPlugin(): Plugin {
+  return {
+    name: "netpulse-goatcounter",
+    transformIndexHtml(html) {
+      if (!gcCount) return html
+      const snippet =
+        `    <script>window.goatcounter={path:function(p){return '/demo'+p}}</script>\n` +
+        `    <script async data-goatcounter="${gcCount}/count" src="${gcCount}/count.js"></script>\n  </head>`
+      return html.replace("</head>", snippet)
+    },
+  }
+}
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -10,6 +30,7 @@ export default defineConfig({
   base: '/',
   plugins: [
     react(),
+    goatcounterPlugin(),
     VitePWA({
       // injectManifest: SW propio (src/sw.ts) con handlers Web Push;
       // generateSW no permite handlers custom (SPEC-PUSH §2).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -586,7 +586,12 @@ Objetivo: alertas más inteligentes y menos ruidosas.
 La fundación (10.1) y el módulo AdGuard (10.2) están hechos y verificados
 E2E. Pendiente:
 
-3. **10.3 — WireGuard peers**: alta/baja de peers desde la app. Riesgo medio.
+3. **10.3 - WireGuard peers** ✅ (24-Ago-2026): alta/baja de peers desde la
+   app. Riesgo medio. El plan crea la interfaz (network.wg0) si falta,
+   reconcilia las secciones wgpeer&lt;N&gt; (public_key + allowed_ips) y termina con
+   `service network reload` + healthcheck `wg show` (auto-rollback si el túnel
+   que estaba arriba no levanta). Anti-lockout: el peer con el pubkey del admin
+   nunca se borra. Módulo: server-go/internal/orchestr/wireguard.go.
 4. **10.4 — DAWN/802.11r config** (write): modificar config de roaming
    desde la app con snapshot+rollback. **Solo tras Fase 14 estabilice**
    (necesitamos la visibilidad para diagnosticar si algo va mal).

--- a/docs/SPEC-FASE10.md
+++ b/docs/SPEC-FASE10.md
@@ -295,4 +295,5 @@ Nueva sección en la app (solo admin): **Orquestación**.
    plan generation, API endpoints, audit log.
 3. **AdGuard module**: primer módulo end-to-end (recurso + plan + apply).
 4. **Frontend orquestación**: UI para AdGuard.
-5. **WireGuard module**: segundo módulo.
+5. **WireGuard module** (✅ 10.3, 24-Ago-2026): segundo módulo (peers,
+   healthcheck `wg show`, anti-lockout del peer del admin).

--- a/server-go/internal/adapters/agent.go
+++ b/server-go/internal/adapters/agent.go
@@ -337,6 +337,11 @@ func (l *Live) polledFromAgent(cfg RouterConfig, p *probe.Payload) *routerPolled
 			out.ports = ethPortsToAdapter(fd.Ports)
 		}
 	}
+	// LuCI (issue #258): etiquetas de puertos/VLANs, fuente de nombres de
+	// topología. Best-effort: sección ausente → conserva la última buena.
+	if p.Data.LuCI != nil {
+		out.luci = p.Data.LuCI
+	}
 
 	if cached == nil {
 		cached = &extrasSnapshot{ports: []EthPort{}, radios: []Radio{},
@@ -354,9 +359,12 @@ func (l *Live) polledFromAgent(cfg RouterConfig, p *probe.Payload) *routerPolled
 	if out.fdb == nil {
 		out.fdb = cached.fdb
 	}
+	if out.luci == nil {
+		out.luci = cached.luci
+	}
 	l.mu.Lock()
 	l.extrasCache[cfg.ID] = &extrasSnapshot{ports: out.ports, radios: out.radios,
-		wireless: out.wireless, fdb: out.fdb}
+		wireless: out.wireless, fdb: out.fdb, luci: out.luci}
 	l.mu.Unlock()
 
 	if out.leases == nil {

--- a/server-go/internal/adapters/agent_live_test.go
+++ b/server-go/internal/adapters/agent_live_test.go
@@ -50,6 +50,11 @@ func testPayload() *probe.Payload {
 		MACs:  map[string]string{"EC:71:DB:44:12:8A": "lan1"},
 		Ports: []probe.EthPort{{ID: "lan1", Label: "LAN 1", Up: true, Speed: "1 Gbps"}},
 	}
+	// LuCI (issue #258): etiquetas de puertos/VLANs para la topología.
+	pl.Data.LuCI = &probe.LuCILabels{
+		PortLabels: map[string]string{"lan1": "Router/Fritzbox"},
+		VlanLabels: map[string]string{"1": "LAN"},
+	}
 	return pl
 }
 
@@ -142,6 +147,10 @@ func TestLiveAgentFreshSkipsSSH(t *testing.T) {
 	}
 	if p.fdb["EC:71:DB:44:12:8A"] != "lan1" || len(p.ports) != 1 || p.ports[0].Speed != "1 Gbps" {
 		t.Fatalf("fdb/ports: %+v %+v", p.fdb, p.ports)
+	}
+	// LuCI del agente (issue #258): etiquetas propagadas al routerPolled.
+	if p.luci == nil || p.luci.PortLabels["lan1"] != "Router/Fritzbox" || p.luci.VlanLabels["1"] != "LAN" {
+		t.Fatalf("luci vía agente: %+v", p.luci)
 	}
 	if len(p.radios) != 1 || p.radios[0].Name != "2.4 GHz" || p.brMac != "94:83:C4:00:00:09" || p.backhaul != "cable" {
 		t.Fatalf("radios/brMac/backhaul: %+v %q %q", p.radios, p.brMac, p.backhaul)

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gnacho/netpulse/agent/probe"
 	"github.com/gnacho/netpulse/server-go/internal/alerts"
 	"github.com/gnacho/netpulse/server-go/internal/config"
 	"github.com/gnacho/netpulse/server-go/internal/db"
@@ -116,6 +117,9 @@ type routerPolled struct {
 	// lldpUnavailable: lldpd no está instalado en este router (issue #247) →
 	// el view-model expone `lldpAvailable:false` para el hint de instalación.
 	lldpUnavailable bool
+	// luci: etiquetas de puertos/VLANs de LuCI (issue #258), si el router las
+	// define en /etc/config/luci. Fuente de nombres para la topología.
+	luci *probe.LuCILabels
 }
 
 // extrasSnapshot es la caché anti-parpadeo por router.
@@ -124,6 +128,7 @@ type extrasSnapshot struct {
 	radios   []Radio
 	wireless map[string]WirelessClient
 	fdb      map[string]string
+	luci     *probe.LuCILabels
 }
 
 // backhaulCacheTTL: el medio del uplink cambia muy raro; no se sondea cada 5 s.
@@ -713,8 +718,12 @@ func (l *Live) pollRouter(ctx context.Context, cfg RouterConfig) (*routerPolled,
 	if fdb != nil {
 		fdbGood = fdb
 	}
+	luciGood := cached.luci
+	if luci := client.GetLuCILabels(); luci != nil {
+		luciGood = luci
+	}
 	l.mu.Lock()
-	l.extrasCache[cfg.ID] = &extrasSnapshot{ports: portsGood, radios: radiosGood, wireless: wirelessGood, fdb: fdbGood}
+	l.extrasCache[cfg.ID] = &extrasSnapshot{ports: portsGood, radios: radiosGood, wireless: wirelessGood, fdb: fdbGood, luci: luciGood}
 	l.mu.Unlock()
 
 	// Uso real de RAM como en la UI del router: used = total − available
@@ -751,6 +760,7 @@ func (l *Live) pollRouter(ctx context.Context, cfg RouterConfig) (*routerPolled,
 		wireless: wirelessGood, ports: portsGood, radios: radiosGood,
 		fdb: fdbGood, brMac: brMac, latencyMs: latencyMs, lossPct: lossPct,
 		backhaul: backhaul, lldp: lldp, lldpUnavailable: lldpUnavailable,
+		luci: luciGood,
 	}, nil
 }
 

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -184,6 +184,9 @@ type Live struct {
 	devicePresence       map[string]bool
 	presenceMisses       map[string]int
 	presenceOfflineAfter int // ticks sin verse antes de declarar offline (default 3)
+	// presencePruneAfter: ticks sin verse que eliminan la MAC de los mapas
+	// (dispositivo que se fue para siempre; ~2h a 5s/tick, issue #206).
+	presencePruneAfter int
 	// dawnAvailable: cache de "¿hay DAWN en algún router?" para el flag del
 	// overview (entrada /roaming). Refrescado asíncronamente (TTL 30s, 1 SSH
 	// al gateway) por dawnAvailableCached para no bloquear buildOverview.
@@ -243,6 +246,7 @@ func NewLive(cfg *config.Config, d *db.DB, initial []RouterConfig, pool *SSHPool
 		devicePresence:       map[string]bool{},
 		presenceMisses:       map[string]int{},
 		presenceOfflineAfter: 3,
+		presencePruneAfter:   2000,
 		wanDown:              map[string]int{},
 		backhaulCache:        map[string]backhaulCacheEntry{},
 		lldpCache:            map[string]lldpCacheEntry{},
@@ -1227,7 +1231,9 @@ func (l *Live) emitUnknownDevice(d Device) {
 // volátil y daría falsos offline. Anti-falsos positivos: un tick perdido no
 // dispara — hace falta `presenceOfflineAfter` ticks seguidos sin verse.
 // Anti-arranque: el primer ciclo solo puebla el estado (todo lo ya conectado
-// en boot no genera online). Toma l.mu.
+// en boot no genera online). Poda: una MAC offline desde hace muchos ticks
+// (dispositivo que se fue para siempre) se elimina de los mapas para que no
+// crezcan sin límite (issue #206). Toma l.mu.
 func (l *Live) trackDevicePresence(devices []Device, nowMs int64) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -1245,6 +1251,9 @@ func (l *Live) trackDevicePresence(devices []Device, nowMs int64) {
 	}
 	for mac, wasOnline := range l.devicePresence {
 		if !wasOnline {
+			// Ya offline: la MAC no re-emite, pero el contador sigue
+			// creciendo para que la poda pueda eliminarla (issue #206).
+			l.presenceMisses[mac]++
 			continue
 		}
 		if seen[mac] {
@@ -1254,6 +1263,17 @@ func (l *Live) trackDevicePresence(devices []Device, nowMs int64) {
 		if l.presenceMisses[mac] >= l.presenceOfflineAfter {
 			l.insertDeviceEvent(mac, l.lastRouterFor(mac), deviceevents.StateOffline, nil, nowMs)
 			l.devicePresence[mac] = false
+		}
+	}
+	// Poda: MACs offline desde hace muchos ticks (se fueron para siempre) se
+	// eliminan para que los mapas no crezcan sin límite (issue #206).
+	// Zero-value (pruneAfter==0) = poda desactivada.
+	if l.presencePruneAfter > 0 {
+		for mac, misses := range l.presenceMisses {
+			if misses >= l.presencePruneAfter {
+				delete(l.presenceMisses, mac)
+				delete(l.devicePresence, mac)
+			}
 		}
 	}
 	l.presenceSeen = true

--- a/server-go/internal/adapters/lldp.go
+++ b/server-go/internal/adapters/lldp.go
@@ -54,16 +54,32 @@ func (n LldpNeighbor) displayName() string {
 	return n.ChassisMac
 }
 
+// lldpDownCached: true si la indisponibilidad de lldpd está cacheada (dentro
+// de lldpDownTTL). Serializado por c.mu: el poller y los handlers HTTP
+// (p.ej. GetSurvey) pueden sondear el mismo cliente en paralelo (issue #208).
+func (c *OpenWrtClient) lldpDownCached() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return time.Now().Before(c.lldpDownUntil)
+}
+
+// cacheLldpDown: cachea que lldpd no está instalado durante lldpDownTTL.
+func (c *OpenWrtClient) cacheLldpDown() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lldpDownUntil = time.Now().Add(lldpDownTTL)
+}
+
 // LldpNeighbors: vecinos LLDP del router (contrato C2). Si lldpcli no existe
 // devuelve ErrLldpUnavailable y cachea la indisponibilidad lldpDownTTL.
 func (c *OpenWrtClient) LldpNeighbors(ctx context.Context) ([]LldpNeighbor, error) {
-	if time.Now().Before(c.lldpDownUntil) {
+	if c.lldpDownCached() {
 		return nil, ErrLldpUnavailable
 	}
 	out, err := c.pool.RunCtx(ctx, c.Host, "lldpcli -f json show neighbors", lldpTimeout)
 	if err != nil {
 		if isLldpUnavailable(err) {
-			c.lldpDownUntil = time.Now().Add(lldpDownTTL)
+			c.cacheLldpDown()
 			return nil, ErrLldpUnavailable
 		}
 		return nil, err

--- a/server-go/internal/adapters/lldp_test.go
+++ b/server-go/internal/adapters/lldp_test.go
@@ -7,7 +7,9 @@ package adapters
 import (
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
+	"time"
 )
 
 // Fixture realista (lldpd 1.0.x en OpenWrt).
@@ -279,6 +281,45 @@ func TestBuildRouterLldpUplink(t *testing.T) {
 	ap.lldp = nil
 	if r := l.buildRouter(ap, nil); r.Lldp != nil {
 		t.Fatalf("sin LLDP: %+v", r.Lldp)
+	}
+}
+
+// TestLldpDownCacheConcurrente: la caché de indisponibilidad de lldpd
+// (lldpDownUntil) tolera lectura+escritura concurrentes (issue #208): el
+// poller y un handler HTTP (p.ej. GetSurvey) pueden sondear el mismo cliente
+// en paralelo. Bajo -race este test falla sin el mutex.
+func TestLldpDownCacheConcurrente(t *testing.T) {
+	c := &OpenWrtClient{}
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				_ = c.lldpDownCached()
+				c.cacheLldpDown()
+			}
+		}()
+	}
+	wg.Wait()
+	if !c.lldpDownCached() {
+		t.Fatal("tras cacheLldpDown, lldpDownCached debería ser true")
+	}
+}
+
+// TestLldpCacheDownExpira: la caché expira pasados lldpDownTTL (fija el TTL
+// desde el momento de la llamada, no acumula).
+func TestLldpCacheDownExpira(t *testing.T) {
+	c := &OpenWrtClient{}
+	c.cacheLldpDown()
+	if !c.lldpDownCached() {
+		t.Fatal("el cache debería estar activo justo tras cacheLldpDown")
+	}
+	c.mu.Lock()
+	c.lldpDownUntil = time.Now().Add(-time.Second)
+	c.mu.Unlock()
+	if c.lldpDownCached() {
+		t.Fatal("el cache debería expirar pasados lldpDownTTL")
 	}
 }
 

--- a/server-go/internal/adapters/openwrt.go
+++ b/server-go/internal/adapters/openwrt.go
@@ -472,6 +472,17 @@ func (c *OpenWrtClient) GetBridgeMac() string {
 	return strings.ToUpper(strings.TrimSpace(out))
 }
 
+// GetLuCILabels: etiquetas de puertos/VLANs de LuCI (issue #258), si el
+// router las define en /etc/config/luci. Best-effort: fichero sin secciones
+// → nil.
+func (c *OpenWrtClient) GetLuCILabels() *probe.LuCILabels {
+	out, err := c.pool.Run(c.Host, probe.CmdLuCILabels, 0)
+	if err != nil {
+		return nil
+	}
+	return probe.ParseLuCILabels(out)
+}
+
 // ---------------------------------------------------------------------------
 // Radios WiFi
 // ---------------------------------------------------------------------------

--- a/server-go/internal/adapters/openwrt.go
+++ b/server-go/internal/adapters/openwrt.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gnacho/netpulse/agent/probe"
@@ -36,11 +37,16 @@ type OpenWrtClient struct {
 
 	pool *SSHPool
 
+	// mu protege el estado mutable del cliente (sid, lastStat, lastNetDev,
+	// lldpDownUntil): los handlers HTTP pueden sondear (p.ej. GetSurvey) en
+	// paralelo con el poller.
+	mu sync.Mutex
+
 	sid        string     // sesión ubus HTTP cacheada
 	lastStat   *cpuSample // /proc/stat previo
 	lastNetDev *netSample // /proc/net/dev previo
 	// lldpDownUntil: indisponibilidad de lldpd cacheada (≥5 min) para no
-	// martillear con un comando que no existe. Solo lo toca el sondeo.
+	// martillear con un comando que no existe. Acceso serializado por mu.
 	lldpDownUntil time.Time
 }
 

--- a/server-go/internal/adapters/presence_live_test.go
+++ b/server-go/internal/adapters/presence_live_test.go
@@ -2,6 +2,8 @@ package adapters
 
 import (
 	"testing"
+
+	"github.com/gnacho/netpulse/server-go/internal/db"
 )
 
 // testLivePresence: Live con DB real y estado de presencia inicializado.
@@ -131,5 +133,52 @@ func TestTrackDevicePresenceCableSkip(t *testing.T) {
 	l.trackDevicePresence([]Device{}, 13000)
 	if n := countDeviceEvents(t, l); n != 0 {
 		t.Fatalf("cableado: %d eventos, esperaba 0", n)
+	}
+}
+
+// TestTrackDevicePresencePrune reproduce el bug #206: los mapas de presencia
+// crecían sin límite con cada MAC wireless histórica. Tras superar
+// presencePruneAfter ticks sin verse, la MAC debe eliminarse de ambos mapas.
+func TestTrackDevicePresencePrune(t *testing.T) {
+	l := testLivePresence(t)
+	l.presencePruneAfter = 5 // bajar el umbral para el test
+	d := Device{MAC: "AA:BB:CC:DD:EE:03", RouterID: "rt1", Online: true, Band: "5 GHz"}
+
+	l.trackDevicePresence([]Device{d}, 1000) // siembra (entra en el mapa)
+	if _, ok := l.devicePresence[d.MAC]; !ok {
+		t.Fatal("la MAC debería estar en devicePresence tras sembrar")
+	}
+
+	// Ticks vacíos: supera offlineAfter (3) → offline, y luego pruneAfter (5).
+	for i := 1; i <= 5; i++ {
+		l.trackDevicePresence([]Device{}, int64(i)*1000+1000)
+	}
+
+	l.mu.Lock()
+	_, inPresence := l.devicePresence[d.MAC]
+	_, inMisses := l.presenceMisses[d.MAC]
+	l.mu.Unlock()
+	if inPresence || inMisses {
+		t.Fatalf("tras la poda la MAC debería haber desaparecido de los mapas (presence=%v misses=%v)", inPresence, inMisses)
+	}
+}
+
+// TestMaintenancePurgaDeviceAttrib: la pasada de mantenimiento borra los
+// atributos de dispositivos sin verse desde hace > AttribRetentionMS.
+func TestMaintenancePurgaDeviceAttrib(t *testing.T) {
+	d := openLiveTestDB(t)
+	_, _ = d.Exec("INSERT INTO device_attrib (mac, router_id, band, signal_dbm, last_seen) VALUES (?, ?, ?, ?, ?)",
+		"AA:BB:CC:DD:EE:04", "rt1", "5 GHz", -40, db.NowMS()-db.AttribRetentionMS-1000)
+	_, _ = d.Exec("INSERT INTO device_attrib (mac, router_id, band, signal_dbm, last_seen) VALUES (?, ?, ?, ?, ?)",
+		"AA:BB:CC:DD:EE:05", "rt1", "5 GHz", -40, db.NowMS()-1000)
+
+	d.Maintenance()
+
+	var n int
+	if err := d.QueryRow("SELECT COUNT(*) FROM device_attrib").Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("device_attrib tras maintenance: %d filas, esperaba 1 (solo la reciente)", n)
 	}
 }

--- a/server-go/internal/adapters/sshpool.go
+++ b/server-go/internal/adapters/sshpool.go
@@ -222,27 +222,57 @@ func (p *SSHPool) Run(host, cmd string, timeout time.Duration) (string, error) {
 		}
 		return string(res.out), nil
 	case <-time.After(timeout):
+		// Timeout: cerrar solo la sesión. NO dropear el cliente entero: el
+		// pool permite sesiones concurrentes sobre el mismo router y un
+		// comando lento no debe cortar las demás (issue #205).
 		_ = session.Close()
-		p.drop(host)
 		return "", fmt.Errorf("ssh %s: timeout (%s)", host, timeout)
 	}
 }
 
 // RunCtx es Run con cancelación por contexto.
 func (p *SSHPool) RunCtx(ctx context.Context, host, cmd string, timeout time.Duration) (string, error) {
-	type res struct {
-		out string
+	if timeout <= 0 {
+		timeout = sshDefaultTimeout
+	}
+	client, err := p.dial(host)
+	if err != nil {
+		return "", err
+	}
+	session, err := client.NewSession()
+	if err != nil {
+		p.drop(host)
+		return "", fmt.Errorf("ssh %s: session: %w", host, err)
+	}
+	defer session.Close()
+
+	type result struct {
+		out []byte
 		err error
 	}
-	ch := make(chan res, 1)
+	ch := make(chan result, 1)
 	go func() {
-		out, err := p.Run(host, cmd, timeout)
-		ch <- res{out, err}
+		out, err := session.Output(cmd)
+		ch <- result{out, err}
 	}()
 	select {
-	case r := <-ch:
-		return r.out, r.err
+	case res := <-ch:
+		if res.err != nil {
+			var ee *ssh.ExitError
+			if !errors.As(res.err, &ee) {
+				p.drop(host) // canal roto, no exit status
+			}
+			return "", fmt.Errorf("ssh %s: %w", host, res.err)
+		}
+		return string(res.out), nil
+	case <-time.After(timeout):
+		_ = session.Close()
+		return "", fmt.Errorf("ssh %s: timeout (%s)", host, timeout)
 	case <-ctx.Done():
+		// Cancelación del cliente: cerrar la sesión para abortar el comando
+		// remoto y liberar la goroutine (issue #204). Sin drop: es una
+		// cancelación del llamador, no un fallo de la conexión.
+		_ = session.Close()
 		return "", ctx.Err()
 	}
 }

--- a/server-go/internal/adapters/topology.go
+++ b/server-go/internal/adapters/topology.go
@@ -131,6 +131,7 @@ func inferTopology(polled map[string]*routerPolled, devices []Device) ([]Device,
 				for _, mac := range kept {
 					if idx, ok := byMAC[mac]; ok && devices[idx].RouterID == routerID {
 						devices[idx].Port = port
+						devices[idx].PortLabel = portLabel(p, port)
 					}
 				}
 			}
@@ -157,7 +158,8 @@ func inferTopology(polled map[string]*routerPolled, devices []Device) ([]Device,
 					setPort()
 					dists = append(dists, DistributionNode{
 						ID: id, Kind: "hypervisor", RouterID: routerID, Port: port,
-						MacCount: len(kept), HostDeviceID: devices[hidx].ID, Name: devices[hidx].Name,
+						PortLabel: portLabel(p, port),
+						MacCount:  len(kept), HostDeviceID: devices[hidx].ID, Name: devices[hidx].Name,
 					})
 					// SPEC-65 D65-2: sellado de infra — host = hypervisor,
 					// las MACs con OUI de hipervisor anidadas bajo él = ct.
@@ -179,7 +181,8 @@ func inferTopology(polled map[string]*routerPolled, devices []Device) ([]Device,
 				setPort()
 				dists = append(dists, DistributionNode{
 					ID: id, Kind: "managed", RouterID: routerID, Port: port,
-					MacCount: len(kept), Name: nb.displayName(), Ip: nb.Mgmt,
+					PortLabel: portLabel(p, port),
+					MacCount:  len(kept), Name: nb.displayName(), Ip: nb.Mgmt,
 					Mac: nb.ChassisMac, Lldp: nb.info(),
 				})
 				// SPEC-65 D65-2: el vecino LLDP managed que existe como Device
@@ -212,7 +215,7 @@ func inferTopology(polled map[string]*routerPolled, devices []Device) ([]Device,
 			// algo multiplexa ese puerto → nodo inferido colgando del gateway.
 			setPort()
 			dn := DistributionNode{
-				ID: id, Kind: "inferred", RouterID: routerID, Port: port, MacCount: len(kept),
+				ID: id, Kind: "inferred", RouterID: routerID, Port: port, PortLabel: portLabel(p, port), MacCount: len(kept),
 			}
 			if routerID == gatewayID {
 				for _, rp := range polled {
@@ -260,6 +263,15 @@ func inferTopology(polled map[string]*routerPolled, devices []Device) ([]Device,
 		}
 	}
 	return devices, dists
+}
+
+// portLabel devuelve la etiqueta LuCI del puerto (issue #258) si el router
+// la define ("" si no existe): la app la usa como nombre preferente.
+func portLabel(p *routerPolled, port string) string {
+	if p == nil || p.luci == nil {
+		return ""
+	}
+	return p.luci.PortLabels[port]
 }
 
 // routerIdentity: datos de un router de la config para casar un vecino LLDP

--- a/server-go/internal/adapters/topology_test.go
+++ b/server-go/internal/adapters/topology_test.go
@@ -1,6 +1,10 @@
 package adapters
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/gnacho/netpulse/agent/probe"
+)
 
 // FDB/port helpers para los tests de inferencia.
 func polledWithFDB(routerID, brMac string, fdb map[string]string) map[string]*routerPolled {
@@ -391,5 +395,45 @@ func TestInferTopologyLldpIdentificaDeviceDirecto(t *testing.T) {
 	}
 	if devices[0].Lldp == nil || devices[0].Lldp.Chassis != "GS308E" || devices[0].Lldp.Mgmt != "192.168.8.13" {
 		t.Fatalf("Device.Lldp: %+v", devices[0].Lldp)
+	}
+}
+
+// Issue #258: las etiquetas de puertos de LuCI (config switchvlan
+// 'port_labels' en /etc/config/luci) se usan como nombre preferente del
+// puerto en el view-model: Device.PortLabel y DistributionNode.PortLabel.
+func TestInferTopologyPortLabelLuCI(t *testing.T) {
+	luci := &probe.LuCILabels{
+		PortLabels: map[string]string{"lan1": "Router/Fritzbox", "lan3": "Servidor"},
+		VlanLabels: map[string]string{"1": "LAN"},
+	}
+	polled := map[string]*routerPolled{
+		"flint2": {cfg: RouterConfig{ID: "flint2", IsGateway: true}, brMac: "94:83:C4:00:00:01",
+			fdb:  map[string]string{"28:C6:8E:1D:90:44": "lan1", "04:D4:C4:8B:30:A7": "lan3", "DC:A6:32:4F:77:02": "lan3"},
+			luci: luci},
+	}
+	devices := []Device{
+		dev("28:C6:8E:1D:90:44", "flint2", "cable"),
+		dev("04:D4:C4:8B:30:A7", "flint2", "cable"),
+		dev("DC:A6:32:4F:77:02", "flint2", "cable"),
+	}
+	devices, dists := inferTopology(polled, devices)
+	if devices[0].Port != "lan1" || devices[0].PortLabel != "Router/Fritzbox" {
+		t.Fatalf("Device.PortLabel lan1: %+v", devices[0])
+	}
+	if len(dists) != 1 || dists[0].Kind != "inferred" {
+		t.Fatalf("distnodes: %+v", dists)
+	}
+	if dists[0].Port != "lan3" || dists[0].PortLabel != "Servidor" {
+		t.Fatalf("DistributionNode.PortLabel: %+v", dists[0])
+	}
+	// Sin etiquetas → PortLabel vacío (omitempty).
+	noLuci := map[string]*routerPolled{
+		"flint2": {cfg: RouterConfig{ID: "flint2", IsGateway: true}, brMac: "94:83:C4:00:00:01",
+			fdb: map[string]string{"28:C6:8E:1D:90:44": "lan1"}},
+	}
+	devices = []Device{dev("28:C6:8E:1D:90:44", "flint2", "cable")}
+	devices, _ = inferTopology(noLuci, devices)
+	if devices[0].Port != "lan1" || devices[0].PortLabel != "" {
+		t.Fatalf("sin etiquetas PortLabel vacío: %+v", devices[0])
 	}
 }

--- a/server-go/internal/adapters/types.go
+++ b/server-go/internal/adapters/types.go
@@ -197,6 +197,10 @@ type Device struct {
 	// --- topología v5 (FDB/LLDP; omitempty: ausentes si no hay datos) ---
 	// Port: puerto físico del bridge donde se aprende la MAC (cableados, FDB).
 	Port string `json:"port,omitempty"`
+	// PortLabel: nombre amigable del puerto definido en LuCI (issue #258)
+	// (`config switchvlan 'port_labels'` en /etc/config/luci). La app lo
+	// muestra como nombre preferente sobre Port cuando existe.
+	PortLabel string `json:"portLabel,omitempty"`
 	// Lldp: identificación del vecino cuando se anuncia por LLDP.
 	Lldp *LldpInfo `json:"lldp,omitempty"`
 	// AttachTo: hub del que cuelga en el mapa (router por defecto; id de
@@ -241,7 +245,10 @@ type DistributionNode struct {
 	Kind     string `json:"kind"` // "inferred"|"hypervisor"|"managed"
 	RouterID string `json:"routerId"`
 	Port     string `json:"port"`
-	MacCount int    `json:"macCount"`
+	// PortLabel: nombre amigable del puerto definido en LuCI (issue #258).
+	// Preferente sobre Port cuando existe.
+	PortLabel string `json:"portLabel,omitempty"`
+	MacCount  int    `json:"macCount"`
 	// HostDeviceID: hipervisor → id del Device host (Proxmox…), si es cliente.
 	HostDeviceID string `json:"hostDeviceId,omitempty"`
 	Name         string `json:"name,omitempty"`

--- a/server-go/internal/auth/auth.go
+++ b/server-go/internal/auth/auth.go
@@ -37,6 +37,11 @@ const (
 	LockMS = 5 * 60 * 1000
 )
 
+// dummyPasswordHash se compara contra la password cuando el usuario no
+// existe, para igualar el timing con el camino de usuario válido y no
+// filtrar existencia de usuarios (issue #209).
+const dummyPasswordHash = "$2a$10$JeMmUvg2.LaUqM9Ir68TBegs4ll8r8KqG6x2f0.wA5f7BUBjtW/yq"
+
 // ---------------------------------------------------------------------------
 // Usuarios
 // ---------------------------------------------------------------------------
@@ -442,7 +447,7 @@ func HandleLogin(d *db.DB, secret string, r *http.Request, username, password st
 	if u == nil {
 		// Compare contra un hash conocido para igualar el timing con el
 		// camino de usuario válido y no filtrar existencia de usuarios.
-		_ = bcrypt.CompareHashAndPassword([]byte("$2a$10$dummy_dummy_dummy_dummy_dummy_dummy_dummy_dummy_dummy_dummy_dummy"), []byte(password))
+		_ = bcrypt.CompareHashAndPassword([]byte(dummyPasswordHash), []byte(password))
 		return nil
 	}
 	if !CheckPassword(password, u.PassHash) {

--- a/server-go/internal/auth/auth_test.go
+++ b/server-go/internal/auth/auth_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/gnacho/netpulse/server-go/internal/config"
 	"github.com/gnacho/netpulse/server-go/internal/db"
 )
@@ -379,5 +381,19 @@ func TestIsSecureRequestSinTrustProxyIgnoraXFP(t *testing.T) {
 	SetTrustProxy(true)
 	if !IsSecureRequest(r) {
 		t.Fatal("con TRUST_PROXY, XFP=https debe considerarse seguro")
+	}
+}
+
+func TestLoginDummyHashValido(t *testing.T) {
+	// El dummy de timing del login debe ser un hash bcrypt VÁLIDO: si no lo
+	// es (p.ej. caracteres ilegales como '_'), CompareHashAndPassword falla
+	// en microsegundos y el login se convierte en un oráculo de enumeración
+	// de usuarios (issue #209).
+	err := bcrypt.CompareHashAndPassword([]byte(dummyPasswordHash), []byte("cualquier-password"))
+	if err == nil {
+		t.Fatal("comparar contra el dummy con una password cualquiera no debe acertar")
+	}
+	if strings.Contains(err.Error(), "illegal base64 data") {
+		t.Fatalf("dummyPasswordHash no es un hash bcrypt válido: %v", err)
 	}
 }

--- a/server-go/internal/db/db.go
+++ b/server-go/internal/db/db.go
@@ -24,6 +24,9 @@ const (
 	RetentionMS  = 7 * 24 * 60 * 60 * 1000 // 7 días
 	Maintenance  = time.Hour
 	databaseFile = "netpulse.db"
+	// AttribRetentionMS: 90 días sin verse para purgar device_attrib
+	// (issue #206; dispositivos que se fueron para siempre).
+	AttribRetentionMS = 90 * 24 * 60 * 60 * 1000
 )
 
 // schemaSQL es el SQL literal de src/db.js:20-85.
@@ -374,7 +377,8 @@ func migrate(db *sql.DB, table, column, ddl string) {
 }
 
 // Maintenance ejecuta una pasada de limpieza (paridad src/db.js:107-120):
-// retención 7 días en metrics/adguard_stats, sesiones expiradas y checkpoint.
+// retención 7 días en metrics/adguard_stats, sesiones expiradas, atributos de
+// dispositivos sin verse en 90 días (issue #206) y checkpoint.
 func (d *DB) Maintenance() {
 	cutoff := NowMS() - RetentionMS
 	steps := []string{
@@ -387,6 +391,13 @@ func (d *DB) Maintenance() {
 		}
 	}
 	if _, err := d.Exec("DELETE FROM sessions WHERE expires_at < ?", NowMS()); err != nil {
+		log.Printf("[netpulse] error en mantenimiento DB: %v", err)
+	}
+	// Atributos de dispositivos que no se ven desde hace 90 días (se fueron
+	// para siempre): sin esta purga device_attrib crece sin límite y alimenta
+	// el listado de dispositivos offline (issue #206).
+	attribCutoff := NowMS() - AttribRetentionMS
+	if _, err := d.Exec("DELETE FROM device_attrib WHERE last_seen < ?", attribCutoff); err != nil {
 		log.Printf("[netpulse] error en mantenimiento DB: %v", err)
 	}
 	// Purga de buckets > 1 año (el raw ya se purgó arriba; daily nunca).

--- a/server-go/internal/httpapi/availability_test.go
+++ b/server-go/internal/httpapi/availability_test.go
@@ -143,6 +143,11 @@ func TestAvailabilityDayActualNoPenaliza(t *testing.T) {
 	if nowMin == 0 {
 		want = 100 // evitar div/0 a medianoche
 	}
+	// El endpoint clamp a 100 (mismo tope que el report semanal, #207): si
+	// nowMin < upMin el ratio bruto excede 100 y el clamp lo lleva a 100.
+	if want > 100 {
+		want = 100
+	}
 	if today_.UpPct < want-0.5 || today_.UpPct > want+0.5 {
 		t.Fatalf("día actual upPct=%v, esperaba ~%.1f (upMin=%d / nowMin=%d)", today_.UpPct, want, today_.UpMin, nowMin)
 	}

--- a/server-go/internal/httpapi/data.go
+++ b/server-go/internal/httpapi/data.go
@@ -81,7 +81,7 @@ func paginate[T any](items []T, page, pageSize int64) map[string]any {
 	total := len(items)
 	start := (page - 1) * pageSize
 	var out []T
-	if start < int64(total) {
+	if start >= 0 && start < int64(total) {
 		end := start + pageSize
 		if end > int64(total) {
 			end = int64(total)

--- a/server-go/internal/httpapi/httpapi_test.go
+++ b/server-go/internal/httpapi/httpapi_test.go
@@ -779,7 +779,7 @@ func TestSecurityHeaders(t *testing.T) {
 		"Referrer-Policy":           "strict-origin-when-cross-origin",
 		"Permissions-Policy":        "geolocation=(), microphone=(), camera=()",
 		"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-		"Content-Security-Policy":   "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'",
+		"Content-Security-Policy":   "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'",
 	}
 	for k, v := range want {
 		if got := res.Header.Get(k); got != v {

--- a/server-go/internal/httpapi/orchestr.go
+++ b/server-go/internal/httpapi/orchestr.go
@@ -331,9 +331,40 @@ func (s *server) computeModuleDiff(resource, routerID string, desired json.RawMe
 		}
 		ops := orchestr.SqmOps(d, sc)
 		return ops, guestWiFiMethod(d.Enabled), nil
+	case "wireguard":
+		var d orchestr.WireGuardDesired
+		if err := json.Unmarshal(desired, &d); err != nil {
+			return nil, "", fmt.Errorf("%w: %v", errInvalidDesired, err)
+		}
+		host := s.hostOfRouter(routerID)
+		if host == "" {
+			return nil, "", errRouterNotFound
+		}
+		// Los peers viven en cualquier router con un túnel WireGuard (no hay
+		// gate de gateway: el túnel puede existir en un sitio remoto).
+		sc, err := orchestr.DetectWireGuard(s.pool, host)
+		if err != nil {
+			return nil, "", fmt.Errorf("%w: %v", errProbeFailed, err)
+		}
+		ops := orchestr.WireGuardOps(d, sc)
+		return ops, wireGuardMethod(sc, d.Interface), nil
 	default:
 		return nil, "", fmt.Errorf("%w: %s", errUnknownModule, resource)
 	}
+}
+
+// wireGuardMethod es la etiqueta del método (para la UI): el túnel está
+// activo en el kernel (active) o no (inactive).
+func wireGuardMethod(sc orchestr.WireGuardScenario, iface string) string {
+	if iface == "" {
+		iface = "wg0"
+	}
+	for _, a := range sc.ActiveIfaces {
+		if a == iface {
+			return "active"
+		}
+	}
+	return "inactive"
 }
 
 // guestWiFiMethod es la etiqueta del método (para la UI): enabled/disabled.

--- a/server-go/internal/httpapi/paginate_test.go
+++ b/server-go/internal/httpapi/paginate_test.go
@@ -1,0 +1,42 @@
+// paginate_test.go — prueba de paginate ante páginas extremas (issue #201).
+package httpapi
+
+import (
+	"math"
+	"testing"
+)
+
+// TestPaginateHugePageNoPanic: una page enorme (p.ej. 9223372036854774784)
+// desbordaba (page-1)*pageSize y producía un índice negativo → panic
+// "slice bounds out of range" (issue #201). No debe paniquear.
+func TestPaginateHugePageNoPanic(t *testing.T) {
+	items := make([]int, 10)
+	for i := range items {
+		items[i] = i
+	}
+	// El valor exacto que desbordaba int64 con pageSize 50 (coerceInt max).
+	out := paginate(items, math.MaxInt64-134217729, 50)
+	if out == nil {
+		t.Fatal("paginate devolvió nil")
+	}
+	if items, ok := out["items"].([]int); ok {
+		if len(items) != 0 {
+			t.Errorf("esperaba 0 items (página fuera de rango), got %d", len(items))
+		}
+	} else {
+		t.Errorf("items con tipo inesperado: %T", out["items"])
+	}
+}
+
+// TestPaginatePrimeraPagina: la página 1 sigue devolviendo los items en orden.
+func TestPaginatePrimeraPagina(t *testing.T) {
+	items := []string{"a", "b", "c", "d"}
+	out := paginate(items, 1, 2)
+	got := out["items"].([]string)
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("esperaba [a b], got %v", got)
+	}
+	if out["total"] != 4 || out["page"] != int64(1) {
+		t.Errorf("meta incorrecta: %v", out)
+	}
+}

--- a/server-go/internal/httpapi/reports.go
+++ b/server-go/internal/httpapi/reports.go
@@ -8,8 +8,10 @@
 // Semántica de disponibilidad (verificada contra datos reales de prod):
 //   - `n` = suma de muestras del día (poll de 5 s; día completo ≈ 17280).
 //   - minutos de recolección = n * 5 / 60.
-//   - upPct = minutos / (días con datos * 1440). La semana en curso queda
-//     parcial y se normaliza solo sobre los días que tienen datos.
+//   - upPct = minutos / (días con datos * 1440), clavado a 100 (issue #207):
+//     un bucket sobre-poblado (más muestras que minutos) no puede superar el
+//     100%, igual que availability. La semana en curso queda parcial y se
+//     normaliza solo sobre los días que tienen datos.
 //   - `up_count` del daily NO es fiable como base (es COUNT(*) de filas
 //     bucket, que en prod coincide con muestras porque el rollup no agrega);
 //     `up_min` del daily es MIN(min_ts) (timestamp), no minutos.
@@ -90,6 +92,9 @@ func (s *server) handleWeeklyReport(w http.ResponseWriter, r *http.Request) {
 		}
 		if e.Days > 0 {
 			e.UpPct = float64(upMin) / (float64(e.Days) * 24 * 60) * 100
+			if e.UpPct > 100 {
+				e.UpPct = 100
+			}
 		}
 		out = append(out, e)
 	}

--- a/server-go/internal/httpapi/reports_test.go
+++ b/server-go/internal/httpapi/reports_test.go
@@ -136,6 +136,28 @@ func TestWeeklyReportAgrupaPorRouterYSemana(t *testing.T) {
 	}
 }
 
+// TestWeeklyReportUpPctClamp: un bucket sobre-poblado (más muestras que
+// minutos del día) no puede superar el 100% de disponibilidad (issue #207).
+// El weekly clampa igual que availability: divergía porque availability sí
+// clavaba y weekly no.
+func TestWeeklyReportUpPctClamp(t *testing.T) {
+	ts := makeTestServer(t)
+	// Día completo = 17280 muestras = 1440 min. El doble (34560) da
+	// upMin = 2880 sobre 1440 min → 200% sin el clamp.
+	insertDaily(t, ts, "gw", "2026-08-03", 34560, sqlNull{false, 0}, 0, 0, 20, 60)
+
+	status, items := getWeekly(t, ts, "4")
+	if status != http.StatusOK {
+		t.Fatalf("status %d, esperaba 200", status)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items = %d, esperaba 1 (un bucket): %+v", len(items), items)
+	}
+	if items[0].UpPct != 100 {
+		t.Fatalf("bucket sobre-poblado upPct=%v, esperaba 100 (clamp)", items[0].UpPct)
+	}
+}
+
 func TestWeeklyReportValidaWeeks(t *testing.T) {
 	ts := makeTestServer(t)
 	for _, bad := range []string{"0", "53", "abc", "-1"} {

--- a/server-go/internal/orchestr/modules.go
+++ b/server-go/internal/orchestr/modules.go
@@ -2,6 +2,13 @@
 // convierte un estado deseado + un escenario detectado en una lista de Ops
 // allowlistedas.
 //
+// Módulos registrados (dispatch en httpapi/orchestr.go computeModuleDiff):
+//   - adguard   → modules.go + adguard_probe.go (Fase 17.1)
+//   - guestwifi → guestwifi.go (Fase 17.2)
+//   - ddns      → ddns.go (Fase 17.3)
+//   - sqm       → sqm.go (Fase 17.4)
+//   - wireguard → wireguard.go (Fase 10.3)
+//
 // Fase 17.1: AdGuardOps usa el AdGuardScenario (probe SSH del servidor) para
 // elegir entre 4 métodos deterministas: apk | opkg | none (binario ya
 // presente) | binary (download oficial de GitHub). Aborta con

--- a/server-go/internal/orchestr/wireguard.go
+++ b/server-go/internal/orchestr/wireguard.go
@@ -1,0 +1,332 @@
+// wireguard.go - módulo de orquestación "WireGuard peers" (Fase 10.3).
+//
+// Reconoce los peers de un túnel WireGuard contra el estado deseado: crea la
+// interfaz network.wg0 (si no existe), añade/actualiza/borra las secciones
+// network.wgpeer<N> (public_key + allowed_ips) y termina con un reload de red
+// más healthcheck `wg show`. Si el túnel que estaba arriba no levanta tras el
+// apply, el executor revierte el plan (rollback real).
+//
+// Anti-lockout: un peer cuyo public_key coincide con
+// WireGuardDesired.AdminPeerPublicKey NUNCA se borra (el admin gestiona el
+// túnel desde ese peer; borrarlo aislaría al admin del túnel).
+package orchestr
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gnacho/netpulse/agent/executor"
+)
+
+// WireGuardPeer es un peer del túnel WireGuard.
+type WireGuardPeer struct {
+	Name string `json:"name"`
+	// PublicKey: clave pública base64 del peer (wireguard pubkey).
+	PublicKey string `json:"publicKey"`
+	// AllowedIPs: CIDRs permitidos del peer, separados por coma
+	// (p. ej. "10.0.0.2/32" o "10.0.0.2/32,10.0.1.0/24").
+	AllowedIPs string `json:"allowedIps"`
+}
+
+// WireGuardDesired es el estado deseado del módulo WireGuard.
+type WireGuardDesired struct {
+	// Interface: nombre de la interfaz del túnel (default "wg0").
+	Interface string `json:"interface"`
+	// Peers: conjunto declarativo de peers. Los peers presentes en el router
+	// que NO estén en esta lista se borran (salvo el del admin).
+	Peers []WireGuardPeer `json:"peers"`
+	// AdminPeerPublicKey: pubkey del peer del admin. Protección anti-lockout:
+	// ese peer nunca se borra, aunque no esté en Peers.
+	AdminPeerPublicKey string `json:"adminPeerPubkey,omitempty"`
+}
+
+// WireGuardScenario describe el estado de WireGuard en el router.
+type WireGuardScenario struct {
+	// WGInstalled: /usr/bin/wg existe (wireguard-tools instalado).
+	WGInstalled bool
+	// WGActive: `wg show` reporta al menos una interfaz arriba.
+	WGActive bool
+	// WGIfaces: interfaces WireGuard presentes en UCI
+	// (network.<name>.proto='wireguard').
+	WGIfaces []string
+	// ActiveIfaces: interfaces activas en el kernel según `wg show`.
+	ActiveIfaces []string
+	// Peers: secciones wgpeer existentes (public_key + allowed_ips).
+	Peers []WireGuardPeer
+}
+
+// probeWireGuardCmd detecta instalación, estado del túnel y secciones UCI.
+// `|| true` tras wg show para no abortar la sesión si wg no está instalado.
+const probeWireGuardCmd = `echo '===WG_BIN==='
+[ -x /usr/bin/wg ] && echo yes || echo no
+echo '===WG==='
+wg show 2>/dev/null
+echo '===NETWORK==='
+uci show network 2>/dev/null
+echo '===END==='`
+
+// DetectWireGuard ejecuta el probe y devuelve el escenario.
+func DetectWireGuard(run CommandRunner, host string) (WireGuardScenario, error) {
+	out, err := run.Run(host, probeWireGuardCmd, 8*time.Second)
+	if err != nil {
+		return WireGuardScenario{}, err
+	}
+	return parseWireGuard(out), nil
+}
+
+// parseWireGuard extrae el escenario del output del probe. Función pura.
+func parseWireGuard(out string) WireGuardScenario {
+	sc := WireGuardScenario{}
+	sections := splitSections(out)
+	sc.WGInstalled = strings.TrimSpace(firstNonEmpty(sections["WG_BIN"])) == "yes"
+
+	// `wg show`: líneas "interface: <nombre>".
+	for _, line := range sections["WG"] {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "interface:") {
+			if name := strings.TrimSpace(strings.TrimPrefix(line, "interface:")); name != "" {
+				sc.ActiveIfaces = append(sc.ActiveIfaces, name)
+			}
+		}
+	}
+	sc.WGActive = len(sc.ActiveIfaces) > 0
+
+	// `uci show network`: secciones interface (proto wireguard) y peers.
+	uci := strings.Join(sections["NETWORK"], "\n")
+	for _, line := range strings.Split(uci, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "network.") {
+			continue
+		}
+		rest := strings.TrimPrefix(line, "network.")
+		switch {
+		case strings.HasSuffix(rest, "=interface"):
+			sec := strings.TrimSuffix(rest, "=interface")
+			if wireguardSectionProto(uci, sec) {
+				sc.WGIfaces = append(sc.WGIfaces, sec)
+			}
+		case strings.Contains(rest, "=wireguard_"):
+			sec := rest[:strings.Index(rest, "=")]
+			peer := WireGuardPeer{
+				Name:      sec,
+				PublicKey: wireguardOption(uci, sec, "public_key"),
+			}
+			peer.AllowedIPs = normalizeAllowedIPs(wireguardOptionList(uci, sec, "allowed_ips"))
+			sc.Peers = append(sc.Peers, peer)
+		}
+	}
+	return sc
+}
+
+// wireguardSectionProto devuelve true si la sección interface tiene
+// proto='wireguard' ("network.<sec>.proto='wireguard'").
+func wireguardSectionProto(uci, sec string) bool {
+	prefix := "network." + sec + ".proto="
+	for _, line := range strings.Split(uci, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, prefix) {
+			return strings.Contains(line, "'wireguard'")
+		}
+	}
+	return false
+}
+
+// wireguardOption lee una option de una sección ("network.<sec>.<opt>='v'").
+func wireguardOption(uci, sec, option string) string {
+	prefix := "network." + sec + "." + option + "="
+	for _, line := range strings.Split(uci, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, prefix) {
+			return strings.Trim(strings.TrimPrefix(line, prefix), "'")
+		}
+	}
+	return ""
+}
+
+// wireguardOptionList une los valores de una option tipo lista
+// ("network.<sec>.allowed_ips='v'" por cada entrada).
+func wireguardOptionList(uci, sec, option string) string {
+	prefix := "network." + sec + "." + option + "="
+	var vals []string
+	for _, line := range strings.Split(uci, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, prefix) {
+			vals = append(vals, strings.Trim(strings.TrimPrefix(line, prefix), "'"))
+		}
+	}
+	return strings.Join(vals, ",")
+}
+
+// WireGuardOps genera las Ops para reconciliar los peers del túnel.
+func WireGuardOps(desired WireGuardDesired, sc WireGuardScenario) []executor.Op {
+	iface := desired.Interface
+	if iface == "" {
+		iface = "wg0"
+	}
+	var ops []executor.Op
+
+	// 1. Interfaz: crear la sección si no existe.
+	if !wgInterfaceExists(sc, iface) {
+		ops = append(ops,
+			executor.Op{Kind: "uci_set_named", Args: map[string]string{"config": "network", "section": iface, "type": "interface"}, Desc: "Create wireguard interface " + iface},
+			executor.Op{Kind: "uci_set", Args: map[string]string{"config": "network", "section": iface, "option": "proto", "value": "wireguard"}, Desc: "Set wireguard proto on " + iface},
+		)
+	}
+
+	// 2. Peers del desired: crear los nuevos, actualizar los existentes.
+	for _, p := range desired.Peers {
+		pub := strings.TrimSpace(p.PublicKey)
+		if pub == "" {
+			continue // fila vacía de la UI
+		}
+		existing := wgPeerByPubkey(sc, pub)
+		if existing != nil {
+			// public_key igual por construcción (match por pubkey): solo
+			// reconciliar allowed_ips si cambia.
+			if normalizeAllowedIPs(existing.AllowedIPs) != normalizeAllowedIPs(p.AllowedIPs) {
+				ops = append(ops, executor.Op{Kind: "uci_delete", Args: map[string]string{"config": "network", "section": existing.Name, "option": "allowed_ips"}, Desc: "Reset allowed_ips on " + existing.Name})
+				for _, cidr := range splitAllowedIPs(p.AllowedIPs) {
+					ops = append(ops, executor.Op{Kind: "uci_add_list", Args: map[string]string{"config": "network", "section": existing.Name, "option": "allowed_ips", "value": cidr}, Desc: "Add allowed_ip " + cidr + " to " + existing.Name})
+				}
+			}
+			continue
+		}
+		name := nextWgPeerName(sc, iface)
+		ops = append(ops,
+			executor.Op{Kind: "uci_set_named", Args: map[string]string{"config": "network", "section": name, "type": "wireguard_" + iface}, Desc: "Create peer section " + name},
+			executor.Op{Kind: "uci_set", Args: map[string]string{"config": "network", "section": name, "option": "public_key", "value": pub}, Desc: "Set public key on " + name},
+		)
+		for _, cidr := range splitAllowedIPs(p.AllowedIPs) {
+			ops = append(ops, executor.Op{Kind: "uci_add_list", Args: map[string]string{"config": "network", "section": name, "option": "allowed_ips", "value": cidr}, Desc: "Add allowed_ip " + cidr + " to " + name})
+		}
+		sc.Peers = append(sc.Peers, WireGuardPeer{Name: name, PublicKey: pub})
+	}
+
+	// 3. Borrar peers que ya no están en el desired. Anti-lockout: el peer
+	// cuyo public_key es el del admin NUNCA se borra.
+	for _, p := range sc.Peers {
+		if wgPeerDesired(desired.Peers, p.PublicKey) {
+			continue
+		}
+		if p.PublicKey != "" && p.PublicKey == desired.AdminPeerPublicKey {
+			continue // protección anti-lockout
+		}
+		ops = append(ops, executor.Op{Kind: "uci_delete_section", Args: map[string]string{"config": "network", "section": p.Name}, Desc: "Remove peer " + p.Name})
+	}
+
+	if len(ops) == 0 {
+		return nil
+	}
+	ops = append(ops, executor.Op{Kind: "uci_commit", Args: map[string]string{"config": "network"}, Desc: "Commit network config"})
+	ops = append(ops, executor.Op{Kind: "service", Args: map[string]string{"name": "network", "action": "reload"}, Desc: "Reload network (apply wireguard)"})
+	if wgCheckNeeded(sc, iface) {
+		ops = append(ops, executor.Op{Kind: "wg_check", Args: map[string]string{"interface": iface}, Desc: "Check tunnel " + iface + " is up (wg show)"})
+	}
+	return ops
+}
+
+// WireGuardHealthcheck verifica que el túnel sigue arriba tras el apply:
+// `wg show <iface>` falla si la interfaz no existe o está caída. Es el
+// healthcheck del módulo (el executor lo ejecuta como op wg_check en el plan).
+func WireGuardHealthcheck(run CommandRunner, host, iface string) error {
+	if iface == "" {
+		iface = "wg0"
+	}
+	out, err := run.Run(host, "wg show "+iface, 8*time.Second)
+	if err != nil {
+		return fmt.Errorf("tunnel %s not up: %w", iface, err)
+	}
+	if !strings.Contains(out, "interface: "+iface) {
+		return fmt.Errorf("tunnel %s not up (wg show sin interfaz)", iface)
+	}
+	return nil
+}
+
+// wgInterfaceExists: la interfaz deseada está en UCI con proto wireguard.
+func wgInterfaceExists(sc WireGuardScenario, iface string) bool {
+	return wgContains(sc.WGIfaces, iface)
+}
+
+// wgPeerByPubkey busca un peer existente por su public_key (nil si no existe).
+func wgPeerByPubkey(sc WireGuardScenario, pub string) *WireGuardPeer {
+	for i := range sc.Peers {
+		if sc.Peers[i].PublicKey == pub {
+			return &sc.Peers[i]
+		}
+	}
+	return nil
+}
+
+// wgPeerDesired: hay un peer en desired con ese public_key.
+func wgPeerDesired(peers []WireGuardPeer, pub string) bool {
+	for _, p := range peers {
+		if strings.TrimSpace(p.PublicKey) == pub {
+			return true
+		}
+	}
+	return false
+}
+
+// nextWgPeerName devuelve el nombre libre wgpeer<N> más bajo no usado.
+func nextWgPeerName(sc WireGuardScenario, iface string) string {
+	used := map[string]bool{iface: true}
+	for _, p := range sc.Peers {
+		used[p.Name] = true
+	}
+	for n := 1; ; n++ {
+		name := fmt.Sprintf("wgpeer%d", n)
+		if !used[name] {
+			return name
+		}
+	}
+}
+
+// splitAllowedIPs parte un valor "cidr1,cidr2" en CIDRs individuales.
+func splitAllowedIPs(val string) []string {
+	var out []string
+	for _, part := range strings.Split(val, ",") {
+		if cidr := strings.TrimSpace(part); cidr != "" {
+			out = append(out, cidr)
+		}
+	}
+	return out
+}
+
+// normalizeAllowedIPs limpia espacios/vacíos de un valor de CIDRs para poder
+// comparar listas entre el router y el desired sin depender del formato.
+func normalizeAllowedIPs(val string) string {
+	parts := splitAllowedIPs(val)
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, ",")
+}
+
+// wgCheckNeeded: solo verificar el túnel si WireGuard está instalado y había
+// un túnel activo antes del apply (el healthcheck protege el túnel EXISTENTE).
+func wgCheckNeeded(sc WireGuardScenario, iface string) bool {
+	if !sc.WGInstalled || !sc.WGActive {
+		return false
+	}
+	return wgContains(sc.ActiveIfaces, iface)
+}
+
+func wgContains(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// validateWireGuardOps valida cada op contra el executor (usado en tests).
+func validateWireGuardOps(ops []executor.Op) error {
+	for _, op := range ops {
+		if err := executor.Validate(op); err != nil {
+			return fmt.Errorf("%s: %w", op.Desc, err)
+		}
+	}
+	return nil
+}

--- a/server-go/internal/orchestr/wireguard_test.go
+++ b/server-go/internal/orchestr/wireguard_test.go
@@ -1,0 +1,292 @@
+package orchestr
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/agent/executor"
+)
+
+// Fixture: túnel wg0 activo con 2 peers (admin + uno gestionado).
+// Formato real de `wg show` + `uci show network`.
+const wireGuardOut = `===WG_BIN===
+yes
+===WG===
+interface: wg0
+  public key: SERVERPUB
+  listening port: 51820
+  peer: ADMINPUB
+    allowed ips: 10.0.0.2/32
+  peer: PEER2PUB
+    allowed ips: 10.0.0.3/32
+===NETWORK===
+network.lan=interface
+network.lan.device='br-lan'
+network.wg0=interface
+network.wg0.proto='wireguard'
+network.wg0.private_key='secret'
+network.wg0.addresses='10.0.0.1/24'
+network.wgpeer1=wireguard_wg0
+network.wgpeer1.public_key='ADMINPUB'
+network.wgpeer1.allowed_ips='10.0.0.2/32'
+network.wgpeer2=wireguard_wg0
+network.wgpeer2.public_key='PEER2PUB'
+network.wgpeer2.allowed_ips='10.0.0.3/32'
+network.wgpeer2.allowed_ips='10.0.0.9/32'
+===END===`
+
+// fakeWGCommandRunner implementa CommandRunner para tests del probe/healthcheck.
+type fakeWGCommandRunner struct {
+	out  string
+	err  error
+	cmd  string
+	host string
+}
+
+func (f *fakeWGCommandRunner) Run(host, cmd string, _ time.Duration) (string, error) {
+	f.host, f.cmd = host, cmd
+	return f.out, f.err
+}
+
+// TestParseWireGuardDetectaTunelYPeers: wg instalado, túnel activo y peers.
+func TestParseWireGuardDetectaTunelYPeers(t *testing.T) {
+	sc := parseWireGuard(wireGuardOut)
+	if !sc.WGInstalled {
+		t.Error("WGInstalled: esperaba true")
+	}
+	if !sc.WGActive {
+		t.Error("WGActive: esperaba true (wg show reporta wg0)")
+	}
+	if len(sc.ActiveIfaces) != 1 || sc.ActiveIfaces[0] != "wg0" {
+		t.Errorf("ActiveIfaces: got %v want [wg0]", sc.ActiveIfaces)
+	}
+	if len(sc.WGIfaces) != 1 || sc.WGIfaces[0] != "wg0" {
+		t.Errorf("WGIfaces: got %v want [wg0]", sc.WGIfaces)
+	}
+	if len(sc.Peers) != 2 {
+		t.Fatalf("Peers: got %d want 2", len(sc.Peers))
+	}
+	if sc.Peers[0].Name != "wgpeer1" || sc.Peers[0].PublicKey != "ADMINPUB" {
+		t.Errorf("peer[0]: got %+v", sc.Peers[0])
+	}
+	if sc.Peers[1].AllowedIPs != "10.0.0.3/32,10.0.0.9/32" {
+		t.Errorf("peer[1] allowed_ips (lista): got %q", sc.Peers[1].AllowedIPs)
+	}
+}
+
+// TestParseWireGuardSinTunel: wg instalado pero sin interfaces ni peers.
+func TestParseWireGuardSinTunel(t *testing.T) {
+	out := `===WG_BIN===
+yes
+===WG===
+===NETWORK===
+network.lan=interface
+===END===`
+	sc := parseWireGuard(out)
+	if !sc.WGInstalled {
+		t.Error("WGInstalled: esperaba true")
+	}
+	if sc.WGActive {
+		t.Error("WGActive: esperaba false sin interfaces")
+	}
+	if len(sc.WGIfaces) != 0 || len(sc.Peers) != 0 {
+		t.Errorf("no debería haber ifaces/peers: %v %v", sc.WGIfaces, sc.Peers)
+	}
+}
+
+// TestParseWireGuardWgNoInstalado: wg ausente → escenario tolerante (no error).
+func TestParseWireGuardWgNoInstalado(t *testing.T) {
+	out := `===WG_BIN===
+no
+===WG===
+===NETWORK===
+network.lan=interface
+===END===`
+	sc := parseWireGuard(out)
+	if sc.WGInstalled {
+		t.Error("WGInstalled: esperaba false")
+	}
+	if sc.WGActive {
+		t.Error("WGActive: esperaba false sin wg")
+	}
+}
+
+// TestWireGuardOpsCreaInterfazYPeers: sin interfaz ni túnel, el plan crea
+// wg0 + un peer y termina con commit + reload (sin wg_check: no había túnel).
+func TestWireGuardOpsCreaInterfazYPeers(t *testing.T) {
+	sc := parseWireGuard(`===WG_BIN===
+no
+===WG===
+===NETWORK===
+network.lan=interface
+===END===`)
+	ops := WireGuardOps(WireGuardDesired{
+		Interface: "wg0",
+		Peers:     []WireGuardPeer{{Name: "laptop", PublicKey: "PEER1PUB", AllowedIPs: "10.0.0.2/32"}},
+	}, sc)
+	if len(ops) == 0 {
+		t.Fatal("plan generó 0 ops")
+	}
+	if err := validateWireGuardOps(ops); err != nil {
+		t.Fatalf("ops no validan en executor: %v", err)
+	}
+	// Crea la interfaz (uci_set_named network.wg0=interface + proto).
+	if !hasOp(ops, "uci_set_named", "section", "wg0") {
+		t.Error("plan sin uci_set_named de la interfaz wg0")
+	}
+	if !hasOp(ops, "uci_set", "option", "proto") {
+		t.Error("plan sin uci_set proto=wireguard")
+	}
+	// Crea el peer wgpeer1 con su public_key y allowed_ips.
+	if !hasOp(ops, "uci_set_named", "section", "wgpeer1") {
+		t.Error("plan sin uci_set_named del peer wgpeer1")
+	}
+	if !hasOp(ops, "uci_set", "option", "public_key") {
+		t.Error("plan sin uci_set public_key del peer")
+	}
+	if !hasOp(ops, "uci_add_list", "option", "allowed_ips") {
+		t.Error("plan sin uci_add_list allowed_ips del peer")
+	}
+	if !hasOp(ops, "uci_commit", "config", "network") {
+		t.Error("plan sin uci_commit network")
+	}
+	if !hasOp(ops, "service", "action", "reload") {
+		t.Error("plan sin service network reload")
+	}
+	// Sin túnel activo previo → sin wg_check (nada que proteger).
+	for _, o := range ops {
+		if o.Kind == "wg_check" {
+			t.Error("no debería incluir wg_check sin túnel activo previo")
+		}
+	}
+}
+
+// TestWireGuardOpsNoBorraPeerAdmin: anti-lockout. El peer del admin está en el
+// router pero no en el desired; con AdminPeerPublicKey se conserva. El otro
+// peer (en desired) se actualiza, no se borra.
+func TestWireGuardOpsNoBorraPeerAdmin(t *testing.T) {
+	sc := parseWireGuard(wireGuardOut)
+	ops := WireGuardOps(WireGuardDesired{
+		Interface:          "wg0",
+		AdminPeerPublicKey: "ADMINPUB",
+		Peers: []WireGuardPeer{
+			{Name: "peer2", PublicKey: "PEER2PUB", AllowedIPs: "10.0.0.3/32"},
+		},
+	}, sc)
+	if err := validateWireGuardOps(ops); err != nil {
+		t.Fatalf("ops no validan: %v", err)
+	}
+	// Sin protección, wgpeer1 (admin) sería candidato a borrado. Con
+	// AdminPeerPublicKey no debe aparecer ningún uci_delete_section.
+	for _, o := range ops {
+		if o.Kind == "uci_delete_section" {
+			t.Errorf("anti-lockout roto: plan borra la sección %q", o.Args["section"])
+		}
+	}
+}
+
+// TestWireGuardOpsBorraPeersSinDesired: sin anti-lockout configurado, los
+// peers que no están en el desired se borran.
+func TestWireGuardOpsBorraPeersSinDesired(t *testing.T) {
+	sc := parseWireGuard(wireGuardOut)
+	ops := WireGuardOps(WireGuardDesired{Interface: "wg0"}, sc)
+	delSections := map[string]bool{}
+	for _, o := range ops {
+		if o.Kind == "uci_delete_section" {
+			delSections[o.Args["section"]] = true
+		}
+	}
+	if !delSections["wgpeer1"] || !delSections["wgpeer2"] {
+		t.Errorf("desired sin peers debe borrar ambos: %v", delSections)
+	}
+}
+
+// TestWireGuardOpsHealthcheckSoloSiTunelActivo: wg_check solo si el túnel
+// estaba arriba antes del apply (proteger el túnel existente).
+func TestWireGuardOpsHealthcheckSoloSiTunelActivo(t *testing.T) {
+	sc := parseWireGuard(wireGuardOut)
+	ops := WireGuardOps(WireGuardDesired{Interface: "wg0", Peers: []WireGuardPeer{{Name: "p", PublicKey: "PEER2PUB", AllowedIPs: "10.0.0.3/32"}}}, sc)
+	found := false
+	for _, o := range ops {
+		if o.Kind == "wg_check" {
+			found = true
+			if o.Args["interface"] != "wg0" {
+				t.Errorf("wg_check interface: got %q want wg0", o.Args["interface"])
+			}
+		}
+	}
+	if !found {
+		t.Error("con túnel activo previo el plan debe incluir wg_check")
+	}
+}
+
+// TestWireGuardOpsActualizaAllowedIPs: un peer existente con allowed_ips
+// distinto se resetea (delete + add_list) sin recrear la sección.
+func TestWireGuardOpsActualizaAllowedIPs(t *testing.T) {
+	sc := parseWireGuard(wireGuardOut)
+	ops := WireGuardOps(WireGuardDesired{
+		Interface: "wg0",
+		Peers:     []WireGuardPeer{{Name: "peer2", PublicKey: "PEER2PUB", AllowedIPs: "10.0.0.3/32,10.0.0.42/32"}},
+	}, sc)
+	if err := validateWireGuardOps(ops); err != nil {
+		t.Fatalf("ops no validan: %v", err)
+	}
+	if !hasOp(ops, "uci_delete", "section", "wgpeer2") {
+		t.Error("debe resetear allowed_ips del peer existente (uci_delete)")
+	}
+	count := 0
+	for _, o := range ops {
+		if o.Kind == "uci_add_list" && o.Args["section"] == "wgpeer2" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("esperaba 2 add_list en wgpeer2, got %d", count)
+	}
+}
+
+// TestWireGuardOpsSinCambios: desired == scenario → sin ops (idempotente).
+func TestWireGuardOpsSinCambios(t *testing.T) {
+	sc := parseWireGuard(wireGuardOut)
+	ops := WireGuardOps(WireGuardDesired{
+		Interface: "wg0",
+		Peers: []WireGuardPeer{
+			{Name: "admin", PublicKey: "ADMINPUB", AllowedIPs: "10.0.0.2/32"},
+			{Name: "peer2", PublicKey: "PEER2PUB", AllowedIPs: "10.0.0.3/32,10.0.0.9/32"},
+		},
+	}, sc)
+	if len(ops) != 0 {
+		t.Errorf("sin diferencias debería generar 0 ops, got %d:\n%+v", len(ops), ops)
+	}
+}
+
+// TestWireGuardHealthcheck: `wg show wg0` arriba → nil; fallo → error.
+func TestWireGuardHealthcheck(t *testing.T) {
+	run := &fakeWGCommandRunner{out: "interface: wg0\n  public key: X\n"}
+	if err := WireGuardHealthcheck(run, "192.168.1.1", "wg0"); err != nil {
+		t.Fatalf("túnel arriba: esperaba nil, got %v", err)
+	}
+	if !strings.Contains(run.cmd, "wg show wg0") {
+		t.Errorf("comando: got %q, esperaba contener 'wg show wg0'", run.cmd)
+	}
+
+	run.err = errors.New("wg show exit 1")
+	if err := WireGuardHealthcheck(run, "192.168.1.1", "wg0"); err == nil {
+		t.Error("túnel caído: esperaba error")
+	}
+}
+
+// hasOp busca una op por kind + (arg, value).
+func hasOp(ops []executor.Op, kind, arg, value string) bool {
+	for _, o := range ops {
+		if o.Kind != kind {
+			continue
+		}
+		if v, ok := o.Args[arg]; ok && v == value {
+			return true
+		}
+	}
+	return false
+}

--- a/server-go/internal/push/notifier.go
+++ b/server-go/internal/push/notifier.go
@@ -89,15 +89,19 @@ func (n *Notifier) Notify(ev alerts.AlertEvent) {
 func (n *Notifier) Close() {
 	n.once.Do(func() {
 		close(n.done)
-		close(n.ch)
 		n.wg.Wait()
 	})
 }
 
 func (n *Notifier) worker() {
 	defer n.wg.Done()
-	for ev := range n.ch {
-		n.sendAll(ev)
+	for {
+		select {
+		case <-n.done:
+			return
+		case ev := <-n.ch:
+			n.sendAll(ev)
+		}
 	}
 }
 

--- a/server-go/internal/push/push_test.go
+++ b/server-go/internal/push/push_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -324,4 +325,34 @@ func TestNotifierPurgesGoneSubscription(t *testing.T) {
 	if len(subs) != 1 || subs[0].Endpoint != alive.URL {
 		t.Fatalf("tras purga: %+v", subs)
 	}
+}
+
+// TestNotifierCloseConNotifyConcurrentesNoPanic reproduce el bug #202:
+// Close() cerraba el canal de la cola y un Notify concurrente podía elegir
+// la rama de envío tras el close → panic "send on closed channel".
+func TestNotifierCloseConNotifyConcurrentesNoPanic(t *testing.T) {
+	d, _ := openDB(t)
+	pub, _, _ := push.EnsureVAPIDKeys(d)
+	n := newNotifier(t, d)
+	_ = pub
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					n.Notify(testEvent())
+				}
+			}
+		}()
+	}
+	time.Sleep(5 * time.Millisecond)
+	n.Close()
+	close(done)
+	wg.Wait()
 }

--- a/server-go/internal/security/security.go
+++ b/server-go/internal/security/security.go
@@ -11,7 +11,7 @@ var Headers = []struct{ K, V string }{
 	{"Referrer-Policy", "strict-origin-when-cross-origin"},
 	{"Permissions-Policy", "geolocation=(), microphone=(), camera=()"},
 	{"Strict-Transport-Security", "max-age=31536000; includeSubDomains"},
-	{"Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'"},
+	{"Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'"},
 }
 
 // Middleware aplica los headers a todas las respuestas (HSTS también por

--- a/server-go/internal/sse/agenthub.go
+++ b/server-go/internal/sse/agenthub.go
@@ -61,10 +61,19 @@ func (h *AgentHub) Send(slug, event string, data any) bool {
 	}
 	payload := fmt.Sprintf("event: %s\ndata: %s\n\n", event, raw)
 	if err := c.write(payload); err != nil {
-		h.remove(slug)
+		h.removeConn(c)
 		return false
 	}
 	return true
+}
+
+func (h *AgentHub) removeConn(c *agentConn) {
+	h.mu.Lock()
+	if h.conns[c.slug] == c {
+		delete(h.conns, c.slug)
+	}
+	h.mu.Unlock()
+	c.close()
 }
 
 func (h *AgentHub) remove(slug string) {
@@ -118,15 +127,15 @@ func (h *AgentHub) HandleStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Cerrar conexión anterior del mismo slug
+	// Cerrar conexión anterior del mismo slug. El write va FUERA del mutex:
+	// un cliente lento no debe bloquear Send/remove de otros (issue #200).
 	h.mu.Lock()
-	if old, ok := h.conns[slug]; ok {
+	old, ok := h.conns[slug]
+	h.mu.Unlock()
+	if ok {
 		_ = old.write("event: bye\ndata: {}\n\n")
-		h.mu.Unlock()
 		time.Sleep(100 * time.Millisecond) // dar tiempo al flush
-		h.remove(slug)
-	} else {
-		h.mu.Unlock()
+		h.removeConn(old)
 	}
 
 	w.Header().Set("Content-Type", "text/event-stream")
@@ -138,7 +147,7 @@ func (h *AgentHub) HandleStream(w http.ResponseWriter, r *http.Request) {
 	h.mu.Lock()
 	h.conns[slug] = c
 	h.mu.Unlock()
-	defer h.remove(slug)
+	defer h.removeConn(c)
 
 	// Enviar evento "connected" al agente (confirmación)
 	_ = c.write("event: connected\ndata: {}\n\n")

--- a/server-go/internal/sse/agenthub_race_test.go
+++ b/server-go/internal/sse/agenthub_race_test.go
@@ -1,0 +1,54 @@
+package sse
+
+import (
+	"testing"
+	"time"
+)
+
+// TestAgentHubRemovePorSlugMataNuevaConexion reproduce el bug #199: el
+// reemplazo de un stream (HandleStream escribe "bye" y llama remove(slug))
+// y luego el defer h.remove(slug) del handler viejo (desplanificado) borra
+// la conexión NUEVA registrada después. La limpieza debe ser por identidad.
+func TestAgentHubRemovePorSlugMataNuevaConexion(t *testing.T) {
+	h := NewAgentHub(func(slug, token string) bool { return true })
+
+	// Conexión vieja A registrada.
+	a := &agentConn{slug: "s1", done: make(chan struct{})}
+	h.mu.Lock()
+	h.conns["s1"] = a
+	h.mu.Unlock()
+
+	// A despierta al cerrarse su done y ejecuta su defer (removeConn(a), por
+	// identidad) DESPLANIFICADO 200 ms (simula la goroutine del handler viejo).
+	aCleanupDone := make(chan struct{})
+	go func() {
+		<-a.done
+		time.Sleep(200 * time.Millisecond)
+		h.removeConn(a)
+		close(aCleanupDone)
+	}()
+
+	// Reemplazo: HandleStream cierra la conexión anterior (por identidad).
+	h.removeConn(a)
+	time.Sleep(100 * time.Millisecond)
+
+	// B se registra (nueva conexión del mismo slug).
+	b := &agentConn{slug: "s1", done: make(chan struct{})}
+	h.mu.Lock()
+	h.conns["s1"] = b
+	h.mu.Unlock()
+
+	<-aCleanupDone
+
+	h.mu.Lock()
+	stillRegistered := h.conns["s1"] == b
+	h.mu.Unlock()
+	select {
+	case <-b.done:
+		t.Fatal("BUG #199: la limpieza de A cerró la conexión nueva B")
+	default:
+	}
+	if !stillRegistered {
+		t.Fatal("BUG #199: la limpieza de A borró la conexión nueva B del map")
+	}
+}

--- a/server-go/internal/sse/hub.go
+++ b/server-go/internal/sse/hub.go
@@ -81,6 +81,10 @@ func (h *Hub) remove(c *client) {
 // Broadcast envía `event` con `data` (JSON) a todos los clientes. Si la
 // sesión de un cliente ya no existe/expiró → evento `bye` y cierre (la
 // comprobación solo ocurre durante un broadcast, como en Node).
+//
+// Cada escritura corre en su propia goroutine: el broadcast se lanza desde
+// el tick del poller y un cliente lento (ventana TCP llena) no debe
+// bloquear la entrega a los demás ni el ciclo de sondeo (issue #200).
 func (h *Hub) Broadcast(event string, data any) {
 	raw, err := json.Marshal(data)
 	if err != nil {
@@ -96,14 +100,16 @@ func (h *Hub) Broadcast(event string, data any) {
 	h.mu.Unlock()
 
 	for _, c := range list {
-		if auth.GetSession(h.db, c.sessionID) == nil {
-			_ = c.write("event: bye\ndata: {}\n\n")
-			h.remove(c)
-			continue
-		}
-		if err := c.write(payload); err != nil {
-			h.remove(c)
-		}
+		go func(c *client) {
+			if auth.GetSession(h.db, c.sessionID) == nil {
+				_ = c.write("event: bye\ndata: {}\n\n")
+				h.remove(c)
+				return
+			}
+			if err := c.write(payload); err != nil {
+				h.remove(c)
+			}
+		}(c)
 	}
 }
 

--- a/server-go/internal/sse/hub_hol_test.go
+++ b/server-go/internal/sse/hub_hol_test.go
@@ -1,0 +1,91 @@
+package sse
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/auth"
+	"github.com/gnacho/netpulse/server-go/internal/config"
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+// slowWriter es un ResponseWriter que bloquea la escritura (ventana TCP
+// llena): nunca completa Fprint, simula un cliente que no drena el socket.
+type slowWriter struct{}
+
+func (slowWriter) Header() http.Header { return http.Header{} }
+func (slowWriter) Write(p []byte) (int, error) {
+	time.Sleep(2500 * time.Millisecond) // bloquea el write como un socket atascado
+	return len(p), nil
+}
+func (slowWriter) WriteHeader(int) {}
+func (slowWriter) Flush()          {}
+
+// chanWriter notifica por canal cuando recibe un write (sin compartir buffer
+// entre la goroutine de Broadcast y el test: evita la data race del recorder).
+type chanWriter struct {
+	ch chan string
+}
+
+func (chanWriter) Header() http.Header { return http.Header{} }
+func (w chanWriter) Write(p []byte) (int, error) {
+	w.ch <- string(p)
+	return len(p), nil
+}
+func (chanWriter) WriteHeader(int) {}
+func (chanWriter) Flush()          {}
+
+// TestBroadcastNoBloqueadoPorClienteLento reproduce el bug #200: un cliente
+// lento no debe bloquear la entrega del broadcast (el poller lanza el
+// broadcast desde su tick). Con el fix, Broadcast con un cliente lento y uno
+// rápido debe devolver en <2s y el rápido recibir el payload.
+func TestBroadcastNoBloqueadoPorClienteLento(t *testing.T) {
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	cfg := &config.Config{AuthUser: "admin", AuthPass: "test1234"}
+	_, err = auth.EnsureSessionSecret(d, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sesiones válidas para que Broadcast no descarte por revocada.
+	fastSess := auth.CreateSession(d, "test", 1)
+	slowSess := auth.CreateSession(d, "test", 1)
+
+	// Cliente rápido (notifica por canal al recibir).
+	fastRecv := make(chan string, 4)
+	fast := &client{id: 1, sessionID: fastSess, w: chanWriter{ch: fastRecv}, flusher: chanWriter{ch: fastRecv}, done: make(chan struct{})}
+
+	// Cliente lento (write bloqueante).
+	slow := &client{id: 2, sessionID: slowSess, w: slowWriter{}, flusher: slowWriter{}, done: make(chan struct{})}
+
+	h := NewHub(d, 10, nil)
+	h.mu.Lock()
+	h.clients[fast.id] = fast
+	h.clients[slow.id] = slow
+	h.mu.Unlock()
+
+	start := time.Now()
+	h.Broadcast("snapshot", map[string]any{"x": 1})
+	elapsed := time.Since(start)
+
+	// Broadcast debe volver pronto (no esperar al cliente lento).
+	if elapsed > 2*time.Second {
+		t.Fatalf("Broadcast bloqueado por el cliente lento: tardó %v", elapsed)
+	}
+
+	// El cliente rápido debe recibir el payload.
+	select {
+	case msg := <-fastRecv:
+		if msg != "event: snapshot\ndata: {\"x\":1}\n\n" {
+			t.Fatalf("payload inesperado: %q", msg)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("el cliente rápido no recibió el snapshot")
+	}
+}

--- a/server-go/internal/webhook/webhook.go
+++ b/server-go/internal/webhook/webhook.go
@@ -90,15 +90,19 @@ func (n *Notifier) Notify(ev alerts.AlertEvent) {
 func (n *Notifier) Close() {
 	n.once.Do(func() {
 		close(n.done)
-		close(n.ch)
 		n.wg.Wait()
 	})
 }
 
 func (n *Notifier) worker() {
 	defer n.wg.Done()
-	for ev := range n.ch {
-		n.sendWithRetry(ev)
+	for {
+		select {
+		case <-n.done:
+			return
+		case ev := <-n.ch:
+			n.sendWithRetry(ev)
+		}
 	}
 }
 
@@ -149,6 +153,10 @@ func (n *Notifier) sendWithRetry(ev alerts.AlertEvent) {
 				n.saveDLQ(ev, body, lastErr.Error())
 				return
 			}
+			retryable = true // 429/5xx → reintentar
+		} else {
+			// Error de transporte (DNS, timeout, conexión rehusada): la
+			// entrega puede tener éxito en un reintento → backoff (issue #203).
 			retryable = true
 		}
 		if attempt < n.cfg.Retries && retryable {

--- a/server-go/internal/webhook/webhook_test.go
+++ b/server-go/internal/webhook/webhook_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -149,4 +150,76 @@ func TestOKNoVaADLQ(t *testing.T) {
 	if cnt != 0 {
 		t.Fatalf("2xx no debería ir a DLQ, tiene %d", cnt)
 	}
+}
+
+// TestTransportErrorReintentaConBackoff reproduce el bug #203: un error de
+// transporte (conexión rehusada) antes se reintentaba EN RÁFAGA sin espera
+// (retryable solo se ponía para respuestas HTTP, no para fallos de red).
+// Tras el fix, entre reintentos debe haber backoff (>= RetryDelay), de modo
+// que el envío completo de un transporte caído dura >= Retries*RetryDelay.
+func TestTransportErrorReintentaConBackoff(t *testing.T) {
+	// Puerto cerrado: el client.Do devuelve error de transporte.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := srv.URL
+	srv.Close() // el puerto ya no acepta conexiones
+
+	d := openWebhookDB(t)
+	cfg := testConfig()
+	cfg.URL = deadURL
+	cfg.Retries = 2
+	cfg.RetryDelay = 60 * time.Millisecond
+	n := NewNotifier(cfg, d)
+	defer n.Close()
+
+	start := time.Now()
+	n.Notify(testAlert())
+	// El worker es asíncrono: esperamos hasta que la DLQ tenga la fila.
+	var cnt int
+	for i := 0; i < 40; i++ {
+		time.Sleep(25 * time.Millisecond)
+		_ = d.QueryRow("SELECT COUNT(*) FROM webhook_events").Scan(&cnt)
+		if cnt == 1 {
+			break
+		}
+	}
+	elapsed := time.Since(start)
+
+	if cnt != 1 {
+		t.Fatalf("el transporte fallido debería acabar en DLQ (1 fila), tiene %d", cnt)
+	}
+	// Sin fix esto acababa casi instantáneo (ráfaga sin backoff). Con el fix,
+	// 2 reintentos x 60ms + el intento inicial: >= 120ms de espera total.
+	minExpected := time.Duration(cfg.Retries) * cfg.RetryDelay
+	if elapsed < minExpected {
+		t.Fatalf("los reintentos de transporte deberían tener backoff: tardó %v, esperaba >= %v", elapsed, minExpected)
+	}
+}
+
+// TestCloseConNotifyConcurrentesNoPanic reproduce el bug #202: Close() cerraba
+// el canal de la cola y un Notify concurrente podía elegir la rama de envío
+// tras el close → panic "send on closed channel". Con -race y repeticiones
+// debe quedar limpio (el worker sale por done, no por range sobre canal cerrado).
+func TestCloseConNotifyConcurrentesNoPanic(t *testing.T) {
+	d := openWebhookDB(t)
+	n := NewNotifier(testConfig(), d)
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					n.Notify(testAlert())
+				}
+			}
+		}()
+	}
+	time.Sleep(5 * time.Millisecond)
+	n.Close()
+	close(done)
+	wg.Wait()
 }

--- a/web/app.js
+++ b/web/app.js
@@ -1407,19 +1407,33 @@ function initLightbox() {
   function openLightbox(img) {
     shotIndex = SHOT_SLIDES.indexOf(img.dataset.view) >= 0 ? SHOT_SLIDES.indexOf(img.dataset.view) : shotIndex
     syncLightbox()
+    clearTimeout(lightbox._closingTimer)
+    lightbox.classList.remove('closing')
     lightbox.hidden = false
+    lightbox.classList.add('open')
     lightbox.setAttribute('aria-hidden', 'false')
     if (lightboxClose) lightboxClose.focus()
     document.body.style.overflow = 'hidden'
   }
 
   function closeLightbox() {
-    lightbox.hidden = true
+    lightbox.classList.remove('open')
+    lightbox.classList.add('closing')
     lightbox.setAttribute('aria-hidden', 'true')
-    document.body.style.overflow = ''
+    clearTimeout(lightbox._closingTimer)
+    lightbox._closingTimer = setTimeout(() => {
+      lightbox.hidden = true
+      lightbox.classList.remove('closing')
+      document.body.style.overflow = ''
+    }, reduceMotion ? 0 : 150)
   }
 
   function nav(dir) {
+    if (lightbox.classList.contains('closing')) {
+      clearTimeout(lightbox._closingTimer)
+      lightbox.classList.remove('closing')
+      lightbox.classList.add('open')
+    }
     renderShot(shotIndex + dir)
     syncLightbox()
   }

--- a/web/index.html
+++ b/web/index.html
@@ -180,7 +180,7 @@
   <!-- ============ CLUB CLOUDLESS ============ -->
   <section class="block" id="club">
     <div class="container">
-      <div class="club-inner reveal">
+      <div class="club-inner">
         <div class="club-copy">
           <span class="eyebrow" data-i18n="club.eyebrow">Parte del Club Cloudless</span>
           <h2 class="font-display text-balance" data-i18n="club.title">Los principios del club</h2>
@@ -199,7 +199,7 @@
   <!-- ============ TEATRO STICKY ============ -->
   <section class="block" id="theater" style="padding-top:1rem;">
     <div class="container">
-      <div class="reveal">
+      <div>
         <span class="eyebrow" data-i18n="misc.demoBadge">datos demo</span>
         <h2 class="font-display text-balance" data-i18n="theater.title">Míralo cobrar vida</h2>
         <p class="lead" data-i18n="theater.lead">Sigue haciendo scroll. Estos son los widgets reales, alimentados con el dataset de demo.</p>
@@ -412,7 +412,7 @@
   <!-- ============ FEATURES ============ -->
   <section class="block" id="features" style="padding-top:2rem;">
     <div class="container">
-      <div class="reveal">
+      <div>
         <span class="eyebrow" data-i18n="nav.features">Funciones</span>
         <h2 class="font-display text-balance" data-i18n="features.title">Todo lo que necesita un NOC doméstico</h2>
         <p class="lead" data-i18n="features.lead">Solo lectura por diseño: NetPulse puede ver tu red, nunca cambiarla.</p>
@@ -475,7 +475,7 @@
   <!-- ============ CAPTURAS ============ -->
   <section class="block" id="shots" style="padding-top:1rem;">
     <div class="container">
-      <div class="reveal">
+      <div>
         <span class="eyebrow" data-i18n="shots.eyebrow">La app</span>
         <h2 class="font-display text-balance" data-i18n="shots.title">Un vistazo a la interfaz</h2>
         <p class="lead" data-i18n="shots.lead">Capturas de NetPulse en modo demo, con el tema que elijas. Una por menú.</p>
@@ -506,7 +506,7 @@
   <!-- ============ INSTALACIÓN ============ -->
   <section class="block" id="install">
     <div class="container">
-      <div class="reveal">
+      <div>
         <span class="eyebrow" data-i18n="nav.install">Instalar</span>
         <h2 class="font-display text-balance" data-i18n="install.title">Una línea para instalar</h2>
         <p class="lead" data-i18n="install.lead">Un único binario Go estático con la app web embebida, corriendo como servicio systemd enjaulado. Sin Docker.</p>
@@ -565,7 +565,7 @@
   <!-- ============ ACERCA DE MÍ ============ -->
   <section class="block" id="about" style="padding-top:1rem;">
     <div class="container">
-      <div class="reveal">
+      <div>
         <span class="eyebrow" data-i18n="about.eyebrow">Acerca de mí</span>
         <h2 class="font-display text-balance" data-i18n="about.title">Detrás de NetPulse hay una persona</h2>
       </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -157,6 +157,7 @@ html[dir="rtl"] #langSelect { margin-left: 0; margin-right: 0.5rem; }
   box-shadow: 0 0 24px -4px rgb(var(--accent) / 0.5);
 }
 .btn-primary:hover { filter: brightness(1.12); transform: translateY(-2px); text-decoration: none; box-shadow: 0 0 36px -2px rgb(var(--accent) / 0.55); }
+.btn-primary:active { transform: translateY(0) scale(0.97); }
 .btn-ghost {
   display: inline-flex; align-items: center; gap: 0.5rem;
   color: rgb(var(--text-secondary)); font-weight: 600; font-size: 1rem;
@@ -164,6 +165,7 @@ html[dir="rtl"] #langSelect { margin-left: 0; margin-right: 0.5rem; }
   background: rgb(var(--surface) / 0.5);
 }
 .btn-ghost:hover { color: rgb(var(--text-primary)); border-color: rgb(var(--accent) / 0.5); background: rgb(var(--accent) / 0.08); text-decoration: none; }
+.btn-ghost:active { transform: translateY(0) scale(0.97); }
 
 .hero-facts { display: flex; gap: 0.65rem; flex-wrap: wrap; margin-top: 2.75rem; }
 .chip {
@@ -511,6 +513,7 @@ html[dir="rtl"] .honest { border-left: none; border-right: 3px solid rgb(var(--w
 .thumb img { width: 100%; height: auto; display: block; }
 .thumb:hover { opacity: 1; }
 .thumb.active { border-color: rgb(var(--accent)); opacity: 1; }
+.thumb:active { transform: translateY(0) scale(0.97); }
 @media (max-width: 720px) {
   .slider-thumbs { justify-content: flex-start; overflow-x: auto; padding-bottom: 0.5rem; }
   .thumb { width: 110px; flex: none; }

--- a/web/styles.css
+++ b/web/styles.css
@@ -525,6 +525,21 @@ html[dir="rtl"] .honest { border-left: none; border-right: 3px solid rgb(var(--w
   flex-direction: column; gap: 1rem;
   padding: 2rem;
   cursor: zoom-out;
+  opacity: 0;
+  transform: scale(0.98);
+  transition: opacity 220ms ease, transform 220ms ease;
+  pointer-events: none;
+}
+.lightbox.open {
+  opacity: 1;
+  transform: none;
+  pointer-events: auto;
+}
+.lightbox.closing {
+  opacity: 0;
+  transform: scale(0.98);
+  transition: opacity 150ms cubic-bezier(0.4, 0, 1, 1), transform 150ms cubic-bezier(0.4, 0, 1, 1);
+  pointer-events: none;
 }
 .lightbox:not([hidden]) { display: flex; }
 .lightbox[hidden] { display: none; }

--- a/web/styles.css
+++ b/web/styles.css
@@ -79,20 +79,12 @@ a:hover { text-decoration: underline; }
 .text-muted { color: rgb(var(--text-muted)); }
 .text-accent { color: rgb(var(--accent)); }
 .text-ok { color: rgb(var(--ok)); }
-.text-warn { color: rgb(var(--warn)); }
-.text-danger { color: rgb(var(--danger)); }
 .text-tunnel { color: rgb(var(--tunnel)); }
 .text-info { color: rgb(var(--info)); }
-.text-gradient {
-  background: linear-gradient(135deg, rgb(var(--accent)) 0%, rgb(var(--ok)) 55%, rgb(var(--tunnel)) 100%);
-  -webkit-background-clip: text; -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
 .uppercase { text-transform: uppercase; }
 .label { font-size: 0.8125rem; line-height: 1.3; font-weight: 600; letter-spacing: 0.08em; }
 .caption { font-size: 0.875rem; line-height: 1.4; font-weight: 500; }
 .text-balance { text-wrap: balance; }
-.mono-num { font-variant-numeric: tabular-nums; }
 
 .card {
   background: rgb(var(--surface));
@@ -199,7 +191,7 @@ section.block { padding: 5rem 0; }
 .block .lead { color: rgb(var(--text-secondary)); max-width: 48rem; margin-top: 1rem; font-size: 1.15rem; line-height: 1.55; }
 
 /* fade-up on scroll */
-.reveal { opacity: 0; transform: translateY(26px); transition: opacity 650ms ease, transform 650ms ease; }
+.reveal { opacity: 0; transform: translateY(26px); transition: opacity 340ms ease, transform 340ms ease; }
 .reveal.in { opacity: 1; transform: none; }
 
 /* ---------- club cloudless ---------- */
@@ -296,12 +288,7 @@ section.block { padding: 5rem 0; }
 @keyframes peerPulse { 0% { opacity: 0.5; transform: scale(1); } 100% { opacity: 0; transform: scale(1.23); } }
 .topo-packet { offset-distance: 0%; }
 @keyframes packetMove { to { offset-distance: 100%; } }
-.topo-flow { opacity: 0; transition: opacity 600ms ease; }
-.topo-flow.on { opacity: 1; }
 .topo-guide { fill: none; stroke: rgb(var(--border-strong)); stroke-width: 1; stroke-dasharray: 2 6; opacity: 0.35; }
-.topo-label { font-size: 15px; font-weight: 700; fill: rgb(var(--text-primary)); stroke: rgb(var(--canvas)); stroke-width: 4px; paint-order: stroke; }
-.topo-label-sub { font-size: 12px; font-weight: 500; fill: rgb(var(--text-secondary)); stroke: rgb(var(--canvas)); stroke-width: 3px; paint-order: stroke; }
-.topo-badge-text { font-size: 7px; font-weight: 800; letter-spacing: 0.04em; }
 
 /* routers */
 .rgrid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.75rem; width: 100%; max-width: 52rem; }
@@ -328,11 +315,6 @@ section.block { padding: 5rem 0; }
 .rcard .statuspill.warn .dot { animation: pulseDot 1.6s infinite; }
 
 /* adguard */
-.ag-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; align-items: stretch; width: 100%; max-width: 50rem; }
-@media (max-width: 560px) { .ag-grid { grid-template-columns: 1fr; } }
-.ag-stat { padding: 1rem; }
-.ag-stat .v { font-family: "Space Grotesk", sans-serif; font-size: 2.4rem; font-weight: 700; }
-.ag-stat .k { font-size: 0.85rem; color: rgb(var(--text-muted)); margin-top: 0.2rem; font-weight: 600; }
 .ag-card { width: 100%; max-width: 30rem; padding: 1.1rem 1.2rem; }
 .ag-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.9rem; }
 .ag-head .label { display: inline-flex; align-items: center; gap: 0.45rem; }


### PR DESCRIPTION
Backlog sweep: 23 issues across backend fixes, frontend, demo, features and orchestration.

## Backend (auditoría, merge de ramas existentes)
- fix(sse): identity-based agent connection cleanup and non-blocking broadcast
- fix(api): guard negative start in paginate to avoid slice panic
- fix(auth): use a valid bcrypt dummy hash so login timing is constant
- fix: notifier close race, webhook backoff, ssh pool, presence pruning

## Backend (nuevo)
- fix(reports): clamp weekly upPct at 100 like availability
- fix(lldp): guard lldpDownUntil cache with a mutex
- fix(security): drop unsafe-inline, externalize boot script and splash

## Frontend
- feat(ui): suggest PWA install after first login (snackbar)
- fix(topology): mobile page layout stacking and horizontal overflow
- feat(nav): slide content transition between views on mobile
- Landing motion: lightbox, press feedback, reveal tuning

## Demo
- feat(i18n): allow forcing the default language at build time
- feat(demo): translate demo proper names to the active language
- feat(demo): optional GoatCounter tracker for public demo builds

## Features
- feat(agents): dedicated fleet agents view with reinstall and rearm recovery
- feat(topology): use LuCI port and vlan labels as preferred port names
- feat(topology): tighten wifi rings and keep host cable clear of APs

## Orquestación
- feat(orchestr): add WireGuard peers module (10.3)

## Tests
- test(availability): clamp expected upPct to 100 so the day test is time-independent

Closes #92
Closes #141
Closes #172
Closes #183
Closes #187
Closes #190
Closes #199
Closes #200
Closes #201
Closes #202
Closes #203
Closes #204
Closes #205
Closes #206
Closes #207
Closes #208
Closes #209
Closes #212
Closes #237
Closes #238
Closes #240
Closes #245
Closes #258
