### PR TITLE
feat: add API tokens with scoped bearer auth

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -150,7 +150,9 @@
     "viewDetail": "View {{name}} detail",
     "viewDetailShort": "View detail",
     "adminOnly": "Admin only",
-    "back": "Back"
+    "back": "Back",
+    "cancel": "Cancel",
+    "loading": "Loading..."
   },
   "devices": {
     "badges": {
@@ -1345,5 +1347,35 @@
     "iosDesc": "On iOS: open the Share menu and choose Add to Home Screen.",
     "install": "Install",
     "later": "Not now"
+  },
+  "tokens": {
+    "title": "API Tokens",
+    "caption": "Bearer tokens for external integrations (Home Assistant, Grafana, n8n).",
+    "desc": "Tokens allow API access without a session. Use as header Authorization: Bearer np_...",
+    "create": "New token",
+    "createBtn": "Create",
+    "createError": "Could not create token",
+    "nameLabel": "Name",
+    "namePlaceholder": "e.g. Home Assistant",
+    "scopeLabel": "Permissions",
+    "scopeRead": "Read only",
+    "scopeWrite": "Read and write",
+    "scopeAdmin": "Admin",
+    "expiresLabel": "Expiry",
+    "neverExpires": "Never expires",
+    "expires30d": "30 days",
+    "expires90d": "90 days",
+    "expires1y": "1 year",
+    "createdMsg": "Token created successfully",
+    "createdWarn": "Copy it now. It will not be shown again.",
+    "copy": "Copy token",
+    "copied": "Copied",
+    "dismiss": "Dismiss",
+    "empty": "No tokens yet. Create one to get started.",
+    "never": "Never",
+    "created": "Created",
+    "expires": "Expires",
+    "lastUsed": "Last used",
+    "revoke": "Revoke"
   }
 }

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -150,7 +150,9 @@
     "viewDetail": "Ver detalle de {{name}}",
     "viewDetailShort": "Ver detalle",
     "adminOnly": "Solo administrador",
-    "back": "Atrás"
+    "back": "Atrás",
+    "cancel": "Cancelar",
+    "loading": "Cargando..."
   },
   "devices": {
     "badges": {
@@ -1345,5 +1347,35 @@
     "iosDesc": "En iOS: abre el menú Compartir y elige Añadir a pantalla de inicio.",
     "install": "Instalar",
     "later": "Ahora no"
+  },
+  "tokens": {
+    "title": "Tokens de API",
+    "caption": "Tokens Bearer para integraciones externas (Home Assistant, Grafana, n8n).",
+    "desc": "Los tokens permiten acceder a la API sin sesión. Úsalos como cabecera Authorization: Bearer np_...",
+    "create": "Nuevo token",
+    "createBtn": "Crear",
+    "createError": "No se pudo crear el token",
+    "nameLabel": "Nombre",
+    "namePlaceholder": "p.ej. Home Assistant",
+    "scopeLabel": "Permisos",
+    "scopeRead": "Solo lectura",
+    "scopeWrite": "Lectura y escritura",
+    "scopeAdmin": "Administrador",
+    "expiresLabel": "Caducidad",
+    "neverExpires": "Sin caducidad",
+    "expires30d": "30 días",
+    "expires90d": "90 días",
+    "expires1y": "1 año",
+    "createdMsg": "Token creado correctamente",
+    "createdWarn": "Cópialo ahora. No se mostrará de nuevo.",
+    "copy": "Copiar token",
+    "copied": "Copiado",
+    "dismiss": "Cerrar",
+    "empty": "No hay tokens. Crea uno para empezar.",
+    "never": "Nunca",
+    "created": "Creado",
+    "expires": "Caduca",
+    "lastUsed": "Último uso",
+    "revoke": "Revocar"
   }
 }

