### PR TITLE
feat: switch management phase 2 - SNMP poller and per-port time series

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -515,7 +515,11 @@
       "sfpTx": "TX power",
       "sfpVendor": "Vendor",
       "sfpWarnTemp": "High temperature",
-      "sfpWarnRx": "Low RX power"
+      "sfpWarnRx": "Low RX power",
+      "seriesTitle": "Traffic history",
+      "seriesRx": "Receive",
+      "seriesTx": "Transmit",
+      "seriesNoData": "No historical data"
     },
     "radios": {
       "channel": "Channel",

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -978,7 +978,10 @@
       "rotating": "Rotating…",
       "firmwareTarget": "Firmware target version",
       "firmwareTargetPlaceholder": "e.g. 25.12.5",
-      "firmwareTargetHint": "Optional. If the installed firmware doesn't match this version, NetPulse alerts."
+      "firmwareTargetHint": "Optional. If the installed firmware doesn't match this version, NetPulse alerts.",
+      "snmpEnabled": "SNMP polling",
+      "snmpCommunity": "Community (SNMPv2c)",
+      "snmpPort": "Port"
     },
     "overrides": {
       "title": "Topology — manual tagging",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -515,7 +515,11 @@
       "sfpTx": "Potencia TX",
       "sfpVendor": "Fabricante",
       "sfpWarnTemp": "Temperatura alta",
-      "sfpWarnRx": "Potencia RX baja"
+      "sfpWarnRx": "Potencia RX baja",
+      "seriesTitle": "Historial de tráfico",
+      "seriesRx": "Recepción",
+      "seriesTx": "Envío",
+      "seriesNoData": "Sin datos históricos"
     },
     "radios": {
       "channel": "Canal",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -978,7 +978,10 @@
       "rotating": "Rotando…",
       "firmwareTarget": "Versión de firmware objetivo",
       "firmwareTargetPlaceholder": "p. ej. 25.12.5",
-      "firmwareTargetHint": "Opcional. Si el firmware instalado no coincide con esta versión, NetPulse lo avisa."
+      "firmwareTargetHint": "Opcional. Si el firmware instalado no coincide con esta versión, NetPulse lo avisa.",
+      "snmpEnabled": "Sondeo SNMP",
+      "snmpCommunity": "Comunidad (SNMPv2c)",
+      "snmpPort": "Puerto"
     },
     "overrides": {
       "title": "Topología — etiquetado manual",

--- a/app/src/components/routers/PortPanel.tsx
+++ b/app/src/components/routers/PortPanel.tsx
@@ -10,17 +10,18 @@ import { EMPTY_EXTRAS, useNetPulse } from '@/data/DataProvider'
 import { Activity } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { PortSeriesChart } from '@/components/routers/PortSeriesChart'
 
 /**
- * Panel visual de puertos Ethernet — dibuja las bocas RJ45 del chasis con
+ * Panel visual de puertos Ethernet - dibuja las bocas RJ45 del chasis con
  * LEDs de link/actividad, ocupación y qué dispositivo hay en cada boca.
  * Variante compacta (APs, col-span-5) y ancha (gateway, col-span-12).
  */
 
 /** fmtPortBps: rate de una boca en humano ("12.4 Mbps" · "320 kbps" · "0").
- *  undefined (sin dato todavía) → "—" para no confundirlo con 0 real. */
+ *  undefined (sin dato todavia) -> "-" para no confundirlo con 0 real. */
 function fmtPortBps(bps?: number): string {
-  if (bps === undefined || Number.isNaN(bps)) return '—'
+  if (bps === undefined || Number.isNaN(bps)) return '-'
   if (bps >= 1e9) return `${(bps / 1e9).toFixed(1)} Gbps`
   if (bps >= 1e6) return `${(bps / 1e6).toFixed(1)} Mbps`
   if (bps >= 1e3) return `${Math.round(bps / 1e3)} kbps`
@@ -301,6 +302,11 @@ export function PortPanel({ router, extras, className }: { router: Router; extra
           </span>
         )}
       </div>
+
+      {/* Per-port traffic history (issue #302) */}
+      {ports.some((p) => p.up) && !isDemo && (
+        <PortSeriesChart routerId={router.id} portId={ports.find((p) => p.up)!.id} />
+      )}
     </section>
   )
 }

