### PR TITLE
release: v2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 ## [Unreleased]
 
+## [2.17.0] - 2026-08-28
+
+### Added
+
+- **Poller SNMP para switches gestionados (#309)**: nuevo paquete `server-go/internal/snmp/` con gosnmp. Sondeo de ifTable/ifXTable (estado, velocidad, contadores, errores), dot1dTpFdbTable (tabla MAC-puerto), sysUpTime/sysDescr. Config SNMP por router (toggle + community + puerto). Integrado en el ciclo de polling junto a SSH/agente.
+- **Series temporales por puerto (#302)**: paquete `server-go/internal/portseries/`. Tres tablas SQLite: raw (7d), buckets 5min (1 año), diario (indefinido). Job nocturno de rollup + purga. API `GET /api/routers/:id/ports/:portId/series`. Sparkline SVG en el panel de puerto con selector 24h/7d/30d.
+
 ## [2.16.0] - 2026-08-28
 
 ### Added

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.16.0",
+  "version": "2.17.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -38,7 +38,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.16.0"
+var Version = "2.17.0"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Bump version to 2.17.0 and update CHANGELOG for switch management phase 2 (#321).

Closes #302, #309