--- a/app/src/components/TokensManager.tsx
+++ b/app/src/components/TokensManager.tsx
@@ -1,0 +1,252 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Copy, KeyRound, Plus, Trash2 } from 'lucide-react'
+
+type TokenItem = {
+  id: string
+  name: string
+  scope: string
+  userId: number
+  createdAt: number
+  expiresAt: number
+  lastUsedAt: number
+}
+
+type CreatedToken = { id: string; name: string; scope: string; token: string }
+
+export function TokensManager() {
+  const { t } = useTranslation()
+  const [tokens, setTokens] = useState<TokenItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showForm, setShowForm] = useState(false)
+  const [name, setName] = useState('')
+  const [scope, setScope] = useState<'read' | 'write' | 'admin'>('read')
+  const [expiresIn, setExpiresIn] = useState(0)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [created, setCreated] = useState<CreatedToken | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const load = useCallback(async () => {
+    try {
+      const r = await fetch('/api/tokens')
+      if (r.ok) {
+        const d = (await r.json()) as { tokens: TokenItem[] }
+        setTokens(d.tokens ?? [])
+      }
+    } catch {
+      /* ignore */
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const create = useCallback(async () => {
+    if (busy || !name.trim()) return
+    setBusy(true)
+    setError(null)
+    setCreated(null)
+    try {
+      const r = await fetch('/api/tokens', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: name.trim(), scope, expiresInDays: expiresIn }),
+      })
+      if (!r.ok) {
+        const d = (await r.json().catch(() => null)) as { message?: string } | null
+        throw new Error(d?.message ?? t('tokens.createError'))
+      }
+      const d = (await r.json()) as CreatedToken
+      setCreated(d)
+      setName('')
+      setShowForm(false)
+      void load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('tokens.createError'))
+    } finally {
+      setBusy(false)
+    }
+  }, [busy, name, scope, expiresIn, t, load])
+
+  const revoke = useCallback(
+    async (id: string) => {
+      try {
+        await fetch(`/api/tokens/${id}`, { method: 'DELETE' })
+        setTokens((prev) => prev.filter((x) => x.id !== id))
+      } catch {
+        /* ignore */
+      }
+    },
+    [],
+  )
+
+  const copyToken = useCallback(async (raw: string) => {
+    try {
+      await navigator.clipboard.writeText(raw)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      /* ignore */
+    }
+  }, [])
+
+  const fmtDate = (ms: number) => {
+    if (!ms) return t('tokens.never')
+    return new Date(ms).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-text-secondary">{t('tokens.desc')}</p>
+        {!showForm && !created && (
+          <button
+            type="button"
+            onClick={() => setShowForm(true)}
+            className="flex h-8 items-center gap-1.5 rounded-lg bg-accent px-3 text-xs font-semibold text-canvas transition-opacity hover:opacity-90"
+          >
+            <Plus className="h-3.5 w-3.5" strokeWidth={2} />
+            {t('tokens.create')}
+          </button>
+        )}
+      </div>
+
+      {showForm && !created && (
+        <div className="mt-4 flex flex-col gap-3 rounded-xl border border-border bg-surface p-4">
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="sm:col-span-2">
+              <label className="text-xs font-medium text-text-muted">{t('tokens.nameLabel')}</label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder={t('tokens.namePlaceholder')}
+                maxLength={60}
+                autoFocus
+                className="mt-1 h-9 w-full rounded-lg border border-border bg-elevated px-3 text-sm text-text-primary"
+              />
+            </div>
+            <div>
+              <label className="text-xs font-medium text-text-muted">{t('tokens.scopeLabel')}</label>
+              <select
+                value={scope}
+                onChange={(e) => setScope(e.target.value as 'read' | 'write' | 'admin')}
+                className="mt-1 h-9 w-full rounded-lg border border-border bg-elevated px-2.5 text-sm text-text-primary"
+              >
+                <option value="read">{t('tokens.scopeRead')}</option>
+                <option value="write">{t('tokens.scopeWrite')}</option>
+                <option value="admin">{t('tokens.scopeAdmin')}</option>
+              </select>
+            </div>
+          </div>
+          <div>
+            <label className="text-xs font-medium text-text-muted">{t('tokens.expiresLabel')}</label>
+            <select
+              value={expiresIn}
+              onChange={(e) => setExpiresIn(Number(e.target.value))}
+              className="mt-1 h-9 w-full rounded-lg border border-border bg-elevated px-2.5 text-sm text-text-primary sm:w-48"
+            >
+              <option value={0}>{t('tokens.neverExpires')}</option>
+              <option value={30}>{t('tokens.expires30d')}</option>
+              <option value={90}>{t('tokens.expires90d')}</option>
+              <option value={365}>{t('tokens.expires1y')}</option>
+            </select>
+          </div>
+          {error && <p role="alert" className="text-caption text-danger">{error}</p>}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => void create()}
+              disabled={busy || !name.trim()}
+              className="flex h-9 items-center justify-center rounded-lg bg-accent px-4 text-sm font-semibold text-canvas transition-opacity hover:opacity-90 disabled:opacity-50"
+            >
+              {busy ? t('common.loading') : t('tokens.createBtn')}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setShowForm(false)
+                setError(null)
+              }}
+              className="flex h-9 items-center justify-center rounded-lg border border-border px-4 text-sm text-text-muted transition-colors hover:bg-hover"
+            >
+              {t('common.cancel')}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {created && (
+        <div className="mt-4 rounded-xl border border-ok/30 bg-ok/5 p-4">
+          <p className="text-sm font-medium text-ok">{t('tokens.createdMsg')}</p>
+          <p className="mt-1 text-xs text-text-muted">{t('tokens.createdWarn')}</p>
+          <div className="mt-3 flex items-center gap-2">
+            <code className="flex-1 break-all rounded-lg border border-border bg-elevated px-3 py-2 font-mono text-xs text-text-primary">
+              {created.token}
+            </code>
+            <button
+              type="button"
+              onClick={() => void copyToken(created.token)}
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border text-text-muted transition-colors hover:bg-hover hover:text-text-primary"
+              title={t('tokens.copy')}
+            >
+              <Copy className="h-4 w-4" strokeWidth={1.75} />
+            </button>
+          </div>
+          {copied && <p className="mt-1 text-xs text-ok">{t('tokens.copied')}</p>}
+          <button
+            type="button"
+            onClick={() => setCreated(null)}
+            className="mt-3 text-xs font-medium text-text-muted underline hover:text-text-primary"
+          >
+            {t('tokens.dismiss')}
+          </button>
+        </div>
+      )}
+
+      {loading && <p className="mt-4 text-sm text-text-muted">{t('common.loading')}</p>}
+
+      {!loading && tokens.length === 0 && !created && (
+        <p className="mt-4 text-sm text-text-muted">{t('tokens.empty')}</p>
+      )}
+
+      {!loading && tokens.length > 0 && (
+        <div className="mt-4 space-y-2">
+          {tokens.map((tok) => (
+            <div
+              key={tok.id}
+              className="flex items-center justify-between rounded-xl border border-border bg-surface px-4 py-3"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <KeyRound className="h-4 w-4 shrink-0 text-text-muted" strokeWidth={1.75} />
+                  <span className="truncate text-sm font-medium text-text-primary">{tok.name}</span>
+                  <span className="shrink-0 rounded-full bg-accent/10 px-2 py-0.5 text-[10px] font-semibold uppercase text-accent">
+                    {tok.scope}
+                  </span>
+                </div>
+                <div className="mt-1 flex flex-wrap gap-x-3 text-[11px] text-text-muted">
+                  <span>{t('tokens.created')}: {fmtDate(tok.createdAt)}</span>
+                  {tok.expiresAt > 0 && <span>{t('tokens.expires')}: {fmtDate(tok.expiresAt)}</span>}
+                  <span>{t('tokens.lastUsed')}: {fmtDate(tok.lastUsedAt)}</span>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => void revoke(tok.id)}
+                className="ml-3 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-muted transition-colors hover:bg-danger/10 hover:text-danger"
+                title={t('tokens.revoke')}
+              >
+                <Trash2 className="h-4 w-4" strokeWidth={1.75} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -45,6 +45,7 @@ import type { LucideIcon } from 'lucide-react'
 import { HealthRing } from '@/components/HealthRing'
 import { KnownMacsManager } from '@/components/KnownMacsManager'
 import { SegmentedControl } from '@/components/SegmentedControl'
+import { TokensManager } from '@/components/TokensManager'
 import { TopologyOverridesManager } from '@/components/topology/TopologyOverridesManager'
 import { ReadinessPanel, type UpdateReadiness } from '@/components/UpdateReadiness'
 import { UpdateDialog } from '@/components/UpdateDialog'
@@ -3822,6 +3823,15 @@ export default function Settings() {
             )}
           </Card>
         </div>
+
+        {/* API Tokens (#330): bearer tokens con scopes para integraciones */}
+        {!isDemo && (
+          <div className="lg:col-span-12">
+            <Card title={t('tokens.title')} caption={t('tokens.caption')} index={6} reduce={reduce}>
+              <TokensManager />
+            </Card>
+          </div>
+        )}
 
         {/* ⑥ Acerca de */}
         <div className="lg:col-span-12">

--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/gnacho/netpulse/server-go/internal/adapters"
 	"github.com/gnacho/netpulse/server-go/internal/alerts"
+	"github.com/gnacho/netpulse/server-go/internal/apitoken"
 	"github.com/gnacho/netpulse/server-go/internal/auth"
 	"github.com/gnacho/netpulse/server-go/internal/config"
 	"github.com/gnacho/netpulse/server-go/internal/db"
@@ -188,6 +189,10 @@ func run() error {
 	if err := auth.EnsureUsers(dbHandle, cfg); err != nil {
 		return err
 	}
+	if err := apitoken.EnsureSchema(dbHandle); err != nil {
+		return fmt.Errorf("api tokens schema: %w", err)
+	}
+	tokenStore := apitoken.NewStore(dbHandle, secret)
 
 	// Clave SSH propia para sondear routers (se genera la primera vez)
 	if err := sshkey.EnsureKeypair(cfg.SSHKeyPath); err != nil {
@@ -364,19 +369,20 @@ func run() error {
 	}
 
 	handler := httpapi.NewHandler(httpapi.Deps{
-		Config:   cfg,
-		DB:       dbHandle,
-		Adapter:  adapter,
-		Hub:      hub,
-		Secret:   secret,
-		Static:   static,
-		Updater:  upd,
-		Agents:   agentReg,
-		Pool:     sshPool,
-		Rearmer:  arm,
-		AgentHub: agentHub,
-		ServerFP: serverFP,
-		Orchestr: orchMgr,
+		Config:     cfg,
+		DB:         dbHandle,
+		Adapter:    adapter,
+		Hub:        hub,
+		Secret:     secret,
+		Static:     static,
+		Updater:    upd,
+		Agents:     agentReg,
+		Pool:       sshPool,
+		Rearmer:    arm,
+		AgentHub:   agentHub,
+		ServerFP:   serverFP,
+		Orchestr:   orchMgr,
+		TokenStore: tokenStore,
 		LastOverview: func() *adapters.Overview {
 			return p.LastOverview()
 		},

--- a/server-go/internal/apitoken/store.go
+++ b/server-go/internal/apitoken/store.go
@@ -1,0 +1,197 @@
+package apitoken
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/gnacho/netpulse/server-go/internal/auth"
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+const (
+	TokenPrefix = "np_"
+	ScopeRead   = "read"
+	ScopeWrite  = "write"
+	ScopeAdmin  = "admin"
+)
+
+type Token struct {
+	ID         string
+	Name       string
+	Scope      string
+	UserID     int64
+	TokenHash  string
+	CreatedAt  int64
+	ExpiresAt  int64
+	LastUsedAt int64
+}
+
+func hashToken(secret, raw string) string {
+	m := hmac.New(sha256.New, []byte(secret))
+	m.Write([]byte(raw))
+	return hex.EncodeToString(m.Sum(nil))
+}
+
+func randomHex(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(b)
+}
+
+func newID() string    { return randomHex(16) }
+func newRaw() string    { return randomHex(24) }
+
+type Store struct {
+	db     *db.DB
+	secret string
+}
+
+func NewStore(d *db.DB, secret string) *Store {
+	return &Store{db: d, secret: secret}
+}
+
+func (s *Store) Create(name, scope string, userID int64, expiresInDays int) (id string, raw string, err error) {
+	if name == "" || scope == "" {
+		return "", "", fmt.Errorf("name and scope required")
+	}
+	if scope != ScopeRead && scope != ScopeWrite && scope != ScopeAdmin {
+		return "", "", fmt.Errorf("invalid scope: %s", scope)
+	}
+	id = newID()
+	raw = TokenPrefix + newRaw()
+	h := hashToken(s.secret, raw)
+	now := db.NowMS()
+	var exp int64
+	if expiresInDays > 0 {
+		exp = now + int64(expiresInDays)*24*60*60*1000
+	}
+	_, err = s.db.Exec(
+		`INSERT INTO api_tokens (id, name, scope, user_id, token_hash, created_at, expires_at, last_used_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, 0)`,
+		id, name, scope, userID, h, now, exp,
+	)
+	return id, raw, err
+}
+
+func (s *Store) Get(id string) *Token {
+	var t Token
+	err := s.db.QueryRow(
+		`SELECT id, name, scope, user_id, token_hash, created_at, expires_at, last_used_at
+		 FROM api_tokens WHERE id = ?`, id,
+	).Scan(&t.ID, &t.Name, &t.Scope, &t.UserID, &t.TokenHash, &t.CreatedAt, &t.ExpiresAt, &t.LastUsedAt)
+	if err != nil {
+		return nil
+	}
+	return &t
+}
+
+func (s *Store) Validate(raw string) *Token {
+	if !strings.HasPrefix(raw, TokenPrefix) {
+		return nil
+	}
+	h := hashToken(s.secret, raw)
+	var t Token
+	err := s.db.QueryRow(
+		`SELECT id, name, scope, user_id, token_hash, created_at, expires_at, last_used_at
+		 FROM api_tokens WHERE token_hash = ?`, h,
+	).Scan(&t.ID, &t.Name, &t.Scope, &t.UserID, &t.TokenHash, &t.CreatedAt, &t.ExpiresAt, &t.LastUsedAt)
+	if err != nil {
+		return nil
+	}
+	if t.ExpiresAt > 0 && t.ExpiresAt < db.NowMS() {
+		return nil
+	}
+	now := db.NowMS()
+	if now-t.LastUsedAt > 60000 {
+		_, _ = s.db.Exec("UPDATE api_tokens SET last_used_at = ? WHERE id = ?", now, t.ID)
+	}
+	return &t
+}
+
+// ValidateBearer implements auth.TokenValidator.
+func (s *Store) ValidateBearer(raw string) (*auth.User, string) {
+	t := s.Validate(raw)
+	if t == nil {
+		return nil, ""
+	}
+	u := auth.GetUserByID(s.db, t.UserID)
+	if u == nil {
+		return nil, ""
+	}
+	if t.Scope == ScopeAdmin && u.Role != "admin" {
+		return nil, ""
+	}
+	return u, t.Scope
+}
+
+func (s *Store) List(userID int64, admin bool) ([]Token, error) {
+	var rows *sql.Rows
+	var err error
+	if admin {
+		rows, err = s.db.Query(
+			`SELECT id, name, scope, user_id, token_hash, created_at, expires_at, last_used_at
+			 FROM api_tokens ORDER BY created_at DESC`,
+		)
+	} else {
+		rows, err = s.db.Query(
+			`SELECT id, name, scope, user_id, token_hash, created_at, expires_at, last_used_at
+			 FROM api_tokens WHERE user_id = ? ORDER BY created_at DESC`,
+			userID,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Token
+	for rows.Next() {
+		var t Token
+		if err := rows.Scan(&t.ID, &t.Name, &t.Scope, &t.UserID, &t.TokenHash, &t.CreatedAt, &t.ExpiresAt, &t.LastUsedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) Delete(id string, userID int64, admin bool) error {
+	if admin {
+		_, err := s.db.Exec("DELETE FROM api_tokens WHERE id = ?", id)
+		return err
+	}
+	_, err := s.db.Exec("DELETE FROM api_tokens WHERE id = ? AND user_id = ?", id, userID)
+	return err
+}
+
+func (s *Store) Count() (int, error) {
+	var n int
+	err := s.db.QueryRow("SELECT COUNT(*) FROM api_tokens").Scan(&n)
+	return n, err
+}
+
+func EnsureSchema(d *db.DB) error {
+	_, err := d.Exec(`
+		CREATE TABLE IF NOT EXISTS api_tokens (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			scope TEXT NOT NULL,
+			user_id INTEGER NOT NULL,
+			token_hash TEXT NOT NULL UNIQUE,
+			created_at INTEGER NOT NULL,
+			expires_at INTEGER NOT NULL DEFAULT 0,
+			last_used_at INTEGER NOT NULL DEFAULT 0
+		)
+	`)
+	if err != nil {
+		return err
+	}
+	_, err = d.Exec("CREATE INDEX IF NOT EXISTS idx_api_tokens_user ON api_tokens(user_id)")
+	return err
+}

--- a/server-go/internal/apitoken/store_test.go
+++ b/server-go/internal/apitoken/store_test.go
@@ -1,0 +1,150 @@
+package apitoken
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gnacho/netpulse/server-go/internal/auth"
+	"github.com/gnacho/netpulse/server-go/internal/config"
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+func setup(t *testing.T) (*Store, *db.DB) {
+	t.Helper()
+	dir := t.TempDir()
+	d, err := db.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	if err := EnsureSchema(d); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{AuthUser: "admin", AuthPass: "test123456"}
+	if err := auth.EnsureUsers(d, cfg); err != nil {
+		t.Fatal(err)
+	}
+	return NewStore(d, "test-secret"), d
+}
+
+func TestCreateAndValidate(t *testing.T) {
+	s, _ := setup(t)
+	id, raw, err := s.Create("my-token", ScopeRead, 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id == "" || raw == "" {
+		t.Fatal("empty id or raw")
+	}
+	if raw[:3] != TokenPrefix {
+		t.Fatalf("raw should start with %s, got %s", TokenPrefix, raw[:3])
+	}
+	tok := s.Validate(raw)
+	if tok == nil {
+		t.Fatal("validate returned nil")
+	}
+	if tok.Name != "my-token" || tok.Scope != ScopeRead {
+		t.Fatalf("unexpected token: %+v", tok)
+	}
+}
+
+func TestValidateExpired(t *testing.T) {
+	s, d := setup(t)
+	_, raw, err := s.Create("exp", ScopeRead, 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok := s.Validate(raw)
+	if tok == nil {
+		t.Fatal("should be valid now")
+	}
+	_, _ = d.Exec("UPDATE api_tokens SET expires_at = 1 WHERE name = 'exp'")
+	tok = s.Validate(raw)
+	if tok != nil {
+		t.Fatal("should be nil after expiry")
+	}
+}
+
+func TestValidateBadToken(t *testing.T) {
+	s, _ := setup(t)
+	if tok := s.Validate("np_bogus"); tok != nil {
+		t.Fatal("should be nil for bogus token")
+	}
+	if tok := s.Validate("not-a-token"); tok != nil {
+		t.Fatal("should be nil for non-prefixed token")
+	}
+}
+
+func TestListAndDelete(t *testing.T) {
+	s, _ := setup(t)
+	s.Create("t1", ScopeRead, 1, 0)
+	s.Create("t2", ScopeWrite, 1, 0)
+	tokens, err := s.List(1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tokens) != 2 {
+		t.Fatalf("expected 2 tokens, got %d", len(tokens))
+	}
+	if err := s.Delete(tokens[0].ID, 1, false); err != nil {
+		t.Fatal(err)
+	}
+	tokens, _ = s.List(1, false)
+	if len(tokens) != 1 {
+		t.Fatalf("expected 1 token after delete, got %d", len(tokens))
+	}
+}
+
+func TestValidateBearerScope(t *testing.T) {
+	s, _ := setup(t)
+	_, raw, _ := s.Create("admin-tok", ScopeAdmin, 1, 0)
+	user, scope := s.ValidateBearer(raw)
+	if user == nil {
+		t.Fatal("admin token should validate")
+	}
+	if scope != ScopeAdmin {
+		t.Fatalf("expected admin scope, got %s", scope)
+	}
+	if user.Role != "admin" {
+		t.Fatalf("expected admin user, got %s", user.Role)
+	}
+}
+
+func TestValidateBearerRead(t *testing.T) {
+	s, _ := setup(t)
+	_, raw, _ := s.Create("read-tok", ScopeRead, 1, 0)
+	user, scope := s.ValidateBearer(raw)
+	if user == nil {
+		t.Fatal("read token should validate")
+	}
+	if scope != ScopeRead {
+		t.Fatalf("expected read scope, got %s", scope)
+	}
+}
+
+func TestInvalidScope(t *testing.T) {
+	s, _ := setup(t)
+	_, _, err := s.Create("bad", "superadmin", 1, 0)
+	if err == nil {
+		t.Fatal("should reject invalid scope")
+	}
+}
+
+func TestEnsureSchemaIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	d, err := db.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	if err := EnsureSchema(d); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureSchema(d); err != nil {
+		t.Fatal("second call should be idempotent")
+	}
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}

--- a/server-go/internal/auth/middleware.go
+++ b/server-go/internal/auth/middleware.go
@@ -16,6 +16,7 @@ type ctxKey int
 const (
 	ctxUser ctxKey = iota
 	ctxSessionID
+	ctxAPIToken
 )
 
 // UserFromContext devuelve el usuario autenticado (nil si no hay).
@@ -27,6 +28,18 @@ func UserFromContext(ctx context.Context) *User {
 // SessionIDFromContext devuelve el sessionId autenticado ("" si no hay).
 func SessionIDFromContext(ctx context.Context) string {
 	s, _ := ctx.Value(ctxSessionID).(string)
+	return s
+}
+
+// TokenValidator valida un bearer token y devuelve el usuario y scope.
+// Devuelve nil si el token no es válido. Implementado por apitoken.Store.
+type TokenValidator interface {
+	ValidateBearer(raw string) (*User, string)
+}
+
+// APITokenFromContext devuelve el scope del token API usado ("" si no es token).
+func APITokenFromContext(ctx context.Context) string {
+	s, _ := ctx.Value(ctxAPIToken).(string)
 	return s
 }
 
@@ -51,8 +64,9 @@ func WriteError(w http.ResponseWriter, status int, code string, message ...strin
 // Fase 6.2), /api/agents/{slug}/stream (SSE bidireccional, Fase 7.3),
 // /api/agents/{slug}/apply-result, /api/agents/{slug}/upgrade-result y
 // /api/agents/{slug}/upgrade-progress (reportes del agente, auth Bearer).
+// Acepta Bearer tokens de API (#330) como alternativa a la cookie de sesión.
 // Fallo → 401 {error:'unauthorized'}.
-func RequireAuth(d *db.DB, secret string, next http.Handler) http.Handler {
+func RequireAuth(d *db.DB, secret string, tv TokenValidator, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 		if !strings.HasPrefix(path, "/api/") || path == "/api/health" || path == "/api/auth/login" ||
@@ -60,6 +74,16 @@ func RequireAuth(d *db.DB, secret string, next http.Handler) http.Handler {
 			(strings.HasPrefix(path, "/api/agents/") && (strings.HasSuffix(path, "/binary") || strings.HasSuffix(path, "/stream") || strings.HasSuffix(path, "/apply-result") || strings.HasSuffix(path, "/upgrade-result") || strings.HasSuffix(path, "/upgrade-progress"))) {
 			next.ServeHTTP(w, r)
 			return
+		}
+		if tv != nil {
+			if raw := bearerToken(r); raw != "" {
+				if user, scope := tv.ValidateBearer(raw); user != nil {
+					ctx := context.WithValue(r.Context(), ctxUser, user)
+					ctx = context.WithValue(ctx, ctxAPIToken, scope)
+					next.ServeHTTP(w, r.WithContext(ctx))
+					return
+				}
+			}
 		}
 		sess := SessionUserFromRequest(d, secret, r)
 		if sess == nil {
@@ -70,6 +94,17 @@ func RequireAuth(d *db.DB, secret string, next http.Handler) http.Handler {
 		ctx = context.WithValue(ctx, ctxSessionID, sess.SessionID)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+func bearerToken(r *http.Request) string {
+	v := r.Header.Get("Authorization")
+	if v == "" {
+		return ""
+	}
+	if !strings.HasPrefix(v, "Bearer ") {
+		return ""
+	}
+	return strings.TrimPrefix(v, "Bearer ")
 }
 
 // RequireAdmin exige role === 'admin' (tras RequireAuth) → 403 {error:'forbidden'}.

--- a/server-go/internal/httpapi/httpapi_test.go
+++ b/server-go/internal/httpapi/httpapi_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gnacho/netpulse/server-go/internal/adapters"
+	"github.com/gnacho/netpulse/server-go/internal/apitoken"
 	"github.com/gnacho/netpulse/server-go/internal/auth"
 	"github.com/gnacho/netpulse/server-go/internal/config"
 	"github.com/gnacho/netpulse/server-go/internal/db"
@@ -74,11 +75,16 @@ func makeTestServerWithMode(t *testing.T, demoMode bool) *testServer {
 	if err := auth.EnsureUsers(d, cfg); err != nil {
 		t.Fatalf("users: %v", err)
 	}
+	if err := apitoken.EnsureSchema(d); err != nil {
+		t.Fatalf("api_tokens schema: %v", err)
+	}
+	tokenStore := apitoken.NewStore(d, secret)
 	adapter := adapters.NewDemo()
 	hub := sse.NewHub(d, cfg.MaxSSEClients, func() any { return nil })
 	handler := httpapi.NewHandler(httpapi.Deps{
 		Config: cfg, DB: d, Adapter: adapter, Hub: hub, Secret: secret,
-		Started: time.Now(),
+		Started:    time.Now(),
+		TokenStore: tokenStore,
 	})
 	srv := httptest.NewServer(handler)
 	ts := &testServer{Server: srv, db: d, secret: secret}

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/gnacho/netpulse/server-go/internal/adapters"
+	"github.com/gnacho/netpulse/server-go/internal/apitoken"
 	"github.com/gnacho/netpulse/server-go/internal/auth"
 	"github.com/gnacho/netpulse/server-go/internal/config"
 	"github.com/gnacho/netpulse/server-go/internal/db"
@@ -76,6 +77,8 @@ type Deps struct {
 	ServerFP string
 	// Orchestr: motor de plan/apply (Fase 10). nil → sin rutas /api/plans.
 	Orchestr *orchestr.Manager
+	// TokenStore: bearer tokens de API con scopes (#330). nil → sin tokens.
+	TokenStore *apitoken.Store
 }
 
 type server struct {
@@ -118,6 +121,9 @@ type server struct {
 
 	// Ventana de frescura del `ts` del agente (anti-replay, auditoría #2).
 	maxTsDrift time.Duration
+
+	// TokenStore: bearer tokens de API (#330). nil = sin tokens.
+	tokenStore *apitoken.Store
 }
 
 // NewHandler ensambla el handler HTTP completo (API + estáticos + SPA).
@@ -130,6 +136,7 @@ func NewHandler(d Deps) http.Handler {
 		serverFP:    d.ServerFP,
 		ingestLimit: newIPRateLimit(ingestRateLimit, ingestRateWindow),
 		upgrades:    newUpgradeTracker(),
+		tokenStore:  d.TokenStore,
 	}
 	// Rearmer compartido entre el endpoint manual y el supervisor de
 	// auto-rearme (cmd/netpulse lo construye y lo pasa para que ambos
@@ -270,6 +277,11 @@ func NewHandler(d Deps) http.Handler {
 	mux.Handle("DELETE /api/users/{id}", auth.RequireAdmin(http.HandlerFunc(s.handleDeleteUser)))
 	mux.Handle("GET /api/webhook/dlq", auth.RequireAdmin(http.HandlerFunc(s.handleWebhookDLQ)))
 
+	// --- API tokens (#330): CRUD de bearer tokens con scopes ---
+	mux.HandleFunc("GET /api/tokens", s.handleTokensList)
+	mux.HandleFunc("POST /api/tokens", s.handleTokensCreate)
+	mux.HandleFunc("DELETE /api/tokens/{id}", s.handleTokensDelete)
+
 	// --- Config (sesión; /api/config/adguard solo admin) ---
 	s.registerConfigRoutes(mux)
 
@@ -307,7 +319,11 @@ func NewHandler(d Deps) http.Handler {
 		mux.Handle("/", static)
 	}
 
-	return requestID(security.Middleware(auth.RequireSameOrigin(auth.RequireAuth(s.db, s.secret, s.demoReadOnly(noStoreMux(mux))))))
+	var tv auth.TokenValidator
+	if s.tokenStore != nil {
+		tv = s.tokenStore
+	}
+	return requestID(security.Middleware(auth.RequireSameOrigin(auth.RequireAuth(s.db, s.secret, tv, s.demoReadOnly(noStoreMux(mux))))))
 }
 
 // requestID lee o genera un x-request-id para cada petición y lo expone en

--- a/server-go/internal/httpapi/tokens_api.go
+++ b/server-go/internal/httpapi/tokens_api.go
@@ -1,0 +1,96 @@
+package httpapi
+
+import (
+	"net/http"
+
+	"github.com/gnacho/netpulse/server-go/internal/auth"
+)
+
+func (s *server) handleTokensList(w http.ResponseWriter, r *http.Request) {
+	if s.tokenStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "tokens_disabled")
+		return
+	}
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	tokens, err := s.tokenStore.List(user.ID, user.Role == "admin")
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "db_error", err.Error())
+		return
+	}
+	type item struct {
+		ID         string `json:"id"`
+		Name       string `json:"name"`
+		Scope      string `json:"scope"`
+		UserID     int64  `json:"userId"`
+		CreatedAt  int64  `json:"createdAt"`
+		ExpiresAt  int64  `json:"expiresAt"`
+		LastUsedAt int64  `json:"lastUsedAt"`
+	}
+	out := make([]item, 0, len(tokens))
+	for _, t := range tokens {
+		out = append(out, item{
+			ID: t.ID, Name: t.Name, Scope: t.Scope, UserID: t.UserID,
+			CreatedAt: t.CreatedAt, ExpiresAt: t.ExpiresAt, LastUsedAt: t.LastUsedAt,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"tokens": out})
+}
+
+func (s *server) handleTokensCreate(w http.ResponseWriter, r *http.Request) {
+	if s.tokenStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "tokens_disabled")
+		return
+	}
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	var body struct {
+		Name       string `json:"name"`
+		Scope      string `json:"scope"`
+		ExpiresIn  int    `json:"expiresInDays"`
+	}
+	if status := readJSONBody(w, r, &body); status != 0 {
+		writeBodyError(w, status, "invalid_body", "")
+		return
+	}
+	if body.Name == "" || body.Scope == "" {
+		writeError(w, http.StatusBadRequest, "invalid_input", "name and scope required")
+		return
+	}
+	id, raw, err := s.tokenStore.Create(body.Name, body.Scope, user.ID, body.ExpiresIn)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "create_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"id": id, "name": body.Name, "scope": body.Scope, "token": raw,
+	})
+}
+
+func (s *server) handleTokensDelete(w http.ResponseWriter, r *http.Request) {
+	if s.tokenStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "tokens_disabled")
+		return
+	}
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "invalid_input")
+		return
+	}
+	if err := s.tokenStore.Delete(id, user.ID, user.Role == "admin"); err != nil {
+		writeError(w, http.StatusInternalServerError, "db_error", err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/server-go/internal/httpapi/tokens_api_test.go
+++ b/server-go/internal/httpapi/tokens_api_test.go
@@ -1,0 +1,124 @@
+package httpapi_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestTokensCRUD(t *testing.T) {
+	ts := makeTestServer(t)
+	defer ts.Close()
+	_, cookie, _ := loginCookie(t, ts.URL, "admin", "test123456")
+
+	createBody, _ := json.Marshal(map[string]any{
+		"name": "test-token", "scope": "read", "expiresInDays": 0,
+	})
+
+	var created struct {
+		ID    string `json:"id"`
+		Token string `json:"token"`
+	}
+	{
+		req, _ := http.NewRequest("POST", ts.URL+"/api/tokens", bytes.NewReader(createBody))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Cookie", "session="+cookie)
+		resp, _ := http.DefaultClient.Do(req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("create: expected 201, got %d", resp.StatusCode)
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&created)
+		if created.ID == "" || created.Token == "" {
+			t.Fatal("create: empty id or token")
+		}
+	}
+
+	{
+		req, _ := http.NewRequest("GET", ts.URL+"/api/tokens", nil)
+		req.Header.Set("Cookie", "session="+cookie)
+		resp, _ := http.DefaultClient.Do(req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("list: expected 200, got %d", resp.StatusCode)
+		}
+		var body struct {
+			Tokens []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"tokens"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		if len(body.Tokens) != 1 || body.Tokens[0].Name != "test-token" {
+			t.Fatalf("list: unexpected: %+v", body.Tokens)
+		}
+	}
+
+	{
+		req, _ := http.NewRequest("DELETE", ts.URL+"/api/tokens/"+created.ID, nil)
+		req.Header.Set("Cookie", "session="+cookie)
+		resp, _ := http.DefaultClient.Do(req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("delete: expected 204, got %d", resp.StatusCode)
+		}
+	}
+
+	{
+		req, _ := http.NewRequest("GET", ts.URL+"/api/tokens", nil)
+		req.Header.Set("Cookie", "session="+cookie)
+		resp, _ := http.DefaultClient.Do(req)
+		defer resp.Body.Close()
+		var body struct {
+			Tokens []struct{ ID string } `json:"tokens"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		if len(body.Tokens) != 0 {
+			t.Fatalf("after delete: expected 0, got %d", len(body.Tokens))
+		}
+	}
+}
+
+func TestTokenBearerAuth(t *testing.T) {
+	ts := makeTestServer(t)
+	defer ts.Close()
+	_, cookie, _ := loginCookie(t, ts.URL, "admin", "test123456")
+
+	createBody, _ := json.Marshal(map[string]any{
+		"name": "bearer-test", "scope": "read", "expiresInDays": 0,
+	})
+	req, _ := http.NewRequest("POST", ts.URL+"/api/tokens", bytes.NewReader(createBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Cookie", "session="+cookie)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	var created struct {
+		Token string `json:"token"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&created)
+	if created.Token == "" {
+		t.Fatal("no token created")
+	}
+
+	req, _ = http.NewRequest("GET", ts.URL+"/api/overview", nil)
+	req.Header.Set("Authorization", "Bearer "+created.Token)
+	resp2, _ := http.DefaultClient.Do(req)
+	defer resp2.Body.Close()
+	if resp2.StatusCode == http.StatusUnauthorized {
+		t.Fatal("bearer token should authenticate, got 401")
+	}
+}
+
+func TestTokenBearerInvalid(t *testing.T) {
+	ts := makeTestServer(t)
+	defer ts.Close()
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/overview", nil)
+	req.Header.Set("Authorization", "Bearer np_invalidtoken")
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("invalid bearer should get 401, got %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
Closes #330

## What

Bearer token authentication alongside cookie sessions. Tokens with read/write/admin scopes for external integrations (Home Assistant, Grafana, n8n).

## Changes

- **New package `apitoken`**: Store with Create/List/Delete/Validate, HMAC-SHA256 hashing, optional expiry
- **Token format**: `np_<48hex>` — recognisable prefix for easy grep
- **Scopes**: read (GET only), write (GET + mutations), admin (full access, requires admin user)
- **Middleware**: `RequireAuth` now accepts cookie OR Bearer token; `TokenValidator` interface for extensibility
- **API**: `GET /api/tokens`, `POST /api/tokens`, `DELETE /api/tokens/{id}`
- **Frontend**: TokensManager component in Settings — create with name/scope/expiry, one-time token reveal with copy, revoke
- **i18n**: ES + EN keys
- **Tests**: 8 unit tests (store) + 3 integration tests (CRUD + bearer auth + invalid token)

## Usage

```bash
curl -H 'Authorization: Bearer np_abc123...' https://netpulse.example.com/api/overview
```
