### PR TITLE
fix(ui): keep router back button fixed at top as icon-only

### DIFF
--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import { Link, NavLink, Outlet, useLocation, useNavigate } from 'react-router'
 import { AnimatePresence, motion } from 'framer-motion'
 import PullToRefresh from '@/components/PullToRefresh'
 import {
+  ArrowLeft,
   BarChart3,
   Bell,
   Bot,
@@ -85,6 +86,25 @@ const PAGE_TITLE_KEYS: [RegExp, string][] = [
 
 function pageTitleKey(pathname: string): string {
   return PAGE_TITLE_KEYS.find(([re]) => re.test(pathname))?.[1] ?? 'nav.overview'
+}
+
+/** true cuando la ruta es el detalle de un router (/routers/:id). */
+function isRouterDetail(pathname: string): boolean {
+  return /^\/routers\/[^/]+/.test(pathname)
+}
+
+/** Botón atrás icon-only, fijo en el topbar/header (issue #275). */
+function BackButton() {
+  const { t } = useTranslation()
+  return (
+    <Link
+      to="/routers"
+      aria-label={t('common.back')}
+      className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border bg-elevated text-text-secondary transition-colors duration-150 hover:border-accent/40 hover:text-accent"
+    >
+      <ArrowLeft className="h-4 w-4" strokeWidth={2} />
+    </Link>
+  )
 }
 
 /** Pill "Modo demo" (amber sutil) — solo cuando no hay backend */
@@ -451,6 +471,7 @@ function Topbar() {
 
   return (
     <header className="sticky top-0 z-30 hidden h-14 items-center gap-4 border-b border-border bg-canvas/80 px-6 backdrop-blur-md md:flex pt-safe">
+      {isRouterDetail(location.pathname) && <BackButton />}
       <h1 className="font-display text-h1 text-text-primary">{t(pageTitleKey(location.pathname))}</h1>
       <div className="ml-auto flex items-center gap-3">
         <button
@@ -488,7 +509,16 @@ function MobileHeader() {
   }
   return (
     <header className="[view-transition-name:netpulse-header] sticky top-0 z-30 flex h-14 items-center justify-between border-b border-border bg-canvas/80 px-4 backdrop-blur-md md:hidden pt-safe">
-      <Logo onClick={scrollTopIfActive('/')} />
+      <div className="flex items-center gap-2">
+        {isRouterDetail(location.pathname) ? (
+          <>
+            <BackButton />
+            <Logo compact onClick={scrollTopIfActive('/')} />
+          </>
+        ) : (
+          <Logo onClick={scrollTopIfActive('/')} />
+        )}
+      </div>
       <div className="flex items-center gap-3">
         <Link to="/" aria-label={t('topbar.networkHealth100', { score: healthScore.score })}>
           <motion.div layoutId="health-ring">

--- a/app/src/components/routers/RouterDetailHeader.tsx
+++ b/app/src/components/routers/RouterDetailHeader.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router'
-import { ArrowLeft, Router as RouterIcon } from 'lucide-react'
+import { Router as RouterIcon } from 'lucide-react'
 import { motion, useReducedMotion } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
 import { roleLabel } from '@/i18n'
@@ -44,13 +44,6 @@ export function RouterDetailHeader({ router }: { router: Router }) {
         />
       )}
       <div className="flex flex-wrap items-center gap-3">
-        <Link
-          to="/routers"
-          className="inline-flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1.5 text-caption font-semibold text-text-secondary transition-colors hover:border-accent/40 hover:text-accent"
-        >
-          <ArrowLeft className="h-3.5 w-3.5" strokeWidth={2} />
-          {t('common.back')}
-        </Link>
         <nav aria-label={t('common.breadcrumb')} className="font-mono text-caption text-text-muted">
           <Link to="/" className="transition-colors hover:text-accent">{t('common.home')}</Link>
           <span className="mx-1.5">/</span>


### PR DESCRIPTION
## Problem

On `/routers/:id`, the back button was a text link ("Back" with arrow) inside `RouterDetailHeader` at the top of the page content. The detail page scrolls with the window, so once the user scrolls down the header (and the back button) scrolls out of view.

## Change

- New `BackButton` (icon-only arrow, button styling) fixed in the sticky topbar (desktop) and mobile header, shown only on `/routers/:id` routes.
- Removed the in-content text back link from `RouterDetailHeader` (no duplication).
- Accessible via the existing `common.back` translation as `aria-label`.

## Verification

- `tsc -b`, eslint and `npm run build` clean.
- Playwright (mobile 390px and desktop 1440px): button visible, arrow present, no text, stays visible after scrolling to the bottom of the page, and the old text link is gone.

Closes #275