### PR TITLE
release: v2.13.0 — reorganized Resumen hero card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 ## [Unreleased]
 
+## [2.13.0] - 2026-08-24
+
+### Added
+
+- **Resumen reorganizado (#265)**: tarjeta hero en una sola columna centrada: saludo con el estado debajo ("Tu red está perfecta" cuando todo va bien, o contador dinámico "N alertas importantes" cuando hay penalizaciones), donut de salud a 220 px centrado y fila de stats (latencia, dispositivos) debajo. El contador sale del breakdown existente del healthScore, sin cambios de backend.
+
 ## [2.12.0] - 2026-08-24
 
 ### Added

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.12.0",
+  "version": "2.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -36,7 +36,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.12.0"
+var Version = "2.13.0"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Release v2.13.0: bump app version, server health version and CHANGELOG entry for the reorganized Resumen hero card (#265).