### PR TITLE
docs(readme): add live demo link and callout

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -31,6 +31,10 @@ WireGuard, estadísticas de AdGuard Home y alertas, en tiempo real. Un
 único binario Go estático con el frontend embebido, autoalojado en una
 caja Linux pequeña.
 
+> **Prueba la demo en vivo**
+>
+> Mírala en funcionamiento sin instalar nada. Entra en **[demo.netpulse.cloudless.club](https://demo.netpulse.cloudless.club)** — una red de ejemplo completa, sin registro. En modo de solo lectura, para que explores sin riesgo.
+
 ## ¿Por qué existe?
 
 Siempre he creído en la soberanía digital: si un dispositivo te hace

--- a/README.es.md
+++ b/README.es.md
@@ -14,6 +14,8 @@
   <a href="https://ko-fi.com/gnacho"><img alt="Apóyame en Ko-fi" src="https://img.shields.io/badge/Ko--fi-Donate-ff5e5b?logo=ko-fi&logoColor=white"></a>
 </p>
 
+<p align="center"><a href="https://demo.netpulse.cloudless.club"><strong>Prueba la demo en vivo</strong></a> en <code>demo.netpulse.cloudless.club</code></p>
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="assets/hero-es-dark.png">

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ a live topology map, WireGuard peers, AdGuard Home stats and alerts, in real
 time. One static Go binary with the frontend embedded, self-hosted on a
 small Linux box.
 
+> **Try the live demo**
+>
+> See it running without installing anything. Head to **[demo.netpulse.cloudless.club](https://demo.netpulse.cloudless.club)** — a full sample network, no sign-up required. In read-only mode, so you can explore freely.
+
 ## Why does this exist?
 
 I believe in digital sovereignty: if a device makes you depend on its

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
   <a href="https://ko-fi.com/gnacho"><img alt="Support on Ko-fi" src="https://img.shields.io/badge/Ko--fi-Donate-ff5e5b?logo=ko-fi&logoColor=white"></a>
 </p>
 
+<p align="center"><a href="https://demo.netpulse.cloudless.club"><strong>Try the live demo</strong></a> on <code>demo.netpulse.cloudless.club</code></p>
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="assets/hero-en-dark.png">


### PR DESCRIPTION
Adds a clear live demo link (in prose, next to the badges) and a visible demo callout after the intro paragraph, in both the English and Spanish README.

Documentation only.