### PR TITLE
fix(agents): external pushers only alert - never install, rearm or update

### DIFF
--- a/app/src/components/routers/AgentsSection.tsx
+++ b/app/src/components/routers/AgentsSection.tsx
@@ -174,8 +174,10 @@ function AgentRow({ agent, router }: { agent?: AgentInfo; router: Router | undef
         <div className="flex flex-wrap items-center gap-2">
           {/* Actualizar: self-update del agente con progreso en vivo (#243) */}
           <AgentUpgradeButton agent={agent} className="h-8" />
-          {/* Rearm: canal preferente para heartbeat stale (proceso vivo) */}
-          {agent && <AgentRearmButton agent={agent} />}
+          {/* Rearm: canal preferente para heartbeat stale (proceso vivo).
+              Solo agentes NATIVOS OpenWrt: los externos (switch por beacon)
+              no tienen SSH - solo alertan (#291). */}
+          {agent && agent.kind !== 'external' && <AgentRearmButton agent={agent} />}
           {canRecover && (
             <button
               type="button"

--- a/server-go/internal/httpapi/agent.go
+++ b/server-go/internal/httpapi/agent.go
@@ -529,6 +529,8 @@ func (s *server) handleAgentRearm(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "not_found", err.Error())
 	case errors.Is(err, rearmer.ErrNoRouter):
 		writeError(w, http.StatusConflict, "router_unknown", err.Error())
+	case errors.Is(err, rearmer.ErrExternalAgent):
+		writeError(w, http.StatusConflict, "not_openwrt", err.Error())
 	case errors.Is(err, rearmer.ErrNoSSH):
 		writeError(w, http.StatusServiceUnavailable, "ssh_unavailable", err.Error())
 	default:

--- a/server-go/internal/rearmer/rearmer.go
+++ b/server-go/internal/rearmer/rearmer.go
@@ -74,6 +74,10 @@ func (e ErrCooldown) Error() string {
 var (
 	ErrNoToken  = fmt.Errorf("ese slug no tiene agente registrado")
 	ErrNoRouter = fmt.Errorf("no hay router con ese slug en la tabla routers")
+	// ErrExternalAgent: el slug es un pusher EXTERNO (tipo no OpenWrt,
+	// p. ej. switch gestionado por beacon): sin SSH, no se instala, no se
+	// rearmera ni se actualiza - solo alerta (#291).
+	ErrExternalAgent = fmt.Errorf("agente externo: sin SSH ni rearme")
 	ErrNoSSH    = fmt.Errorf("el servidor no tiene pool SSH (modo demo o clave ausente)")
 	ErrNoDB     = fmt.Errorf("db no disponible")
 )
@@ -119,9 +123,17 @@ func (r *Rearmer) SetCooldown(d time.Duration) {
 	}
 }
 
+// nativeAgentType: ¿el tipo de router admite agente nativo (OpenWrt) y por
+// tanto rearme/reinstalación por SSH? Los tipos externos (managed-switch,
+// p. ej. un switch por beacon) NO: solo alertan.
+func nativeAgentType(t string) bool {
+	return t == "" || t == "openwrt" || t == "glinet"
+}
+
 // Rearm ejecuta un rearme completo del slug. Errores tipificados
-// (ErrNoDB, ErrNoToken, ErrNoRouter, ErrNoSSH, ErrCooldown) para que el
-// handler HTTP los mapee a su status; cualquier otro error es fallo SSH.
+// (ErrNoDB, ErrNoToken, ErrNoRouter, ErrNoSSH, ErrExternalAgent,
+// ErrCooldown) para que el handler HTTP los mapee a su status; cualquier
+// otro error es fallo SSH.
 func (r *Rearmer) Rearm(slug string) (Result, error) {
 	if r.db == nil {
 		return Result{}, ErrNoDB
@@ -136,6 +148,9 @@ func (r *Rearmer) Rearm(slug string) (Result, error) {
 	host := ""
 	for _, rc := range routerstore.ListRouters(r.db) {
 		if rc.ID == slug {
+			if !nativeAgentType(rc.Type) {
+				return Result{}, ErrExternalAgent
+			}
 			host = rc.Host
 			break
 		}
@@ -282,7 +297,20 @@ func (s *Supervisor) CheckOnce() {
 	if s.registry == nil || s.db == nil || s.rearmer == nil {
 		return
 	}
+	// Externos (p. ej. switch gestionado por beacon): sin SSH, nunca se
+	// rearman. Se resuelven una vez por pasada (misma tabla que Rearm).
+	external := map[string]bool{}
+	for _, rc := range routerstore.ListRouters(s.db) {
+		if !nativeAgentType(rc.Type) {
+			external[rc.ID] = true
+		}
+	}
 	for _, slug := range s.registeredSlugs() {
+		if external[slug] {
+			// El Dead Man's Switch ya alerta la caída; aquí solo se ignora.
+			s.closeFailID(slug)
+			continue
+		}
 		// Solo rearma si el agente EXPIRÓ (TTL): conocido y último push
 		// fuera del TTL. Un slug sin push nunca visto no se rearma (no hay
 		// evidencia de que el servicio haya estado vivo).

--- a/server-go/internal/rearmer/rearmer_test.go
+++ b/server-go/internal/rearmer/rearmer_test.go
@@ -5,6 +5,7 @@
 package rearmer_test
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -328,5 +329,26 @@ func TestRearmerManualSigueFuncionando(t *testing.T) {
 	}
 	if _, err := env.arm.Rearm("noexiste"); err == nil {
 		t.Fatalf("slug sin token debe dar ErrNoToken")
+	}
+}
+
+// Un slug cuyo router es de tipo EXTERNO (managed-switch por beacon) no se
+// rearmera: Rearm devuelve ErrExternalAgent (sin SSH) y el supervisor lo
+// ignora (solo alerta el Dead Man's Switch, que vive en el adapter live).
+func TestRearmExternalAgentRejected(t *testing.T) {
+	env := makeRearmEnv(t, "switch16")
+	// el env añade "patio" openwrt; añadir switch16 como managed-switch
+	if _, err := routerstore.AddRouter(env.d.DB, routerstore.AddInput{
+		Name: "switch16", Host: "192.168.1.6", Type: "managed-switch",
+	}); err != nil {
+		t.Fatalf("AddRouter switch16: %v", err)
+	}
+	if _, err := env.arm.Rearm("switch16"); !errors.Is(err, rearmer.ErrExternalAgent) {
+		t.Fatalf("switch externo: got %v want ErrExternalAgent", err)
+	}
+	// El nativo "patio" sigue pasando (su error no debe ser ErrExternalAgent).
+	_, err := env.arm.Rearm("patio")
+	if errors.Is(err, rearmer.ErrExternalAgent) {
+		t.Fatalf("patio (openwrt) no debe rechazarse como externo")
 	}
 }


### PR DESCRIPTION
Rearmer.Rearm rejects non-native router types (managed-switch by beacon, etc.) with ErrExternalAgent; the auto-rearm supervisor skips external slugs every pass while the dead man's switch keeps alerting their downtime; the fleet UI hides the rearm button for kind=external. Reinstall and upgrade were already type-gated.