### PR TITLE
fix(orchestr): forward dnsmasq to a dedicated AdGuard DNS port

### DIFF
--- a/server-go/internal/orchestr/modules.go
+++ b/server-go/internal/orchestr/modules.go
@@ -27,6 +27,12 @@ import (
 // "binary". Actualizar cuando se quiera ofrecer una release más reciente.
 const adguardVersion = "v0.107.62"
 
+// adGuardDNSPort es el puerto donde AdGuard Home escucha el DNS (dns.port).
+// Es fijo y separado del puerto de la UI (bind_port = AdGuardDesired.Port) para
+// que dnsmasq reenvíe al resolutor y no a la UI web (issue #269). Elegido fuera
+// del puerto 53 para no colisionar con dnsmasq, que sigue sirviendo la LAN en :53.
+const adGuardDNSPort = "5353"
+
 // ErrManagedByFirmware indica que el router trae un fork de AdGuard del
 // fabricante (p. ej. GL.iNet gl-sdk4-adguardhome). El handler lo traduce a
 // HTTP 422 para que el usuario lo vea en el dry-run antes de aplicar nada.
@@ -35,7 +41,7 @@ var ErrManagedByFirmware = errors.New("managed_by_firmware")
 // AdGuardDesired es el estado deseado para el módulo AdGuard Home.
 type AdGuardDesired struct {
 	Enabled     bool   `json:"enabled"`
-	Port        string `json:"port"`        // puerto HTTP de la UI de AdGuard (default "3000")
+	Port        string `json:"port"`        // puerto HTTP de la UI de AdGuard (bind_port; default "3000")
 	UpstreamDNS string `json:"upstreamDns"` // DNS upstream (default "1.1.1.1")
 	// AllowNonGateway: permitir AdGuard en un router que no es el gateway.
 	// El servidor lo exige para no rechazar con 422 adguard_gateway_only
@@ -77,13 +83,15 @@ func AdGuardOps(desired AdGuardDesired, sc AdGuardScenario) ([]executor.Op, erro
 }
 
 // adGuardConfigOps: asume AdGuard ya instalado (opkg/apk/binario presente).
-// Solo configura el DNS forwarding de dnsmasq y arranca el servicio procd.
-// tcp_check al puerto de la UI verifica que el servicio levantó de verdad
-// (si no, el executor revierte staged).
+// Configura el DNS forwarding de dnsmasq hacia el puerto DNS de AdGuard (fijo,
+// adGuardDNSPort) y arranca el servicio procd. tcp_check al puerto de la UI
+// (bind_port) verifica que el servicio levantó de verdad (si no, el executor
+// revierte staged). El puerto port es SOLO de la UI, no del resolver (issue #269).
 func adGuardConfigOps(port, dns string) []executor.Op {
+	_ = dns // el upstream lo fija la config de AdGuard en write_file, no dnsmasq
 	return []executor.Op{
 		{Kind: "uci_set", Args: map[string]string{"config": "dhcp", "section": "@dnsmasq[0]", "option": "no_resolv", "value": "1"}, Desc: "Don't use /etc/resolv.conf"},
-		{Kind: "uci_set", Args: map[string]string{"config": "dhcp", "section": "@dnsmasq[0]", "option": "server", "value": "127.0.0.1#" + port}, Desc: "Forward DNS to AdGuard on port " + port},
+		{Kind: "uci_set", Args: map[string]string{"config": "dhcp", "section": "@dnsmasq[0]", "option": "server", "value": "127.0.0.1#" + adGuardDNSPort}, Desc: "Forward DNS to AdGuard on port " + adGuardDNSPort},
 		{Kind: "uci_commit", Args: map[string]string{"config": "dhcp"}, Desc: "Commit DHCP changes"},
 		{Kind: "service", Args: map[string]string{"name": "adguardhome", "action": "enable"}, Desc: "Enable AdGuard Home on boot"},
 		{Kind: "service", Args: map[string]string{"name": "adguardhome", "action": "start"}, Desc: "Start AdGuard Home"},
@@ -131,7 +139,7 @@ func adGuardBinaryOps(sc AdGuardScenario, port, dns string) []executor.Op {
 		{Kind: "service", Args: map[string]string{"name": "adguardhome", "action": "start"}, Desc: "Start AdGuard Home"},
 		{Kind: "tcp_check", Args: map[string]string{"host": "127.0.0.1", "port": port}, Desc: "Check AdGuard Home UI is listening"},
 		{Kind: "uci_set", Args: map[string]string{"config": "dhcp", "section": "@dnsmasq[0]", "option": "no_resolv", "value": "1"}, Desc: "Don't use /etc/resolv.conf"},
-		{Kind: "uci_set", Args: map[string]string{"config": "dhcp", "section": "@dnsmasq[0]", "option": "server", "value": "127.0.0.1#" + port}, Desc: "Forward DNS to AdGuard on port " + port},
+		{Kind: "uci_set", Args: map[string]string{"config": "dhcp", "section": "@dnsmasq[0]", "option": "server", "value": "127.0.0.1#" + adGuardDNSPort}, Desc: "Forward DNS to AdGuard on port " + adGuardDNSPort},
 		{Kind: "uci_commit", Args: map[string]string{"config": "dhcp"}, Desc: "Commit DHCP changes"},
 		{Kind: "service", Args: map[string]string{"name": "dnsmasq", "action": "restart"}, Desc: "Restart dnsmasq to apply DNS forwarding"},
 	}
@@ -139,13 +147,14 @@ func adGuardBinaryOps(sc AdGuardScenario, port, dns string) []executor.Op {
 
 // adGuardConfigTemplate: config YAML mínimo de AdGuard Home para primer
 // arranque sin wizard. %s = bind_port (HTTP admin UI), %s = upstream DNS.
-// DNS escucha en 0.0.0.0:53 (dnsmasq ya no resuelve, forwardea a AdGuard).
+// El DNS escucha en 0.0.0.0:<adGuardDNSPort> (fijo, separado de la UI);
+// dnsmasq sigue en :53 sirviendo la LAN y reenvía a AdGuard en ese puerto.
 const adGuardConfigTemplate = `bind_port: %s
 users: []
 dns:
   bind_hosts:
     - 0.0.0.0
-  port: 53
+  port: ` + adGuardDNSPort + `
   upstream_dns:
     - %s
   protection_enabled: true

--- a/server-go/internal/orchestr/modules_test.go
+++ b/server-go/internal/orchestr/modules_test.go
@@ -1,6 +1,7 @@
 package orchestr
 
 import (
+	"encoding/base64"
 	"errors"
 	"strings"
 	"testing"
@@ -70,15 +71,26 @@ func TestAdGuardOpsEscenarioApk(t *testing.T) {
 			t.Errorf("apk no debe descargar binario: encontró %s", op.Kind)
 		}
 	}
-	// El puerto deseado se aplica.
+	// El reenvío DNS va al puerto DNS fijo (adGuardDNSPort), NO al puerto de la UI.
+	// El puerto deseado (5300) solo afecta a la UI (bind_port/tcp_check).
 	hasForward := false
 	for _, op := range ops {
-		if op.Kind == "uci_set" && op.Args["option"] == "server" && op.Args["value"] == "127.0.0.1#5300" {
+		if op.Kind == "uci_set" && op.Args["option"] == "server" && op.Args["value"] == "127.0.0.1#"+adGuardDNSPort {
 			hasForward = true
 		}
 	}
 	if !hasForward {
-		t.Error("apk debe forwardear DNS al puerto deseado 5300")
+		t.Errorf("apk debe forwardear DNS al puerto DNS fijo %s, no al de la UI", adGuardDNSPort)
+	}
+	// El tcp_check de la UI usa el puerto deseado, no el del DNS.
+	hasTCP := false
+	for _, op := range ops {
+		if op.Kind == "tcp_check" && op.Args["port"] == "5300" {
+			hasTCP = true
+		}
+	}
+	if !hasTCP {
+		t.Error("tcp_check de la UI debe apuntar al puerto 5300 (bind_port)")
 	}
 	validateAll(t, ops)
 }
@@ -167,6 +179,59 @@ func TestAdGuardOpsBinaryFallbackSuffix(t *testing.T) {
 	}
 	if !strings.Contains(ops[0].Args["url"], "_arm64.tar.gz") {
 		t.Errorf("fallback URL debe usar arm64: %s", ops[0].Args["url"])
+	}
+	validateAll(t, ops)
+}
+
+func TestAdGuardOpsDNSForwardMatchConfigBinary(t *testing.T) {
+	// Regresión issue #269: el puerto que dnsmasq reenvía (127.0.0.1#X) debe
+	// coincidir con el dns.port de la config de AdGuard, y el DNS no debe
+	// chocar con la UI (bind_port). Antes reenviaba al puerto de la UI.
+	sc := AdGuardScenario{Arch: "aarch64", AdguardSuffix: "arm64"}
+	ops, err := AdGuardOps(AdGuardDesired{Enabled: true, Port: "3000", UpstreamDNS: "1.1.1.1"}, sc)
+	if err != nil {
+		t.Fatalf("binary inesperado error: %v", err)
+	}
+
+	// puerto de reenvío dnsmasq
+	var fwdPort string
+	for _, op := range ops {
+		if op.Kind == "uci_set" && op.Args["option"] == "server" {
+			fwdPort = strings.TrimPrefix(op.Args["value"], "127.0.0.1#")
+		}
+	}
+	if fwdPort == "" {
+		t.Fatal("no se encontró op uci_set server de reenvío")
+	}
+	if fwdPort != adGuardDNSPort {
+		t.Errorf("dnsmasq reenvía a %q, esperado %q", fwdPort, adGuardDNSPort)
+	}
+
+	// puerto de la UI (bind_port / tcp_check) debe ser distinto del DNS
+	var uiPort string
+	for _, op := range ops {
+		if op.Kind == "tcp_check" {
+			uiPort = op.Args["port"]
+		}
+	}
+	if uiPort == fwdPort {
+		t.Errorf("UI y DNS comparten puerto %q: colisión", uiPort)
+	}
+
+	// la config embebida debe tener dns.port == fwdPort
+	for _, op := range ops {
+		if op.Kind == "write_file" && strings.Contains(op.Args["path"], "AdGuardHome.yaml") {
+			raw, err := base64.StdEncoding.DecodeString(op.Args["content_b64"])
+			if err != nil {
+				t.Fatalf("config no es base64 válido: %v", err)
+			}
+			if !strings.Contains(string(raw), "  port: "+fwdPort) {
+				t.Errorf("config dns.port no coincide con reenvío %q\nconfig:\n%s", fwdPort, raw)
+			}
+			if !strings.Contains(string(raw), "  port: 53") {
+				t.Errorf("config no debe usar el puerto fijo 53 (mal):\n%s", raw)
+			}
+		}
 	}
 	validateAll(t, ops)
 }


### PR DESCRIPTION
## Summary

AdGuard Home serves the web UI on `bind_port` and the DNS on `dns.port`; they are distinct. The AdGuard orchestration module reused `AdGuardDesired.Port` (the UI port) both as `bind_port` and as the dnsmasq forwarding target, so dnsmasq would forward DNS queries to the AdGuard **web UI** port instead of the resolver.

## Fix

- Add a fixed `adGuardDNSPort = "5353"` (outside port 53 to avoid colliding with dnsmasq, which keeps serving the LAN on `:53`).
- `adGuardConfigTemplate` now writes `dns.port: 5353` (was hardcoded `53`).
- Both `uci_set ... server=127.0.0.1#<port>` ops (config and binary scenarios) now forward to `adGuardDNSPort`. `AdGuardDesired.Port` stays as the UI port (`bind_port` + `tcp_check`).
- Updated `TestAdGuardOpsEscenarioApk` and added `TestAdGuardOpsDNSForwardMatchConfigBinary` as a regression test asserting forwarding matches the config `dns.port` and the UI port differs from the DNS port.

## Verification

- `go vet ./internal/orchestr/...` clean.
- `go test -race ./internal/orchestr/...` and `go test ./internal/...` pass (including `httpapi`).
- Frontend unchanged (no rebuild needed); the deploy to the CT will ride the next release to avoid overwriting the embedded frontend bundle.

Closes #269