### PR TITLE
release: v2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 ## [Unreleased]
 
+## [2.16.0] - 2026-08-28
+
+### Added
+
+- **Base OUI embebida (#314)**: 39769 prefijos MAC para resolver fabricante de dispositivos en vivo. `Device.Manufacturer` ahora se rellena desde el prefijo OUI en lugar de "Desconocido".
+- **Sugerencias accionables en alertas (#310)**: campo `hint` opcional con sugerencia estática por tipo de alerta (agente caído, temperatura alta, WAN caído, etc.). Visible en el feed, push notifications y service worker.
+- **Topología LLDP como ground truth (#300)**: los enlaces de infraestructura (router-switch, switch-switch en cadena) usan LLDP como fuente primaria. FDB queda como fallback cuando lldpd no está instalado.
+- **Vista VLAN de solo lectura (#315)**: panel colapsable en el detalle del router con tabla de VLANs (ID, puertos, tagged/untagged, PVID) parseada de `bridge vlan show`.
+- **Monitorización SFP/DDM (#313)**: sonda `ethtool -m` en el agente + parsing de campos SFP del beacon. Temperatura, voltaje y potencia óptica TX/RX en el detalle de puerto. Alertas por RX < -14 dBm y temperatura > 70 °C.
+- **Clasificación por huella DHCP/LLDP (#301)**: el clasificador de dispositivos amplía las reglas de hostname con DHCP vendor class, client-id y capacidades LLDP.
+- **Descubrimiento de tipo de dispositivo (#304)**: filtros por tipo y badges en el inventario de dispositivos. La API devuelve `typeCounts` agrupado.
+
 ## [2.15.0] - 2026-08-28
 
 ### Added

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.15.0",
+  "version": "2.16.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -38,7 +38,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.15.0"
+var Version = "2.16.0"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Bump version to 2.16.0 and update CHANGELOG for switch management phase 1 (#319).

Closes #300, #301, #304, #310, #313, #314, #315