### PR TITLE
release: v2.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 ## [Unreleased]
 
+## [2.18.0] - 2026-08-28
+
+### Added
+
+- **Alertas inteligentes de puerto (#303)**: `PortMonitor` rastrea transiciones de estado y detecta flapping (>5 transiciones en 10 min). Integrado en las rutas de agente, SSH y SNMP.
+- **Alerta puerto fantasma (#307)**: alerta cuando un puerto con trafico estable se queda sin trafico durante 12+ muestras consecutivas. Requiere historico previo para evitar falsos positivos.
+- **Alerta enlace degradado (#308)**: alerta cuando la velocidad negociada baja por debajo de la mitad del historico dominante durante 3+ polls consecutivos.
+- **Health score por puerto (#299)**: puntuacion 0-100 por puerto basada en estado de enlace (30%), utilizacion (25%), errores (25%) y flapping (20%). Expuesto en la API de detalle del router.
+- **Widget panel frontal del switch (#306)**: LEDs por puerto (verde/ambar/rojo/gris) con etiquetas de velocidad e indicadores PoE. Tooltips al pasar el raton. Activo para switches con 8+ puertos. Colapso responsive en movil.
+
 ## [2.17.0] - 2026-08-28
 
 ### Added

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.17.0",
+  "version": "2.18.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -38,7 +38,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.17.0"
+var Version = "2.18.0"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Bump version to 2.18.0 and update CHANGELOG for switch management phase 3 (#323).

Closes #299, #303, #306, #307, #308