--- a/app/src/components/routers/PortSeriesChart.tsx
+++ b/app/src/components/routers/PortSeriesChart.tsx
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface PortPoint {
+  ts: string
+  rxBytes: number
+  txBytes: number
+  rxErrors: number
+  txErrors: number
+  rxBps: number
+  txBps: number
+  speedMbps: number
+}
+
+interface PortSeriesResponse {
+  points: PortPoint[]
+  resolution: string
+}
+
+type Range = '24h' | '7d' | '30d'
+
+const RANGES: Range[] = ['24h', '7d', '30d']
+
+function rangeToSeconds(range: Range): number {
+  switch (range) {
+    case '24h': return 24 * 3600
+    case '7d': return 7 * 24 * 3600
+    case '30d': return 30 * 24 * 3600
+  }
+}
+
+function fmtBps(bps: number): string {
+  if (bps >= 1e9) return `${(bps / 1e9).toFixed(1)} Gbps`
+  if (bps >= 1e6) return `${(bps / 1e6).toFixed(1)} Mbps`
+  if (bps >= 1e3) return `${Math.round(bps / 1e3)} kbps`
+  return `${Math.round(bps)} bps`
+}
+
+function Sparkline({ points, colorKey }: { points: PortPoint[]; colorKey: 'rxBps' | 'txBps' }) {
+  if (points.length < 2) return null
+  const W = 200
+  const H = 40
+  const PAD = 2
+  const values = points.map((p) => p[colorKey])
+  const max = Math.max(...values, 1)
+  const stepX = (W - PAD * 2) / (values.length - 1)
+  const path = values
+    .map((v, i) => {
+      const x = PAD + i * stepX
+      const y = H - PAD - ((v / max) * (H - PAD * 2))
+      return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`
+    })
+    .join(' ')
+  const fillPath = path + ` L${(W - PAD).toFixed(1)},${H - PAD} L${PAD},${H - PAD} Z`
+  const color = colorKey === 'rxBps' ? '#3b82f6' : '#10b981'
+  const fillColor = colorKey === 'rxBps' ? 'rgba(59,130,246,0.12)' : 'rgba(16,185,129,0.12)'
+  return (
+    <svg width={W} height={H} viewBox={`0 0 ${W} ${H}`} className="block" aria-hidden="true">
+      <path d={fillPath} fill={fillColor} />
+      <path d={path} fill="none" stroke={color} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+export function PortSeriesChart({ routerId, portId }: { routerId: string; portId: string }) {
+  const { t } = useTranslation()
+  const [range, setRange] = useState<Range>('24h')
+  const [data, setData] = useState<PortPoint[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    try {
+      const now = Math.floor(Date.now() / 1000)
+      const from = now - rangeToSeconds(range)
+      const res = await fetch(`/api/routers/${encodeURIComponent(routerId)}/ports/${encodeURIComponent(portId)}/series?from=${from}&to=${now}`)
+      if (res.ok) {
+        const json: PortSeriesResponse = await res.json()
+        setData(json.points ?? [])
+      } else {
+        setData([])
+      }
+    } catch {
+      setData([])
+    } finally {
+      setLoading(false)
+    }
+  }, [routerId, portId, range])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  const hasData = data.length > 1
+  const peakRx = hasData ? Math.max(...data.map((p) => p.rxBps)) : 0
+  const peakTx = hasData ? Math.max(...data.map((p) => p.txBps)) : 0
+
+  return (
+    <div className="mt-3 rounded-xl border border-border/60 bg-elevated/30 p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-caption font-medium text-text-secondary">{t('routerDetail.ports.seriesTitle')}</span>
+        <div className="flex gap-1">
+          {RANGES.map((r) => (
+            <button
+              key={r}
+              type="button"
+              onClick={() => setRange(r)}
+              className={`rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
+                range === r
+                  ? 'bg-accent/15 text-accent'
+                  : 'text-text-muted hover:bg-canvas hover:text-text-secondary'
+              }`}
+            >
+              {r}
+            </button>
+          ))}
+        </div>
+      </div>
+      {loading ? (
+        <div className="flex h-10 items-center justify-center text-caption text-text-muted">...</div>
+      ) : hasData ? (
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <span className="w-5 text-[10px] font-medium text-blue-500">RX</span>
+            <Sparkline points={data} colorKey="rxBps" />
+            <span className="ml-auto font-mono text-[10px] text-text-muted">{fmtBps(peakRx)}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="w-5 text-[10px] font-medium text-emerald-500">TX</span>
+            <Sparkline points={data} colorKey="txBps" />
+            <span className="ml-auto font-mono text-[10px] text-text-muted">{fmtBps(peakTx)}</span>
+          </div>
+        </div>
+      ) : (
+        <div className="flex h-10 items-center justify-center text-caption text-text-muted">
+          {t('routerDetail.ports.seriesNoData')}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -272,6 +272,9 @@ interface ConfigRouter {
   is_gateway: boolean
   agent_only: boolean
   firmware_target: string
+  snmp_enabled: boolean
+  snmp_community: string
+  snmp_port: number
 }
 
 interface DiscoverCandidate {
@@ -302,6 +305,9 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
   const [editGateway, setEditGateway] = useState(false)
   const [editAgentOnly, setEditAgentOnly] = useState(false)
   const [editFirmwareTarget, setEditFirmwareTarget] = useState('')
+  const [editSnmpEnabled, setEditSnmpEnabled] = useState(false)
+  const [editSnmpCommunity, setEditSnmpCommunity] = useState('')
+  const [editSnmpPort, setEditSnmpPort] = useState(161)
   const [editSubmitting, setEditSubmitting] = useState(false)
   const [pubkey, setPubkey] = useState<{ publicKey: string; fingerprint: string } | null>(null)
   const [copied, setCopied] = useState(false)
@@ -489,6 +495,9 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
     setEditGateway(r.is_gateway)
     setEditAgentOnly(r.agent_only)
     setEditFirmwareTarget(r.firmware_target ?? '')
+    setEditSnmpEnabled(r.snmp_enabled ?? false)
+    setEditSnmpCommunity(r.snmp_community ?? '')
+    setEditSnmpPort(r.snmp_port ?? 161)
     setError(null)
   }
 
@@ -508,6 +517,9 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
           gateway: editGateway,
           agent_only: editAgentOnly,
           firmware_target: editFirmwareTarget.trim(),
+          snmp_enabled: editSnmpEnabled,
+          snmp_community: editSnmpCommunity.trim() || undefined,
+          snmp_port: editSnmpPort,
         }),
       })
       if (res.status === 409) {
@@ -815,6 +827,47 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
                 />
                 <p className="mt-1 text-caption leading-relaxed text-text-muted">{t('settings.routers.firmwareTargetHint')}</p>
               </div>
+              {(editType === 'managed-switch' || editType === 'external' || editSnmpEnabled) && (
+                <div className="space-y-2.5 rounded-lg border border-border bg-canvas/50 p-3">
+                  <label className="flex cursor-pointer items-center gap-2 text-sm text-text-secondary">
+                    <Switch checked={editSnmpEnabled} onCheckedChange={setEditSnmpEnabled} />
+                    {t('settings.routers.snmpEnabled')}
+                  </label>
+                  {editSnmpEnabled && (
+                    <div className="grid grid-cols-2 gap-2.5">
+                      <div>
+                        <label htmlFor="snmp-community" className="mb-1 block text-caption font-medium uppercase tracking-[0.06em] text-text-muted">
+                          {t('settings.routers.snmpCommunity')}
+                        </label>
+                        <input
+                          id="snmp-community"
+                          type="text"
+                          value={editSnmpCommunity}
+                          onChange={(e) => setEditSnmpCommunity(e.target.value)}
+                          placeholder="public"
+                          aria-label={t('settings.routers.snmpCommunity')}
+                          className="w-full rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+                        />
+                      </div>
+                      <div>
+                        <label htmlFor="snmp-port" className="mb-1 block text-caption font-medium uppercase tracking-[0.06em] text-text-muted">
+                          {t('settings.routers.snmpPort')}
+                        </label>
+                        <input
+                          id="snmp-port"
+                          type="number"
+                          min={1}
+                          max={65535}
+                          value={editSnmpPort}
+                          onChange={(e) => setEditSnmpPort(Number(e.target.value))}
+                          aria-label={t('settings.routers.snmpPort')}
+                          className="w-full rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
               {error && <p className="text-caption text-danger">{error}</p>}
               <div className="flex justify-end gap-2">
                 <button

--- a/server-go/go.mod
+++ b/server-go/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gosnmp/gosnmp v1.44.0 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/server-go/go.sum
+++ b/server-go/go.sum
@@ -10,6 +10,8 @@ github.com/google/pprof v0.0.0-20260802141513-ef3492d7dac3 h1:LMLX+LgTNWpfvCBdFe
 github.com/google/pprof v0.0.0-20260802141513-ef3492d7dac3/go.mod h1:jl5iWTm0/hd5PjEYEOuwAJ57L/CibdZfrqZ5XA5GrCk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gosnmp/gosnmp v1.44.0 h1:6SUNAJWjSu/j05rm+M1G39NoPW8jvShiFqYf6XNnM+k=
+github.com/gosnmp/gosnmp v1.44.0/go.mod h1:30xQDXCVXXehh/xwRd62+JwIizwc3HZaBi4F/Hv5/0o=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsReI=

--- a/server-go/internal/adapters/agent.go
+++ b/server-go/internal/adapters/agent.go
@@ -584,6 +584,8 @@ func (l *Live) polledFromAgent(cfg RouterConfig, p *probe.Payload) *routerPolled
 		wireless: out.wireless, fdb: out.fdb, luci: out.luci}
 	l.mu.Unlock()
 
+	l.recordPortSamples(cfg.ID, out.ports)
+
 	if out.leases == nil {
 		out.leases = []DhcpLease{}
 	}

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gnacho/netpulse/server-go/internal/db"
 	"github.com/gnacho/netpulse/server-go/internal/deviceevents"
 	"github.com/gnacho/netpulse/server-go/internal/oui"
+	"github.com/gnacho/netpulse/server-go/internal/portseries"
 )
 
 // fmtUptime: "<d>d <h>h" (index.js:32-36).
@@ -878,6 +879,7 @@ func (l *Live) pollRouter(ctx context.Context, cfg RouterConfig) (*routerPolled,
 	if temp != nil {
 		tempV = *temp
 	}
+	l.recordPortSamples(cfg.ID, portsGood)
 	return &routerPolled{
 		cfg: cfg, client: client, sysInfo: sysInfo, board: board,
 		cpu: cpuV, ram: ramPct, temp: tempV,
@@ -1435,6 +1437,50 @@ func (l *Live) lastRouterFor(mac string) string {
 	var routerID string
 	_ = l.db.QueryRow("SELECT router_id FROM device_attrib WHERE mac = ?", mac).Scan(&routerID)
 	return routerID
+}
+
+// parseSpeedMbps converts a human speed string ("1 Gbps", "100 Mbps", "2.5G")
+// to Mbps. Returns 0 on unknown formats.
+func parseSpeedMbps(s string) int {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	s = strings.ReplaceAll(s, "bps", "")
+	s = strings.ReplaceAll(s, "Bps", "")
+	s = strings.TrimSpace(s)
+	if strings.HasSuffix(s, "G") {
+		if v, err := strconv.ParseFloat(strings.TrimSuffix(s, "G"), 64); err == nil {
+			return int(v * 1000)
+		}
+	}
+	if strings.HasSuffix(s, "M") {
+		if v, err := strconv.ParseFloat(strings.TrimSuffix(s, "M"), 64); err == nil {
+			return int(v)
+		}
+	}
+	return 0
+}
+
+// recordPortSamples persists per-port time series samples (issue #302).
+// Called after port stats are collected (SSH or agent path).
+func (l *Live) recordPortSamples(routerID string, ports []EthPort) {
+	if l.db == nil || l.db.PortSeries == nil || len(ports) == 0 {
+		return
+	}
+	now := time.Now()
+	for _, p := range ports {
+		if p.ID == "" {
+			continue
+		}
+		_ = l.db.PortSeries.RecordSample(portseries.PortSample{
+			RouterID: routerID, PortID: p.ID, TS: now,
+			RxBytes: p.RxBytes, TxBytes: p.TxBytes,
+			RxErrors: p.RxErrs, TxErrors: p.TxErrs,
+			RxBps: p.RxBps, TxBps: p.TxBps,
+			SpeedMbps: parseSpeedMbps(p.Speed),
+		})
+	}
 }
 
 // pollAdGuard: stats del cliente configurado; fallback inactivo si falla.

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -191,6 +191,9 @@ type Live struct {
 	// (contadores absolutos + ts) para calcular los rates por boca con el
 	// delta entre payloads (issue #305). Protegido por mu.
 	lastAgentIf map[string]*agentIfSample
+	// snmpPorts (issue #309): contadores del último poll SNMP por router y
+	// puerto. Se usa para calcular rxBps/txBps entre polls sucesivos.
+	snmpPorts map[string]map[string]snmpPortSample
 	lastPolled  map[string]*routerPolled
 	failCount   map[string]int
 	lastErr     map[string]error // último error del sondeo (issue #257: distinguir sin-acceso de caído)
@@ -271,6 +274,7 @@ func NewLive(cfg *config.Config, d *db.DB, initial []RouterConfig, pool *SSHPool
 		layoutCache:          map[string][]PortLayout{},
 		extrasCache:          map[string]*extrasSnapshot{},
 		lastAgentIf:          map[string]*agentIfSample{},
+		snmpPorts:            map[string]map[string]snmpPortSample{},
 		lastPolled:           map[string]*routerPolled{},
 		failCount:            map[string]int{},
 		lastErr:              map[string]error{},
@@ -396,6 +400,11 @@ func (l *Live) SetRouters(list []RouterConfig) {
 	for id := range l.lastAgentIf {
 		if !ids[id] {
 			delete(l.lastAgentIf, id)
+		}
+	}
+	for id := range l.snmpPorts {
+		if !ids[id] {
+			delete(l.snmpPorts, id)
 		}
 	}
 	for id := range l.lastPolled {
@@ -739,6 +748,9 @@ func (l *Live) pollRouter(ctx context.Context, cfg RouterConfig) (*routerPolled,
 			p.wanInfo = l.probeWanInfo(cfg.ID, client)
 		}
 		return p, nil
+	}
+	if cfg.SnmpEnabled {
+		return l.pollRouterSNMP(cfg)
 	}
 	l.mu.Lock()
 	client := l.clients[cfg.ID]

--- a/server-go/internal/adapters/snmp_live.go
+++ b/server-go/internal/adapters/snmp_live.go
@@ -1,0 +1,126 @@
+package adapters
+
+import (
+	"fmt"
+	"log"
+	"math"
+	"time"
+
+	npsnmp "github.com/gnacho/netpulse/server-go/internal/snmp"
+)
+
+func (l *Live) pollRouterSNMP(cfg RouterConfig) (*routerPolled, error) {
+	session, err := npsnmp.NewSession(npsnmp.Config{
+		Host:      cfg.Host,
+		Port:      cfg.SnmpPort,
+		Community: cfg.SnmpCommunity,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("snmp %s: %w", cfg.Host, err)
+	}
+	defer npsnmp.CloseSession(session)
+
+	sysInfo, err := npsnmp.PollSystem(session)
+	if err != nil {
+		log.Printf("[netpulse] SNMP system %s: %v", cfg.ID, err)
+	}
+	ports, err := npsnmp.PollIfTable(session)
+	if err != nil {
+		log.Printf("[netpulse] SNMP ifTable %s: %v", cfg.ID, err)
+	}
+	fdb, err := npsnmp.PollFdbTable(session)
+	if err != nil {
+		log.Printf("[netpulse] SNMP FDB %s: %v", cfg.ID, err)
+	}
+
+	portIdxToName := map[int]string{}
+	for _, p := range ports {
+		portIdxToName[p.Index] = p.DisplayName()
+	}
+
+	ethPorts := make([]EthPort, 0, len(ports))
+	for _, p := range ports {
+		name := p.DisplayName()
+		label := name
+		ethPorts = append(ethPorts, EthPort{
+			ID:      fmt.Sprintf("snmp-%d", p.Index),
+			Label:   label,
+			Up:      p.OperUp,
+			Speed:   p.SpeedString(),
+			Iface:   name,
+			RxBytes: p.RxBytes,
+			TxBytes: p.TxBytes,
+			RxErrs:  p.RxErrors,
+			TxErrs:  p.TxErrors,
+		})
+	}
+
+	prevPorts := l.snmpPrevPorts(cfg.ID)
+	l.mu.Lock()
+	l.snmpPortCache(cfg.ID, ethPorts)
+	l.mu.Unlock()
+	for i := range ethPorts {
+		prev, ok := prevPorts[ethPorts[i].ID]
+		if !ok {
+			continue
+		}
+		dt := time.Since(prev.at).Seconds()
+		if dt <= 0 {
+			continue
+		}
+		if ethPorts[i].RxBytes >= prev.rxBytes {
+			ethPorts[i].RxBps = math.Round(float64(ethPorts[i].RxBytes-prev.rxBytes)*8/dt*10) / 10
+		}
+		if ethPorts[i].TxBytes >= prev.txBytes {
+			ethPorts[i].TxBps = math.Round(float64(ethPorts[i].TxBytes-prev.txBytes)*8/dt*10) / 10
+		}
+	}
+
+	fdbMap := map[string]string{}
+	for _, e := range fdb {
+		name, ok := portIdxToName[e.IfIndex]
+		if !ok || name == "" {
+			continue
+		}
+		fdbMap[e.MAC] = name
+	}
+
+	var uptimeSec float64
+	if sysInfo != nil {
+		uptimeSec = float64(sysInfo.UpTimeSec)
+	}
+
+	return &routerPolled{
+		cfg:       cfg,
+		uptimeSec: uptimeSec,
+		ports:     ethPorts,
+		fdb:       fdbMap,
+	}, nil
+}
+
+type snmpPortSample struct {
+	at      time.Time
+	rxBytes uint64
+	txBytes uint64
+}
+
+func (l *Live) snmpPrevPorts(routerID string) map[string]snmpPortSample {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.snmpPorts == nil {
+		return nil
+	}
+	return l.snmpPorts[routerID]
+}
+
+func (l *Live) snmpPortCache(routerID string, ports []EthPort) {
+	if l.snmpPorts == nil {
+		l.snmpPorts = map[string]map[string]snmpPortSample{}
+	}
+	samples := map[string]snmpPortSample{}
+	now := time.Now()
+	for _, p := range ports {
+		samples[p.ID] = snmpPortSample{at: now, rxBytes: p.RxBytes, txBytes: p.TxBytes}
+	}
+	l.snmpPorts[routerID] = samples
+}

--- a/server-go/internal/adapters/types.go
+++ b/server-go/internal/adapters/types.go
@@ -663,6 +663,12 @@ type RouterConfig struct {
 	// FirmwareTarget: versión objetivo configurada por el admin (issue #241).
 	// "" = sin comprobar (el live no emite aviso de firmware).
 	FirmwareTarget string `json:"firmware_target,omitempty"`
+	// SNMP (issue #309): credenciales para sondeo SNMP del switch gestionado.
+	// SnmpEnabled activa el poller SNMP; Community es la comunidad SNMPv2c
+	// ("" = "public"); Port es el puerto UDP (0 = 161 por defecto).
+	SnmpEnabled   bool   `json:"snmp_enabled"`
+	SnmpCommunity string `json:"snmp_community,omitempty"`
+	SnmpPort      int    `json:"snmp_port,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/server-go/internal/db/db.go
+++ b/server-go/internal/db/db.go
@@ -336,6 +336,10 @@ func Open(dataDir string, opts ...OpenOption) (*DB, error) {
 	migrate(sqldb, "routers", "mac", "ALTER TABLE routers ADD COLUMN mac TEXT")
 	// issue #241: target de firmware por router (string libre; NULL/"" = sin comprobar).
 	migrate(sqldb, "routers", "firmware_target", "ALTER TABLE routers ADD COLUMN firmware_target TEXT")
+	// issue #309: SNMP polling for managed switches.
+	migrate(sqldb, "routers", "snmp_enabled", "ALTER TABLE routers ADD COLUMN snmp_enabled INTEGER NOT NULL DEFAULT 0")
+	migrate(sqldb, "routers", "snmp_community", "ALTER TABLE routers ADD COLUMN snmp_community TEXT")
+	migrate(sqldb, "routers", "snmp_port", "ALTER TABLE routers ADD COLUMN snmp_port INTEGER NOT NULL DEFAULT 0")
 
 	// Si no hubo migración Node (instalación fresca creada por Go), marca la
 	// DB para que el siguiente arranque no dispare una "migración" espuria

--- a/server-go/internal/db/db.go
+++ b/server-go/internal/db/db.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	_ "modernc.org/sqlite"
+
+	"github.com/gnacho/netpulse/server-go/internal/portseries"
 )
 
 const (
@@ -234,6 +236,64 @@ CREATE TABLE IF NOT EXISTS update_history (
   error        TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_update_history_ts ON update_history(ts DESC);
+
+-- Per-port time series (issue #302): raw (7d) -> 5m (1y) -> daily (forever).
+CREATE TABLE IF NOT EXISTS port_series_raw (
+  router_id TEXT NOT NULL,
+  port_id TEXT NOT NULL,
+  ts INTEGER NOT NULL,
+  rx_bytes INTEGER NOT NULL DEFAULT 0,
+  tx_bytes INTEGER NOT NULL DEFAULT 0,
+  rx_errors INTEGER NOT NULL DEFAULT 0,
+  tx_errors INTEGER NOT NULL DEFAULT 0,
+  rx_frames INTEGER NOT NULL DEFAULT 0,
+  tx_frames INTEGER NOT NULL DEFAULT 0,
+  rx_bps REAL NOT NULL DEFAULT 0,
+  tx_bps REAL NOT NULL DEFAULT 0,
+  speed_mbps INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (router_id, port_id, ts)
+);
+CREATE INDEX IF NOT EXISTS idx_port_series_raw_ts ON port_series_raw(ts);
+CREATE INDEX IF NOT EXISTS idx_port_series_raw_rpt ON port_series_raw(router_id, port_id, ts);
+
+CREATE TABLE IF NOT EXISTS port_series_5m (
+  router_id TEXT NOT NULL,
+  port_id TEXT NOT NULL,
+  bucket_ts INTEGER NOT NULL,
+  n INTEGER NOT NULL,
+  rx_bytes INTEGER NOT NULL DEFAULT 0,
+  tx_bytes INTEGER NOT NULL DEFAULT 0,
+  rx_errors INTEGER NOT NULL DEFAULT 0,
+  tx_errors INTEGER NOT NULL DEFAULT 0,
+  rx_frames INTEGER NOT NULL DEFAULT 0,
+  tx_frames INTEGER NOT NULL DEFAULT 0,
+  rx_bps_min REAL NOT NULL DEFAULT 0,
+  rx_bps_max REAL NOT NULL DEFAULT 0,
+  rx_bps_avg REAL NOT NULL DEFAULT 0,
+  tx_bps_min REAL NOT NULL DEFAULT 0,
+  tx_bps_max REAL NOT NULL DEFAULT 0,
+  tx_bps_avg REAL NOT NULL DEFAULT 0,
+  speed_mbps INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (router_id, port_id, bucket_ts)
+);
+CREATE INDEX IF NOT EXISTS idx_port_series_5m_ts ON port_series_5m(bucket_ts);
+
+CREATE TABLE IF NOT EXISTS port_series_daily (
+  router_id TEXT NOT NULL,
+  port_id TEXT NOT NULL,
+  date TEXT NOT NULL,
+  n INTEGER NOT NULL,
+  rx_bytes INTEGER NOT NULL DEFAULT 0,
+  tx_bytes INTEGER NOT NULL DEFAULT 0,
+  rx_errors INTEGER NOT NULL DEFAULT 0,
+  tx_errors INTEGER NOT NULL DEFAULT 0,
+  rx_frames INTEGER NOT NULL DEFAULT 0,
+  tx_frames INTEGER NOT NULL DEFAULT 0,
+  rx_bps_avg REAL NOT NULL DEFAULT 0,
+  tx_bps_avg REAL NOT NULL DEFAULT 0,
+  speed_mbps INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (router_id, port_id, date)
+);
 `
 
 
@@ -247,6 +307,8 @@ type DB struct {
 	// rollbackJournal: journal DELETE en vez de WAL (modo on-box, Fase 9 R6).
 	// Los wal_checkpoint de mantenimiento se omiten en este modo.
 	rollbackJournal bool
+	// PortSeries: per-port time series store (issue #302).
+	PortSeries *portseries.Store
 }
 
 // NowMS devuelve el epoch actual en milisegundos (como Date.now()).
@@ -352,6 +414,12 @@ func Open(dataDir string, opts ...OpenOption) (*DB, error) {
 	}
 
 	d := &DB{DB: sqldb, Path: dbPath, stop: make(chan struct{}), rollbackJournal: o.rollbackJournal}
+	ps, err := portseries.NewStore(sqldb)
+	if err != nil {
+		sqldb.Close()
+		return nil, fmt.Errorf("port_series store: %w", err)
+	}
+	d.PortSeries = ps
 	d.wg.Add(1)
 	go d.maintenanceLoop()
 	return d, nil
@@ -473,6 +541,11 @@ func (d *DB) NightlyJob() {
 	}
 
 	log.Printf("[netpulse] rollup nocturno: fin (%s)", time.Since(start).Round(time.Millisecond))
+
+	// Per-port time series rollup (issue #302).
+	if d.PortSeries != nil {
+		d.PortSeries.NightlyJob()
+	}
 }
 
 // BucketMS es el tamaño del bucket medio en ms (5 minutos).

--- a/server-go/internal/httpapi/beacon.go
+++ b/server-go/internal/httpapi/beacon.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/gnacho/netpulse/agent/probe"
 	"github.com/gnacho/netpulse/server-go/internal/alerts"
+	"github.com/gnacho/netpulse/server-go/internal/portseries"
 )
 
 // beaconPort: una boca del beacon. n = número 1..9; l = código de link
@@ -225,6 +226,7 @@ func (s *server) ingestBeacon(src string, raw []byte) {
 		}
 		ports = append(ports, ep)
 	}
+	s.recordBeaconPortSamples(p.Slug, p.Ports)
 	// Alertas SFP (#313): RX baja o temperatura alta en módulos ópticos.
 	// Se emiten aquí (no en polledFromAgent) para que el dedup del motor
 	// colapse duplicados entre beacons del mismo switch.
@@ -380,6 +382,48 @@ func (s *server) emitSFPAlerts(slug string, labels map[string]string, sfpByPort 
 				Description: fmt.Sprintf("Temperatura %.1f °C (umbral %.0f °C)", sfp.Temperature, sfpAlertTempHigh),
 			})
 		}
+	}
+}
+
+// recordBeaconPortSamples persists beacon frame counts as port series samples
+// (issue #302). Beacon ports carry cumulative tx/rx frame counts and link speed
+// but no byte counters (the 8051 firmware does not track bytes per port).
+func (s *server) recordBeaconPortSamples(slug string, bps []beaconPort) {
+	if s.db == nil || s.db.PortSeries == nil || len(bps) == 0 {
+		return
+	}
+	now := time.Now()
+	for _, bp := range bps {
+		if bp.N < 1 || bp.N > 32 {
+			continue
+		}
+		speedMbps := 0
+		if sp, ok := beaconLinkSpeed[bp.L]; ok && bp.L != 0 {
+			switch {
+			case sp == "10G":
+				speedMbps = 10000
+			case sp == "5G":
+				speedMbps = 5000
+			case sp == "2.5G":
+				speedMbps = 2500
+			case sp == "1G":
+				speedMbps = 1000
+			case sp == "500M":
+				speedMbps = 500
+			case sp == "100M":
+				speedMbps = 100
+			case sp == "10M":
+				speedMbps = 10
+			}
+		}
+		_ = s.db.PortSeries.RecordSample(portseries.PortSample{
+			RouterID:  slug,
+			PortID:    fmt.Sprintf("lan%d", bp.N),
+			TS:        now,
+			RxFrames:  uint64(bp.Rx),
+			TxFrames:  uint64(bp.Tx),
+			SpeedMbps: speedMbps,
+		})
 	}
 }
 

--- a/server-go/internal/httpapi/config.go
+++ b/server-go/internal/httpapi/config.go
@@ -89,6 +89,10 @@ type routerInput struct {
 	AgentOnly bool    `json:"agent_only"`
 	// FirmwareTarget: versión objetivo del firmware (issue #241; opcional).
 	FirmwareTarget *string `json:"firmware_target"`
+	// SNMP (issue #309): credenciales para sondeo SNMP del switch gestionado.
+	SnmpEnabled   *bool   `json:"snmp_enabled"`
+	SnmpCommunity *string `json:"snmp_community"`
+	SnmpPort      *int    `json:"snmp_port"`
 }
 
 // validateHost replica hostSchema (trim, 1..253, regex). Devuelve el valor
@@ -148,6 +152,22 @@ func (s *server) handleAddConfigRouter(w http.ResponseWriter, r *http.Request) {
 	if in.FirmwareTarget != nil {
 		firmwareTarget = strings.TrimSpace(*in.FirmwareTarget)
 	}
+	snmpEnabled := false
+	if in.SnmpEnabled != nil {
+		snmpEnabled = *in.SnmpEnabled
+	}
+	snmpCommunity := ""
+	if in.SnmpCommunity != nil {
+		snmpCommunity = strings.TrimSpace(*in.SnmpCommunity)
+	}
+	snmpPort := 0
+	if in.SnmpPort != nil {
+		snmpPort = *in.SnmpPort
+		if snmpPort < 0 || snmpPort > 65535 {
+			writeError(w, http.StatusBadRequest, "invalid_input", "snmp_port must be between 0 and 65535")
+			return
+		}
+	}
 	for _, rt := range routerstore.ListRouters(s.db.DB) {
 		if rt.Host == host {
 			writeError(w, http.StatusConflict, "duplicate_host", "Ya hay un router con "+host)
@@ -157,6 +177,7 @@ func (s *server) handleAddConfigRouter(w http.ResponseWriter, r *http.Request) {
 	created, err := routerstore.AddRouter(s.db.DB, routerstore.AddInput{
 		Name: name, Host: host, Type: typ, IsGateway: in.Gateway, AgentOnly: in.AgentOnly,
 		FirmwareTarget: firmwareTarget,
+		SnmpEnabled: snmpEnabled, SnmpCommunity: snmpCommunity, SnmpPort: snmpPort,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error")
@@ -230,10 +251,25 @@ func (s *server) handleUpdateConfigRouter(w http.ResponseWriter, r *http.Request
 		v := strings.TrimSpace(*in.FirmwareTarget)
 		firmwareTarget = &v
 	}
+	var snmpPort *int
+	if in.SnmpPort != nil {
+		p := *in.SnmpPort
+		if p < 0 || p > 65535 {
+			writeError(w, http.StatusBadRequest, "invalid_input", "snmp_port must be between 0 and 65535")
+			return
+		}
+		snmpPort = &p
+	}
+	var snmpCommunity *string
+	if in.SnmpCommunity != nil {
+		v := strings.TrimSpace(*in.SnmpCommunity)
+		snmpCommunity = &v
+	}
 	updated, ok := routerstore.UpdateRouter(s.db.DB, id, routerstore.UpdateInput{
 		Name: name, Host: host, Type: typ,
 		IsGateway: &gw, AgentOnly: &ao,
 		FirmwareTarget: firmwareTarget,
+		SnmpEnabled: in.SnmpEnabled, SnmpCommunity: snmpCommunity, SnmpPort: snmpPort,
 	})
 	if !ok {
 		writeError(w, http.StatusNotFound, "not_found")

--- a/server-go/internal/httpapi/config_test.go
+++ b/server-go/internal/httpapi/config_test.go
@@ -319,3 +319,45 @@ func TestConfigRoutersFirmwareTarget(t *testing.T) {
 		t.Fatalf("firmware_target persistido=%q, esperaba 24.10.1", found)
 	}
 }
+
+func TestConfigRoutersSNMP(t *testing.T) {
+	srv := makeTestServer(t)
+	_, cookie, _ := loginCookie(t, srv.URL, "admin", "test123456")
+
+	res := doReq(t, "POST", srv.URL+"/api/config/routers", cookie,
+		`{"name":"sw1","host":"192.168.8.20","type":"managed-switch","snmp_enabled":true,"snmp_community":"public","snmp_port":161}`)
+	if res.StatusCode != 201 {
+		t.Fatalf("POST router: %d", res.StatusCode)
+	}
+	body := readJSON(t, res)
+	router := body["router"].(map[string]any)
+	if router["snmp_enabled"] != true {
+		t.Fatalf("snmp_enabled tras alta: %v", router)
+	}
+	if router["snmp_community"] != "public" {
+		t.Fatalf("snmp_community tras alta: %v", router)
+	}
+	if router["snmp_port"] != float64(161) {
+		t.Fatalf("snmp_port tras alta: %v", router)
+	}
+
+	res = doReq(t, "PUT", srv.URL+"/api/config/routers/sw1", cookie,
+		`{"host":"192.168.8.20","snmp_enabled":false,"snmp_community":"secret"}`)
+	if res.StatusCode != 200 {
+		t.Fatalf("PUT snmp: %d", res.StatusCode)
+	}
+	body = readJSON(t, res)
+	rt := body["router"].(map[string]any)
+	if rt["snmp_enabled"] != false {
+		t.Fatalf("snmp_enabled tras PUT: %v", rt)
+	}
+	if rt["snmp_community"] != "secret" {
+		t.Fatalf("snmp_community tras PUT: %v", rt)
+	}
+
+	res = doReq(t, "POST", srv.URL+"/api/config/routers", cookie,
+		`{"name":"sw2","host":"192.168.8.21","type":"managed-switch","snmp_port":99999}`)
+	if res.StatusCode != 400 {
+		t.Fatalf("POST invalid snmp_port: %d; want 400", res.StatusCode)
+	}
+}

--- a/server-go/internal/httpapi/data.go
+++ b/server-go/internal/httpapi/data.go
@@ -7,10 +7,12 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gnacho/netpulse/server-go/internal/adapters"
 	"github.com/gnacho/netpulse/server-go/internal/alerts"
 	"github.com/gnacho/netpulse/server-go/internal/deviceevents"
+	"github.com/gnacho/netpulse/server-go/internal/portseries"
 	"github.com/gnacho/netpulse/server-go/internal/roamevents"
 )
 
@@ -425,4 +427,51 @@ func (s *server) handleAdguardClients(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"clients": clients})
+}
+
+// handlePortSeries: GET /api/routers/{id}/ports/{portId}/series
+// Query params: from (unix seconds), to (unix seconds), resolution (raw|5m|daily).
+func (s *server) handlePortSeries(w http.ResponseWriter, r *http.Request) {
+	if s.db == nil || s.db.PortSeries == nil {
+		writeError(w, http.StatusServiceUnavailable, "unavailable")
+		return
+	}
+	routerID := r.PathValue("id")
+	portID := r.PathValue("portId")
+	q := r.URL.Query()
+	now := time.Now()
+	to := now
+	from := now.Add(-24 * time.Hour)
+	if v := q.Get("from"); v != "" {
+		if ts, err := strconv.ParseInt(v, 10, 64); err == nil {
+			from = time.Unix(ts, 0)
+		}
+	}
+	if v := q.Get("to"); v != "" {
+		if ts, err := strconv.ParseInt(v, 10, 64); err == nil {
+			to = time.Unix(ts, 0)
+		}
+	}
+	resolution := q.Get("resolution")
+	if resolution == "" {
+		resolution = portseries.Resolution(from, to)
+	}
+	if resolution != "raw" && resolution != "5m" && resolution != "daily" {
+		writeError(w, http.StatusBadRequest, "invalid_resolution")
+		return
+	}
+	points, err := s.db.PortSeries.GetSeries(routerID, portID, from, to, resolution)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "query_error", err.Error())
+		return
+	}
+	if points == nil {
+		points = []portseries.PortPoint{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"points":     points,
+		"resolution": resolution,
+		"routerId":   routerID,
+		"portId":     portID,
+	})
 }

--- a/server-go/internal/httpapi/httpapi_test.go
+++ b/server-go/internal/httpapi/httpapi_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gnacho/netpulse/server-go/internal/config"
 	"github.com/gnacho/netpulse/server-go/internal/db"
 	"github.com/gnacho/netpulse/server-go/internal/httpapi"
+	"github.com/gnacho/netpulse/server-go/internal/portseries"
 	"github.com/gnacho/netpulse/server-go/internal/sse"
 )
 
@@ -853,5 +854,90 @@ func TestWebhookDLQEndpoint(t *testing.T) {
 	}
 	if body["total"].(float64) != 0 {
 		t.Fatalf("DLQ vacío esperado, total=%v", body["total"])
+	}
+}
+
+func TestPortSeriesEndpoint(t *testing.T) {
+	srv := makeTestServer(t)
+	defer srv.Close()
+	_, cookie, _ := loginCookie(t, srv.URL, "admin", "test123456")
+
+	if srv.db.PortSeries == nil {
+		t.Fatal("PortSeries store not initialized")
+	}
+	now := time.Now()
+	err := srv.db.PortSeries.RecordSample(portseries.PortSample{
+		RouterID: "rt1", PortID: "lan1", TS: now,
+		RxBytes: 1000, TxBytes: 2000, RxBps: 500, TxBps: 1000, SpeedMbps: 1000,
+	})
+	if err != nil {
+		t.Fatalf("record sample: %v", err)
+	}
+
+	from := now.Add(-time.Hour).Unix()
+	to := now.Add(time.Hour).Unix()
+	req, _ := http.NewRequest("GET",
+		fmt.Sprintf("%s/api/routers/rt1/ports/lan1/series?from=%d&to=%d", srv.URL, from, to), nil)
+	req.Header.Set("Cookie", "session="+cookie)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+	body := readJSON(t, res)
+	if body["resolution"] != "raw" {
+		t.Errorf("expected raw resolution, got %v", body["resolution"])
+	}
+	points, ok := body["points"].([]any)
+	if !ok {
+		t.Fatalf("points is not an array: %T", body["points"])
+	}
+	if len(points) == 0 {
+		t.Error("expected at least 1 point, got 0")
+	}
+}
+
+func TestPortSeriesAutoResolution(t *testing.T) {
+	srv := makeTestServer(t)
+	defer srv.Close()
+	_, cookie, _ := loginCookie(t, srv.URL, "admin", "test123456")
+
+	now := time.Now()
+	from := now.Add(-60 * 24 * time.Hour).Unix()
+	to := now.Unix()
+	req, _ := http.NewRequest("GET",
+		fmt.Sprintf("%s/api/routers/rt1/ports/lan1/series?from=%d&to=%d", srv.URL, from, to), nil)
+	req.Header.Set("Cookie", "session="+cookie)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+	body := readJSON(t, res)
+	if body["resolution"] != "daily" {
+		t.Errorf("expected daily resolution for 60d range, got %v", body["resolution"])
+	}
+}
+
+func TestPortSeriesInvalidResolution(t *testing.T) {
+	srv := makeTestServer(t)
+	defer srv.Close()
+	_, cookie, _ := loginCookie(t, srv.URL, "admin", "test123456")
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api/routers/rt1/ports/lan1/series?resolution=invalid", nil)
+	req.Header.Set("Cookie", "session="+cookie)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 400 {
+		t.Errorf("expected 400 for invalid resolution, got %d", res.StatusCode)
 	}
 }

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -196,6 +196,7 @@ func NewHandler(d Deps) http.Handler {
 	mux.HandleFunc("GET /api/roam-events", s.handleRoamEvents)
 	mux.HandleFunc("GET /api/device-events", s.handleDeviceEvents)
 	mux.HandleFunc("GET /api/adguard/clients", s.handleAdguardClients)
+	mux.HandleFunc("GET /api/routers/{id}/ports/{portId}/series", s.handlePortSeries)
 	mux.HandleFunc("GET /api/system/info", s.handleSystemInfo)
 	mux.HandleFunc("GET /api/reports/weekly", s.handleWeeklyReport)
 	mux.HandleFunc("GET /api/reports/availability", s.handleAvailabilityReport)

--- a/server-go/internal/portseries/portseries.go
+++ b/server-go/internal/portseries/portseries.go
@@ -1,0 +1,328 @@
+// Package portseries: per-port time series with tiered retention (issue #302).
+// raw (7d) -> buckets 5m (1 year) -> daily (forever).
+package portseries
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"time"
+)
+
+const (
+	RawRetentionMS     = 7 * 24 * 60 * 60 * 1000
+	BucketRetentionMS  = 365 * 24 * 60 * 60 * 1000
+	BucketMS           = 5 * 60 * 1000
+)
+
+// PortSample is a single data point for a port.
+type PortSample struct {
+	RouterID  string
+	PortID    string
+	TS        time.Time
+	RxBytes   uint64
+	TxBytes   uint64
+	RxErrors  uint64
+	TxErrors  uint64
+	RxFrames  uint64
+	TxFrames  uint64
+	RxBps     float64
+	TxBps     float64
+	SpeedMbps int
+}
+
+// PortPoint is a time-series point returned by GetSeries.
+type PortPoint struct {
+	TS        time.Time `json:"ts"`
+	RxBytes   uint64    `json:"rxBytes"`
+	TxBytes   uint64    `json:"txBytes"`
+	RxErrors  uint64    `json:"rxErrors"`
+	TxErrors  uint64    `json:"txErrors"`
+	RxBps     float64   `json:"rxBps"`
+	TxBps     float64   `json:"txBps"`
+	SpeedMbps int       `json:"speedMbps"`
+}
+
+// SchemaSQL returns the DDL for the port series tables.
+func SchemaSQL() string {
+	return `
+CREATE TABLE IF NOT EXISTS port_series_raw (
+  router_id TEXT NOT NULL,
+  port_id TEXT NOT NULL,
+  ts INTEGER NOT NULL,
+  rx_bytes INTEGER NOT NULL DEFAULT 0,
+  tx_bytes INTEGER NOT NULL DEFAULT 0,
+  rx_errors INTEGER NOT NULL DEFAULT 0,
+  tx_errors INTEGER NOT NULL DEFAULT 0,
+  rx_frames INTEGER NOT NULL DEFAULT 0,
+  tx_frames INTEGER NOT NULL DEFAULT 0,
+  rx_bps REAL NOT NULL DEFAULT 0,
+  tx_bps REAL NOT NULL DEFAULT 0,
+  speed_mbps INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (router_id, port_id, ts)
+);
+CREATE INDEX IF NOT EXISTS idx_port_series_raw_ts ON port_series_raw(ts);
+CREATE INDEX IF NOT EXISTS idx_port_series_raw_router_port_ts ON port_series_raw(router_id, port_id, ts);
+
+CREATE TABLE IF NOT EXISTS port_series_5m (
+  router_id TEXT NOT NULL,
+  port_id TEXT NOT NULL,
+  bucket_ts INTEGER NOT NULL,
+  n INTEGER NOT NULL,
+  rx_bytes INTEGER NOT NULL DEFAULT 0,
+  tx_bytes INTEGER NOT NULL DEFAULT 0,
+  rx_errors INTEGER NOT NULL DEFAULT 0,
+  tx_errors INTEGER NOT NULL DEFAULT 0,
+  rx_frames INTEGER NOT NULL DEFAULT 0,
+  tx_frames INTEGER NOT NULL DEFAULT 0,
+  rx_bps_min REAL NOT NULL DEFAULT 0,
+  rx_bps_max REAL NOT NULL DEFAULT 0,
+  rx_bps_avg REAL NOT NULL DEFAULT 0,
+  tx_bps_min REAL NOT NULL DEFAULT 0,
+  tx_bps_max REAL NOT NULL DEFAULT 0,
+  tx_bps_avg REAL NOT NULL DEFAULT 0,
+  speed_mbps INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (router_id, port_id, bucket_ts)
+);
+CREATE INDEX IF NOT EXISTS idx_port_series_5m_ts ON port_series_5m(bucket_ts);
+
+CREATE TABLE IF NOT EXISTS port_series_daily (
+  router_id TEXT NOT NULL,
+  port_id TEXT NOT NULL,
+  date TEXT NOT NULL,
+  n INTEGER NOT NULL,
+  rx_bytes INTEGER NOT NULL DEFAULT 0,
+  tx_bytes INTEGER NOT NULL DEFAULT 0,
+  rx_errors INTEGER NOT NULL DEFAULT 0,
+  tx_errors INTEGER NOT NULL DEFAULT 0,
+  rx_frames INTEGER NOT NULL DEFAULT 0,
+  tx_frames INTEGER NOT NULL DEFAULT 0,
+  rx_bps_avg REAL NOT NULL DEFAULT 0,
+  tx_bps_avg REAL NOT NULL DEFAULT 0,
+  speed_mbps INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (router_id, port_id, date)
+);
+`
+}
+
+// Store wraps a *sql.DB for port series operations.
+type Store struct {
+	db *sql.DB
+}
+
+// NewStore creates a Store and ensures tables exist.
+func NewStore(db *sql.DB) (*Store, error) {
+	if _, err := db.Exec(SchemaSQL()); err != nil {
+		return nil, fmt.Errorf("port_series schema: %w", err)
+	}
+	return &Store{db: db}, nil
+}
+
+// RecordSample inserts a raw sample.
+func (s *Store) RecordSample(sample PortSample) error {
+	if sample.RouterID == "" || sample.PortID == "" {
+		return nil
+	}
+	tsMs := sample.TS.UnixMilli()
+	_, err := s.db.Exec(`INSERT OR REPLACE INTO port_series_raw
+		(router_id, port_id, ts, rx_bytes, tx_bytes, rx_errors, tx_errors,
+		 rx_frames, tx_frames, rx_bps, tx_bps, speed_mbps)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		sample.RouterID, sample.PortID, tsMs,
+		sample.RxBytes, sample.TxBytes, sample.RxErrors, sample.TxErrors,
+		sample.RxFrames, sample.TxFrames, sample.RxBps, sample.TxBps,
+		sample.SpeedMbps)
+	return err
+}
+
+// Resolution selects the tier based on time range.
+func Resolution(from, to time.Time) string {
+	dur := to.Sub(from)
+	if dur <= 24*time.Hour {
+		return "raw"
+	}
+	if dur <= 30*24*time.Hour {
+		return "5m"
+	}
+	return "daily"
+}
+
+// GetSeries reads points for a port in [from, to] at the given resolution.
+func (s *Store) GetSeries(routerID, portID string, from, to time.Time, resolution string) ([]PortPoint, error) {
+	fromMs := from.UnixMilli()
+	toMs := to.UnixMilli()
+	switch resolution {
+	case "raw":
+		return s.getRaw(routerID, portID, fromMs, toMs)
+	case "5m":
+		return s.get5m(routerID, portID, fromMs, toMs)
+	case "daily":
+		return s.getDaily(routerID, portID, from, to)
+	default:
+		return nil, fmt.Errorf("unknown resolution: %s", resolution)
+	}
+}
+
+func (s *Store) getRaw(routerID, portID string, fromMs, toMs int64) ([]PortPoint, error) {
+	rows, err := s.db.Query(`SELECT ts, rx_bytes, tx_bytes, rx_errors, tx_errors,
+		rx_bps, tx_bps, speed_mbps FROM port_series_raw
+		WHERE router_id=? AND port_id=? AND ts>=? AND ts<=?
+		ORDER BY ts`, routerID, portID, fromMs, toMs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PortPoint
+	for rows.Next() {
+		var tsMs int64
+		var p PortPoint
+		if err := rows.Scan(&tsMs, &p.RxBytes, &p.TxBytes, &p.RxErrors, &p.TxErrors,
+			&p.RxBps, &p.TxBps, &p.SpeedMbps); err != nil {
+			return nil, err
+		}
+		p.TS = time.UnixMilli(tsMs)
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) get5m(routerID, portID string, fromMs, toMs int64) ([]PortPoint, error) {
+	rows, err := s.db.Query(`SELECT bucket_ts, rx_bytes, tx_bytes, rx_errors, tx_errors,
+		rx_bps_avg, tx_bps_avg, speed_mbps FROM port_series_5m
+		WHERE router_id=? AND port_id=? AND bucket_ts>=? AND bucket_ts<=?
+		ORDER BY bucket_ts`, routerID, portID, fromMs, toMs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PortPoint
+	for rows.Next() {
+		var tsMs int64
+		var p PortPoint
+		if err := rows.Scan(&tsMs, &p.RxBytes, &p.TxBytes, &p.RxErrors, &p.TxErrors,
+			&p.RxBps, &p.TxBps, &p.SpeedMbps); err != nil {
+			return nil, err
+		}
+		p.TS = time.UnixMilli(tsMs)
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) getDaily(routerID, portID string, from, to time.Time) ([]PortPoint, error) {
+	fromDate := from.UTC().Format("2006-01-02")
+	toDate := to.UTC().Format("2006-01-02")
+	rows, err := s.db.Query(`SELECT date, rx_bytes, tx_bytes, rx_errors, tx_errors,
+		rx_bps_avg, tx_bps_avg, speed_mbps FROM port_series_daily
+		WHERE router_id=? AND port_id=? AND date>=? AND date<=?
+		ORDER BY date`, routerID, portID, fromDate, toDate)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PortPoint
+	for rows.Next() {
+		var dateStr string
+		var p PortPoint
+		if err := rows.Scan(&dateStr, &p.RxBytes, &p.TxBytes, &p.RxErrors, &p.TxErrors,
+			&p.RxBps, &p.TxBps, &p.SpeedMbps); err != nil {
+			return nil, err
+		}
+		t, err := time.Parse("2006-01-02", dateStr)
+		if err != nil {
+			continue
+		}
+		p.TS = t
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// RollupRawTo5m aggregates raw samples into 5-min buckets.
+func (s *Store) RollupRawTo5m(window time.Duration) error {
+	since := time.Now().Add(-window).UnixMilli()
+	_, err := s.db.Exec(`INSERT OR REPLACE INTO port_series_5m
+		(router_id, port_id, bucket_ts, n,
+		 rx_bytes, tx_bytes, rx_errors, tx_errors, rx_frames, tx_frames,
+		 rx_bps_min, rx_bps_max, rx_bps_avg,
+		 tx_bps_min, tx_bps_max, tx_bps_avg, speed_mbps)
+		SELECT router_id, port_id,
+			(ts / ?) * ?,
+			COUNT(*),
+			MAX(rx_bytes), MAX(tx_bytes), MAX(rx_errors), MAX(tx_errors),
+			MAX(rx_frames), MAX(tx_frames),
+			MIN(rx_bps), MAX(rx_bps), AVG(rx_bps),
+			MIN(tx_bps), MAX(tx_bps), AVG(tx_bps),
+			MAX(speed_mbps)
+		FROM port_series_raw
+		WHERE ts >= ?
+		GROUP BY router_id, port_id, (ts / ?) * ?`,
+		BucketMS, BucketMS, since, BucketMS, BucketMS)
+	return err
+}
+
+// Rollup5mToDaily aggregates 5-m buckets into daily rows.
+func (s *Store) Rollup5mToDaily(window time.Duration) error {
+	since := time.Now().Add(-window).UnixMilli()
+	_, err := s.db.Exec(`INSERT OR REPLACE INTO port_series_daily
+		(router_id, port_id, date, n,
+		 rx_bytes, tx_bytes, rx_errors, tx_errors, rx_frames, tx_frames,
+		 rx_bps_avg, tx_bps_avg, speed_mbps)
+		SELECT router_id, port_id,
+			strftime('%Y-%m-%d', bucket_ts / 1000, 'unixepoch'),
+			SUM(n),
+			MAX(rx_bytes), MAX(tx_bytes), MAX(rx_errors), MAX(tx_errors),
+			MAX(rx_frames), MAX(tx_frames),
+			AVG(rx_bps_avg), AVG(tx_bps_avg),
+			MAX(speed_mbps)
+		FROM port_series_5m
+		WHERE bucket_ts >= ?
+		GROUP BY router_id, port_id, strftime('%Y-%m-%d', bucket_ts / 1000, 'unixepoch')`,
+		since)
+	return err
+}
+
+// PurgeRaw deletes raw samples older than retention.
+func (s *Store) PurgeRaw() (int64, error) {
+	cutoff := time.Now().UnixMilli() - RawRetentionMS
+	res, err := s.db.Exec("DELETE FROM port_series_raw WHERE ts < ?", cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// Purge5m deletes 5-m buckets older than retention.
+func (s *Store) Purge5m() (int64, error) {
+	cutoff := time.Now().UnixMilli() - BucketRetentionMS
+	res, err := s.db.Exec("DELETE FROM port_series_5m WHERE bucket_ts < ?", cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// NightlyJob runs the full rollup + purge cycle.
+func (s *Store) NightlyJob() {
+	start := time.Now()
+	log.Printf("[netpulse:portseries] nightly rollup: start")
+
+	if err := s.RollupRawTo5m(48 * time.Hour); err != nil {
+		log.Printf("[netpulse:portseries] rollup raw->5m error: %v", err)
+	}
+	if err := s.Rollup5mToDaily(35 * 24 * time.Hour); err != nil {
+		log.Printf("[netpulse:portseries] rollup 5m->daily error: %v", err)
+	}
+	if n, err := s.PurgeRaw(); err != nil {
+		log.Printf("[netpulse:portseries] purge raw error: %v", err)
+	} else if n > 0 {
+		log.Printf("[netpulse:portseries] purged %d raw samples", n)
+	}
+	if n, err := s.Purge5m(); err != nil {
+		log.Printf("[netpulse:portseries] purge 5m error: %v", err)
+	} else if n > 0 {
+		log.Printf("[netpulse:portseries] purged %d 5m buckets", n)
+	}
+
+	log.Printf("[netpulse:portseries] nightly rollup: done (%s)", time.Since(start).Round(time.Millisecond))
+}

--- a/server-go/internal/portseries/portseries_test.go
+++ b/server-go/internal/portseries/portseries_test.go
@@ -1,0 +1,235 @@
+package portseries
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func openTestDB(t *testing.T) *Store {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:?_pragma=journal_mode(WAL)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	s, err := NewStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return s
+}
+
+func TestSchemaCreation(t *testing.T) {
+	s := openTestDB(t)
+	if s == nil {
+		t.Fatal("nil store")
+	}
+	for _, tbl := range []string{"port_series_raw", "port_series_5m", "port_series_daily"} {
+		var name string
+		err := s.db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name=?", tbl).Scan(&name)
+		if err != nil {
+			t.Errorf("table %s not created: %v", tbl, err)
+		}
+	}
+}
+
+func TestRecordAndReadRaw(t *testing.T) {
+	s := openTestDB(t)
+	now := time.Now().Truncate(time.Millisecond)
+	sample := PortSample{
+		RouterID: "rt1", PortID: "lan1", TS: now,
+		RxBytes: 1000, TxBytes: 2000, RxErrors: 1, TxErrors: 0,
+		RxFrames: 10, TxFrames: 20, RxBps: 500.0, TxBps: 1000.0, SpeedMbps: 1000,
+	}
+	if err := s.RecordSample(sample); err != nil {
+		t.Fatal(err)
+	}
+	from := now.Add(-time.Hour)
+	to := now.Add(time.Hour)
+	points, err := s.GetSeries("rt1", "lan1", from, to, "raw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(points) != 1 {
+		t.Fatalf("expected 1 point, got %d", len(points))
+	}
+	p := points[0]
+	if p.RxBytes != 1000 || p.TxBytes != 2000 || p.RxErrors != 1 || p.RxBps != 500.0 || p.TxBps != 1000.0 || p.SpeedMbps != 1000 {
+		t.Errorf("unexpected point: %+v", p)
+	}
+}
+
+func TestRecordEmptyRouterPort(t *testing.T) {
+	s := openTestDB(t)
+	err := s.RecordSample(PortSample{RouterID: "", PortID: "lan1", TS: time.Now()})
+	if err != nil {
+		t.Errorf("empty router should be skipped silently, got: %v", err)
+	}
+	err = s.RecordSample(PortSample{RouterID: "rt1", PortID: "", TS: time.Now()})
+	if err != nil {
+		t.Errorf("empty port should be skipped silently, got: %v", err)
+	}
+}
+
+func TestRollupRawTo5m(t *testing.T) {
+	s := openTestDB(t)
+	base := time.Now().Truncate(time.Minute).Add(-10 * time.Minute)
+	for i := 0; i < 12; i++ {
+		ts := base.Add(time.Duration(i) * 30 * time.Second)
+		err := s.RecordSample(PortSample{
+			RouterID: "rt1", PortID: "lan1", TS: ts,
+			RxBytes: uint64(100 * i), TxBytes: uint64(200 * i),
+			RxBps: float64(i * 100), TxBps: float64(i * 200), SpeedMbps: 1000,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := s.RollupRawTo5m(time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	points, err := s.GetSeries("rt1", "lan1", base.Add(-time.Hour), base.Add(time.Hour), "5m")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(points) == 0 {
+		t.Fatal("expected 5m buckets, got 0")
+	}
+}
+
+func TestRollup5mToDaily(t *testing.T) {
+	s := openTestDB(t)
+	base := time.Now().Truncate(time.Minute).Add(-2 * time.Hour)
+	for i := 0; i < 24; i++ {
+		ts := base.Add(time.Duration(i) * 5 * time.Minute)
+		err := s.RecordSample(PortSample{
+			RouterID: "rt1", PortID: "lan1", TS: ts,
+			RxBytes: uint64(1000), TxBytes: uint64(2000),
+			RxBps: 100.0, TxBps: 200.0, SpeedMbps: 1000,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := s.RollupRawTo5m(3 * time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Rollup5mToDaily(3 * time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	points, err := s.GetSeries("rt1", "lan1", base.Add(-24*time.Hour), base.Add(24*time.Hour), "daily")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(points) == 0 {
+		t.Fatal("expected daily points, got 0")
+	}
+}
+
+func TestResolution(t *testing.T) {
+	now := time.Now()
+	if r := Resolution(now.Add(-2*time.Hour), now); r != "raw" {
+		t.Errorf("2h should be raw, got %s", r)
+	}
+	if r := Resolution(now.Add(-7*24*time.Hour), now); r != "5m" {
+		t.Errorf("7d should be 5m, got %s", r)
+	}
+	if r := Resolution(now.Add(-60*24*time.Hour), now); r != "daily" {
+		t.Errorf("60d should be daily, got %s", r)
+	}
+}
+
+func TestGetSeriesEmpty(t *testing.T) {
+	s := openTestDB(t)
+	now := time.Now()
+	for _, res := range []string{"raw", "5m", "daily"} {
+		points, err := s.GetSeries("nonexistent", "lan1", now.Add(-time.Hour), now, res)
+		if err != nil {
+			t.Errorf("resolution %s: unexpected error: %v", res, err)
+		}
+		if len(points) != 0 {
+			t.Errorf("resolution %s: expected 0 points, got %d", res, len(points))
+		}
+	}
+}
+
+func TestPurgeRaw(t *testing.T) {
+	s := openTestDB(t)
+	old := time.Now().Add(-8 * 24 * time.Hour)
+	recent := time.Now().Add(-1 * time.Hour)
+	for _, ts := range []time.Time{old, recent} {
+		if err := s.RecordSample(PortSample{
+			RouterID: "rt1", PortID: "lan1", TS: ts,
+			RxBytes: 100, TxBytes: 200, RxBps: 10, TxBps: 20,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	n, err := s.PurgeRaw()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 purged, got %d", n)
+	}
+	points, err := s.GetSeries("rt1", "lan1", time.Now().Add(-2*time.Hour), time.Now(), "raw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(points) != 1 {
+		t.Errorf("expected 1 remaining raw point, got %d", len(points))
+	}
+}
+
+func TestPurge5m(t *testing.T) {
+	s := openTestDB(t)
+	old := time.Now().Add(-400 * 24 * time.Hour)
+	recent := time.Now().Add(-1 * time.Hour)
+	for _, ts := range []time.Time{old, recent} {
+		bucketMs := (ts.UnixMilli() / int64(BucketMS)) * int64(BucketMS)
+		_, err := s.db.Exec(`INSERT OR REPLACE INTO port_series_5m
+			(router_id, port_id, bucket_ts, n, rx_bytes, tx_bytes,
+			 rx_errors, tx_errors, rx_frames, tx_frames,
+			 rx_bps_min, rx_bps_max, rx_bps_avg,
+			 tx_bps_min, tx_bps_max, tx_bps_avg, speed_mbps)
+			VALUES (?, ?, ?, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1000)`,
+			"rt1", "lan1", bucketMs)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	n, err := s.Purge5m()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 purged, got %d", n)
+	}
+}
+
+func TestNightlyJobIntegration(t *testing.T) {
+	s := openTestDB(t)
+	base := time.Now().Truncate(time.Minute).Add(-10 * time.Minute)
+	for i := 0; i < 12; i++ {
+		ts := base.Add(time.Duration(i) * 30 * time.Second)
+		if err := s.RecordSample(PortSample{
+			RouterID: "rt1", PortID: "lan1", TS: ts,
+			RxBytes: uint64(100 * i), TxBytes: uint64(200 * i),
+			RxBps: float64(i * 100), TxBps: float64(i * 200), SpeedMbps: 1000,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s.NightlyJob()
+	points, err := s.GetSeries("rt1", "lan1", base.Add(-time.Hour), base.Add(time.Hour), "5m")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(points) == 0 {
+		t.Error("expected 5m buckets after nightly job, got 0")
+	}
+}

--- a/server-go/internal/routerstore/routerstore.go
+++ b/server-go/internal/routerstore/routerstore.go
@@ -27,7 +27,7 @@ const probeTimeout = 4 * time.Second
 // ListRouters devuelve la tabla routers ordenada is_gateway DESC,
 // created_at ASC, con is_gateway como booleano.
 func ListRouters(db *sql.DB) []adapters.RouterConfig {
-	rows, err := db.Query("SELECT id, name, host, type, is_gateway, agent_only, firmware_target, created_at FROM routers ORDER BY is_gateway DESC, created_at ASC")
+	rows, err := db.Query("SELECT id, name, host, type, is_gateway, agent_only, firmware_target, created_at, snmp_enabled, snmp_community, snmp_port FROM routers ORDER BY is_gateway DESC, created_at ASC")
 	if err != nil {
 		return []adapters.RouterConfig{}
 	}
@@ -35,15 +35,18 @@ func ListRouters(db *sql.DB) []adapters.RouterConfig {
 	out := []adapters.RouterConfig{}
 	for rows.Next() {
 		var r adapters.RouterConfig
-		var gw, ao int
-		var name, ft sql.NullString
-		if err := rows.Scan(&r.ID, &name, &r.Host, &r.Type, &gw, &ao, &ft, &r.CreatedAt); err != nil {
+		var gw, ao, snmpEn, snmpPort int
+		var name, ft, snmpComm sql.NullString
+		if err := rows.Scan(&r.ID, &name, &r.Host, &r.Type, &gw, &ao, &ft, &r.CreatedAt, &snmpEn, &snmpComm, &snmpPort); err != nil {
 			continue
 		}
 		r.Name = name.String
 		r.FirmwareTarget = ft.String
 		r.IsGateway = gw == 1
 		r.AgentOnly = ao == 1
+		r.SnmpEnabled = snmpEn == 1
+		r.SnmpCommunity = snmpComm.String
+		r.SnmpPort = snmpPort
 		out = append(out, r)
 	}
 	return out
@@ -122,6 +125,10 @@ type AddInput struct {
 	AgentOnly bool
 	// FirmwareTarget: versión objetivo (issue #241). "" = sin comprobar.
 	FirmwareTarget string
+	// SNMP (issue #309): credenciales para sondeo SNMP.
+	SnmpEnabled   bool
+	SnmpCommunity string
+	SnmpPort      int
 }
 
 // AddRouter inserta un router (si IsGateway, el resto pierde el flag —
@@ -154,9 +161,13 @@ func AddRouter(db *sql.DB, in AddInput) (adapters.RouterConfig, error) {
 	if in.AgentOnly {
 		ao = 1
 	}
+	snmpEn := 0
+	if in.SnmpEnabled {
+		snmpEn = 1
+	}
 	if _, err := tx.Exec(
-		"INSERT INTO routers (id, name, host, type, is_gateway, agent_only, firmware_target, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-		id, name, in.Host, in.Type, gw, ao, in.FirmwareTarget, now,
+		"INSERT INTO routers (id, name, host, type, is_gateway, agent_only, firmware_target, created_at, snmp_enabled, snmp_community, snmp_port) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		id, name, in.Host, in.Type, gw, ao, in.FirmwareTarget, now, snmpEn, in.SnmpCommunity, in.SnmpPort,
 	); err != nil {
 		return adapters.RouterConfig{}, err
 	}
@@ -191,6 +202,10 @@ type UpdateInput struct {
 	AgentOnly *bool
 	// FirmwareTarget: versión objetivo (issue #241). nil = no tocar; "" = limpiar.
 	FirmwareTarget *string
+	// SNMP (issue #309): nil = no tocar; puntero a bool/string/int = aplicar.
+	SnmpEnabled   *bool
+	SnmpCommunity *string
+	SnmpPort      *int
 }
 
 // UpdateRouter actualiza un router existente por id. Si IsGateway pasa a true,
@@ -247,6 +262,22 @@ func UpdateRouter(db *sql.DB, id string, in UpdateInput) (adapters.RouterConfig,
 	if in.FirmwareTarget != nil {
 		sets = append(sets, "firmware_target = ?")
 		args = append(args, *in.FirmwareTarget)
+	}
+	if in.SnmpEnabled != nil {
+		v := 0
+		if *in.SnmpEnabled {
+			v = 1
+		}
+		sets = append(sets, "snmp_enabled = ?")
+		args = append(args, v)
+	}
+	if in.SnmpCommunity != nil {
+		sets = append(sets, "snmp_community = ?")
+		args = append(args, *in.SnmpCommunity)
+	}
+	if in.SnmpPort != nil {
+		sets = append(sets, "snmp_port = ?")
+		args = append(args, *in.SnmpPort)
 	}
 	if len(sets) > 0 {
 		args = append(args, id)

--- a/server-go/internal/snmp/fdbTable.go
+++ b/server-go/internal/snmp/fdbTable.go
@@ -1,0 +1,68 @@
+package snmp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+type FdbEntry struct {
+	MAC            string
+	BridgePortIndex int
+	IfIndex        int
+}
+
+func PollFdbTable(s *gosnmp.GoSNMP) ([]FdbEntry, error) {
+	portToIfIndex := map[int]int{}
+	pdus, err := walkSafe(s, OidDot1dBasePortIfIndex)
+	if err == nil {
+		for _, pdu := range pdus {
+			idx := trailingIndex(pdu.Name, OidDot1dBasePortIfIndex)
+			if idx <= 0 {
+				continue
+			}
+			portToIfIndex[idx] = int(uint64Val(pdu))
+		}
+	}
+
+	fdbPdus, err := walkSafe(s, OidDot1dTpFdbPort)
+	if err != nil {
+		return nil, fmt.Errorf("snmp fdb walk: %w", err)
+	}
+	var out []FdbEntry
+	for _, pdu := range fdbPdus {
+		mac := extractMacFromOid(pdu.Name, OidDot1dTpFdbPort)
+		if mac == "" {
+			continue
+		}
+		bridgePort := int(uint64Val(pdu))
+		ifIdx := portToIfIndex[bridgePort]
+		out = append(out, FdbEntry{
+			MAC:            mac,
+			BridgePortIndex: bridgePort,
+			IfIndex:        ifIdx,
+		})
+	}
+	return out, nil
+}
+
+func extractMacFromOid(name, prefix string) string {
+	if !strings.HasPrefix(name, prefix+".") {
+		return ""
+	}
+	suffix := name[len(prefix)+1:]
+	parts := strings.Split(suffix, ".")
+	if len(parts) != 6 {
+		return ""
+	}
+	out := make([]string, 6)
+	for i, p := range parts {
+		var n int
+		if _, err := fmt.Sscanf(p, "%d", &n); err != nil || n < 0 || n > 255 {
+			return ""
+		}
+		out[i] = fmt.Sprintf("%02x", n)
+	}
+	return strings.Join(out, ":")
+}

--- a/server-go/internal/snmp/ifTable.go
+++ b/server-go/internal/snmp/ifTable.go
@@ -1,0 +1,156 @@
+package snmp
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+type PortStats struct {
+	Index      int
+	Name       string
+	Descr      string
+	Alias      string
+	SpeedBps   uint64
+	HighSpeedMbps uint32
+	OperUp     bool
+	RxBytes    uint64
+	TxBytes    uint64
+	RxErrors   uint64
+	TxErrors   uint64
+}
+
+func (p PortStats) SpeedString() string {
+	if !p.OperUp {
+		return ""
+	}
+	var bps uint64
+	if p.HighSpeedMbps > 0 {
+		bps = uint64(p.HighSpeedMbps) * 1_000_000
+	} else {
+		bps = p.SpeedBps
+	}
+	if bps == 0 {
+		return ""
+	}
+	if bps >= 1_000_000_000 {
+		return fmt.Sprintf("%d Gbps", bps/1_000_000_000)
+	}
+	if bps >= 1_000_000 {
+		return fmt.Sprintf("%d Mbps", bps/1_000_000)
+	}
+	return fmt.Sprintf("%d Kbps", bps/1_000)
+}
+
+func (p PortStats) DisplayName() string {
+	if p.Alias != "" {
+		return p.Alias
+	}
+	if p.Name != "" {
+		return p.Name
+	}
+	if p.Descr != "" {
+		return p.Descr
+	}
+	return fmt.Sprintf("port-%d", p.Index)
+}
+
+func PollIfTable(s *gosnmp.GoSNMP) ([]PortStats, error) {
+	oids := []string{
+		OidIfIndex, OidIfDescr, OidIfSpeed, OidIfOperStatus,
+		OidIfInOctets, OidIfInErrors, OidIfOutOctets, OidIfOutErrors,
+		OidIfName, OidIfHighSpeed, OidIfAlias,
+	}
+	byIdx := map[int]*PortStats{}
+	for _, oid := range oids {
+		pdus, err := walkSafe(s, oid)
+		if err != nil {
+			continue
+		}
+		for _, pdu := range pdus {
+			idx := trailingIndex(pdu.Name, oid)
+			if idx <= 0 {
+				continue
+			}
+			ps, ok := byIdx[idx]
+			if !ok {
+				ps = &PortStats{Index: idx}
+				byIdx[idx] = ps
+			}
+			applyPortField(ps, oid, pdu)
+		}
+	}
+	out := make([]PortStats, 0, len(byIdx))
+	for _, ps := range byIdx {
+		out = append(out, *ps)
+	}
+	sortByIndex(out)
+	return out, nil
+}
+
+func applyPortField(ps *PortStats, oid string, pdu gosnmp.SnmpPDU) {
+	switch oid {
+	case OidIfIndex:
+		ps.Index = int(uint64Val(pdu))
+	case OidIfDescr:
+		ps.Descr = stringVal(pdu)
+	case OidIfSpeed:
+		ps.SpeedBps = uint64Val(pdu)
+	case OidIfOperStatus:
+		ps.OperUp = uint64Val(pdu) == 1
+	case OidIfInOctets:
+		ps.RxBytes = uint64Val(pdu)
+	case OidIfInErrors:
+		ps.RxErrors = uint64Val(pdu)
+	case OidIfOutOctets:
+		ps.TxBytes = uint64Val(pdu)
+	case OidIfOutErrors:
+		ps.TxErrors = uint64Val(pdu)
+	case OidIfName:
+		ps.Name = stringVal(pdu)
+	case OidIfHighSpeed:
+		v := uint64Val(pdu)
+		if v <= 0xFFFFFFFF {
+			ps.HighSpeedMbps = uint32(v)
+		}
+	case OidIfAlias:
+		ps.Alias = stringVal(pdu)
+	}
+}
+
+func walkSafe(s *gosnmp.GoSNMP, oid string) ([]gosnmp.SnmpPDU, error) {
+	out, err := s.BulkWalkAll(oid)
+	if err != nil {
+		out2, err2 := s.WalkAll(oid)
+		if err2 != nil {
+			return nil, err
+		}
+		return out2, nil
+	}
+	return out, nil
+}
+
+func trailingIndex(name, prefix string) int {
+	if !strings.HasPrefix(name, prefix+".") {
+		return 0
+	}
+	suffix := name[len(prefix)+1:]
+	if strings.Contains(suffix, ".") {
+		return 0
+	}
+	n, err := strconv.Atoi(suffix)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func sortByIndex(ps []PortStats) {
+	for i := 1; i < len(ps); i++ {
+		for j := i; j > 0 && ps[j-1].Index > ps[j].Index; j-- {
+			ps[j-1], ps[j] = ps[j], ps[j-1]
+		}
+	}
+}

--- a/server-go/internal/snmp/oids.go
+++ b/server-go/internal/snmp/oids.go
@@ -1,0 +1,27 @@
+package snmp
+
+const (
+	OidSysDescr    = ".1.3.6.1.2.1.1.1.0"
+	OidSysName     = ".1.3.6.1.2.1.1.5.0"
+	OidSysUpTime   = ".1.3.6.1.2.1.1.3.0"
+
+	OidIfNumber    = ".1.3.6.1.2.1.2.1.0"
+	OidIfTable     = ".1.3.6.1.2.1.2.2.1"
+	OidIfIndex     = ".1.3.6.1.2.1.2.2.1.1"
+	OidIfDescr     = ".1.3.6.1.2.1.2.2.1.2"
+	OidIfType      = ".1.3.6.1.2.1.2.2.1.3"
+	OidIfSpeed     = ".1.3.6.1.2.1.2.2.1.5"
+	OidIfOperStatus= ".1.3.6.1.2.1.2.2.1.8"
+	OidIfInOctets  = ".1.3.6.1.2.1.2.2.1.10"
+	OidIfInErrors  = ".1.3.6.1.2.1.2.2.1.14"
+	OidIfOutOctets = ".1.3.6.1.2.1.2.2.1.16"
+	OidIfOutErrors = ".1.3.6.1.2.1.2.2.1.20"
+
+	OidIfXTable    = ".1.3.6.1.2.1.31.1.1.1"
+	OidIfName      = ".1.3.6.1.2.1.31.1.1.1.1"
+	OidIfHighSpeed = ".1.3.6.1.2.1.31.1.1.1.15"
+	OidIfAlias     = ".1.3.6.1.2.1.31.1.1.1.18"
+
+	OidDot1dTpFdbPort    = ".1.3.6.1.2.1.17.4.3.1.2"
+	OidDot1dBasePortIfIndex = ".1.3.6.1.2.1.17.1.4.1.2"
+)

--- a/server-go/internal/snmp/poller.go
+++ b/server-go/internal/snmp/poller.go
@@ -1,0 +1,64 @@
+package snmp
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+const (
+	DefaultPort    = 161
+	DefaultTimeout = 5 * time.Second
+	DefaultRetries = 1
+)
+
+type Config struct {
+	Host      string
+	Port      int
+	Community string
+	Version   gosnmp.SnmpVersion
+}
+
+func (c Config) normalizedPort() int {
+	if c.Port > 0 {
+		return c.Port
+	}
+	return DefaultPort
+}
+
+func (c Config) version() gosnmp.SnmpVersion {
+	if c.Version != 0 {
+		return c.Version
+	}
+	return gosnmp.Version2c
+}
+
+func NewSession(cfg Config) (*gosnmp.GoSNMP, error) {
+	if cfg.Host == "" {
+		return nil, fmt.Errorf("snmp: host required")
+	}
+	community := cfg.Community
+	if community == "" {
+		community = "public"
+	}
+	s := &gosnmp.GoSNMP{
+		Target:    cfg.Host,
+		Port:      uint16(cfg.normalizedPort()),
+		Community: community,
+		Version:   cfg.version(),
+		Timeout:   DefaultTimeout,
+		Retries:   DefaultRetries,
+	}
+	if err := s.Connect(); err != nil {
+		return nil, fmt.Errorf("snmp connect: %w", err)
+	}
+	return s, nil
+}
+
+func CloseSession(s *gosnmp.GoSNMP) {
+	if s == nil {
+		return
+	}
+	_ = s.Conn.Close()
+}

--- a/server-go/internal/snmp/snmp_test.go
+++ b/server-go/internal/snmp/snmp_test.go
@@ -1,0 +1,179 @@
+package snmp
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+func TestTrailingIndex(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+		want   int
+	}{
+		{".1.3.6.1.2.1.2.2.1.1.5", OidIfIndex, 5},
+		{".1.3.6.1.2.1.2.2.1.1.42", OidIfIndex, 42},
+		{".1.3.6.1.2.1.2.2.1.1", OidIfIndex, 0},
+		{".1.3.6.1.2.1.31.1.1.1.1.7", OidIfName, 7},
+		{".9.9.9", OidIfIndex, 0},
+	}
+	for _, tt := range tests {
+		got := trailingIndex(tt.name, tt.prefix)
+		if got != tt.want {
+			t.Errorf("trailingIndex(%q, %q) = %d; want %d", tt.name, tt.prefix, got, tt.want)
+		}
+	}
+}
+
+func TestExtractMacFromOid(t *testing.T) {
+	prefix := OidDot1dTpFdbPort
+	tests := []struct {
+		name string
+		want string
+	}{
+		{prefix + ".0.17.34.51.68.85", "00:11:22:33:44:55"},
+		{prefix + ".255.255.255.255.255.255", "ff:ff:ff:ff:ff:ff"},
+		{prefix + ".1.2.3.4.5", ""},
+		{prefix + ".1.2.3.4.5.6.7", ""},
+		{prefix + ".0.17.34.51.68.256", ""},
+		{"other.0.17.34.51.68.85", ""},
+	}
+	for _, tt := range tests {
+		got := extractMacFromOid(tt.name, prefix)
+		if got != tt.want {
+			t.Errorf("extractMacFromOid(%q) = %q; want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestPortStatsSpeedString(t *testing.T) {
+	tests := []struct {
+		name string
+		ps   PortStats
+		want string
+	}{
+		{"down", PortStats{OperUp: false}, ""},
+		{"1G highspeed", PortStats{OperUp: true, HighSpeedMbps: 1000}, "1 Gbps"},
+		{"10G highspeed", PortStats{OperUp: true, HighSpeedMbps: 10000}, "10 Gbps"},
+		{"100M ifSpeed", PortStats{OperUp: true, SpeedBps: 100_000_000}, "100 Mbps"},
+		{"2.5G highspeed", PortStats{OperUp: true, HighSpeedMbps: 2500}, "2 Gbps"},
+		{"zero speed", PortStats{OperUp: true}, ""},
+	}
+	for _, tt := range tests {
+		got := tt.ps.SpeedString()
+		if got != tt.want {
+			t.Errorf("SpeedString(%s) = %q; want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestPortStatsDisplayName(t *testing.T) {
+	tests := []struct {
+		ps   PortStats
+		want string
+	}{
+		{PortStats{Alias: "Uplink"}, "Uplink"},
+		{PortStats{Name: "eth0"}, "eth0"},
+		{PortStats{Descr: "GigabitEthernet0/1"}, "GigabitEthernet0/1"},
+		{PortStats{Index: 5}, "port-5"},
+		{PortStats{Alias: "Uplink", Name: "eth0"}, "Uplink"},
+	}
+	for _, tt := range tests {
+		got := tt.ps.DisplayName()
+		if got != tt.want {
+			t.Errorf("DisplayName(%+v) = %q; want %q", tt.ps, got, tt.want)
+		}
+	}
+}
+
+func TestApplyPortField(t *testing.T) {
+	ps := &PortStats{Index: 1}
+	applyPortField(ps, OidIfOperStatus, gosnmp.SnmpPDU{Value: 1})
+	if !ps.OperUp {
+		t.Error("expected OperUp=true for value 1")
+	}
+	applyPortField(ps, OidIfOperStatus, gosnmp.SnmpPDU{Value: 2})
+	if ps.OperUp {
+		t.Error("expected OperUp=false for value 2")
+	}
+	applyPortField(ps, OidIfSpeed, gosnmp.SnmpPDU{Value: uint(1000000000)})
+	if ps.SpeedBps != 1_000_000_000 {
+		t.Errorf("SpeedBps = %d; want 1000000000", ps.SpeedBps)
+	}
+	applyPortField(ps, OidIfName, gosnmp.SnmpPDU{Value: "eth0"})
+	if ps.Name != "eth0" {
+		t.Errorf("Name = %q; want eth0", ps.Name)
+	}
+	applyPortField(ps, OidIfHighSpeed, gosnmp.SnmpPDU{Value: uint(10000)})
+	if ps.HighSpeedMbps != 10000 {
+		t.Errorf("HighSpeedMbps = %d; want 10000", ps.HighSpeedMbps)
+	}
+	applyPortField(ps, OidIfInOctets, gosnmp.SnmpPDU{Value: big.NewInt(123456789)})
+	if ps.RxBytes != 123456789 {
+		t.Errorf("RxBytes = %d; want 123456789", ps.RxBytes)
+	}
+}
+
+func TestSystemInfoParsing(t *testing.T) {
+	pdus := []gosnmp.SnmpPDU{
+		{Name: OidSysDescr, Value: "Linux switch 5.15"},
+		{Name: OidSysName, Value: "core-switch"},
+		{Name: OidSysUpTime, Value: uint(360000)},
+	}
+	info := &SystemInfo{}
+	for _, v := range pdus {
+		switch v.Name {
+		case OidSysDescr:
+			info.Descr = stringVal(v)
+		case OidSysName:
+			info.Name = stringVal(v)
+		case OidSysUpTime:
+			info.UpTimeSec = uint64Val(v) / 100
+		}
+	}
+	if info.Descr != "Linux switch 5.15" {
+		t.Errorf("Descr = %q", info.Descr)
+	}
+	if info.Name != "core-switch" {
+		t.Errorf("Name = %q", info.Name)
+	}
+	if info.UpTimeSec != 3600 {
+		t.Errorf("UpTimeSec = %d; want 3600", info.UpTimeSec)
+	}
+}
+
+func TestStringVal(t *testing.T) {
+	if got := stringVal(gosnmp.SnmpPDU{Value: "hello", Type: gosnmp.OctetString}); got != "hello" {
+		t.Errorf("stringVal string = %q", got)
+	}
+	if got := stringVal(gosnmp.SnmpPDU{Value: []byte("bytes"), Type: gosnmp.OctetString}); got != "bytes" {
+		t.Errorf("stringVal bytes = %q", got)
+	}
+	if got := stringVal(gosnmp.SnmpPDU{Type: gosnmp.NoSuchObject}); got != "" {
+		t.Errorf("stringVal NoSuchObject = %q", got)
+	}
+}
+
+func TestUint64Val(t *testing.T) {
+	if got := uint64Val(gosnmp.SnmpPDU{Value: uint(42), Type: gosnmp.Gauge32}); got != 42 {
+		t.Errorf("uint64Val = %d", got)
+	}
+	if got := uint64Val(gosnmp.SnmpPDU{Value: big.NewInt(999999), Type: gosnmp.Counter64}); got != 999999 {
+		t.Errorf("uint64Val big = %d", got)
+	}
+	if got := uint64Val(gosnmp.SnmpPDU{Type: gosnmp.NoSuchInstance}); got != 0 {
+		t.Errorf("uint64Val NoSuchInstance = %d", got)
+	}
+}
+
+func TestSortByIndex(t *testing.T) {
+	ps := []PortStats{{Index: 3}, {Index: 1}, {Index: 2}}
+	sortByIndex(ps)
+	for i, p := range ps {
+		if p.Index != i+1 {
+			t.Errorf("sortByIndex: ps[%d].Index = %d; want %d", i, p.Index, i+1)
+		}
+	}
+}

--- a/server-go/internal/snmp/system.go
+++ b/server-go/internal/snmp/system.go
@@ -1,0 +1,58 @@
+package snmp
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+type SystemInfo struct {
+	Descr    string
+	Name     string
+	UpTimeSec uint64
+}
+
+func PollSystem(s *gosnmp.GoSNMP) (*SystemInfo, error) {
+	oids := []string{OidSysDescr, OidSysName, OidSysUpTime}
+	result, err := s.Get(oids)
+	if err != nil {
+		return nil, fmt.Errorf("snmp system get: %w", err)
+	}
+	info := &SystemInfo{}
+	for _, v := range result.Variables {
+		switch v.Name {
+		case OidSysDescr:
+			info.Descr = stringVal(v)
+		case OidSysName:
+			info.Name = stringVal(v)
+		case OidSysUpTime:
+			info.UpTimeSec = uint64Val(v) / 100
+		}
+	}
+	return info, nil
+}
+
+func stringVal(v gosnmp.SnmpPDU) string {
+	if v.Type == gosnmp.NoSuchObject || v.Type == gosnmp.NoSuchInstance {
+		return ""
+	}
+	switch val := v.Value.(type) {
+	case string:
+		return val
+	case []byte:
+		return string(val)
+	default:
+		return fmt.Sprintf("%v", val)
+	}
+}
+
+func uint64Val(v gosnmp.SnmpPDU) uint64 {
+	if v.Type == gosnmp.NoSuchObject || v.Type == gosnmp.NoSuchInstance {
+		return 0
+	}
+	if bi, ok := v.Value.(*big.Int); ok {
+		return bi.Uint64()
+	}
+	return gosnmp.ToBigInt(v.Value).Uint64()
+}


### PR DESCRIPTION
## Summary

Phase 2 of switch management: SNMP data source for third-party managed switches and persistent per-port time series with tiered retention.

### Changes

- **SNMP poller (#309)**: new `server-go/internal/snmp/` package using gosnmp. Polls ifTable/ifXTable (port state, speed, counters, errors), dot1dTpFdbTable (MAC-to-port), sysUpTime/sysDescr. Router config gains SNMP toggle + community string + port. Integrated into live polling alongside SSH/agent paths. Frontend: SNMP section in router edit form.

- **Per-port time series (#302)**: new `server-go/internal/portseries/` package. Three SQLite tables: raw (7d), 5-minute buckets (1y), daily aggregates (indefinite). Nightly rollup + purge job. API endpoint `GET /api/routers/:id/ports/:portId/series` with auto resolution. Frontend: SVG sparkline chart in PortPanel with 24h/7d/30d toggle.

Closes #302
Closes #309