### PR TITLE
feat: integrate collector sidecar series into main UI

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1390,5 +1390,13 @@
     "expires": "Expires",
     "lastUsed": "Last used",
     "revoke": "Revoke"
+  },
+  "collector": {
+    "title": "TCP Latency (collector)",
+    "sidecar": "sidecar",
+    "range": "Time range",
+    "ms": "ms",
+    "noData": "No data",
+    "caption": "TCP probes every 5s from the collector daemon"
   }
 }

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1390,5 +1390,13 @@
     "expires": "Caduca",
     "lastUsed": "Último uso",
     "revoke": "Revocar"
+  },
+  "collector": {
+    "title": "Latencia TCP (collector)",
+    "sidecar": "sidecar",
+    "range": "Rango temporal",
+    "ms": "ms",
+    "noData": "Sin datos",
+    "caption": "Sondas TCP cada 5s desde el daemon collector"
   }
 }

--- a/app/src/components/CollectorCharts.tsx
+++ b/app/src/components/CollectorCharts.tsx
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import { Activity, Clock } from 'lucide-react'
+import { SegmentedControl } from '@/components/SegmentedControl'
+
+type Metric = { id: number; key: string; unit: string; kind: string }
+type DataPoint = [number, number]
+
+type Range = '1h' | '24h' | '7d'
+
+const RANGES: { value: Range; label: string; seconds: number }[] = [
+  { value: '1h', label: '1h', seconds: 3600 },
+  { value: '24h', label: '24h', seconds: 86400 },
+  { value: '7d', label: '7d', seconds: 604800 },
+]
+
+function targetName(key: string): string {
+  return key.replace(/^tcp_latency_ms\./, '').replace(/^tcp_ok\./, '')
+}
+
+function isLatency(m: Metric): boolean {
+  return m.key.startsWith('tcp_latency_ms.')
+}
+
+function isAvailability(m: Metric): boolean {
+  return m.key.startsWith('tcp_ok.')
+}
+
+function fmtTime(ts: number): string {
+  return new Date(ts * 1000).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+}
+
+function ChartTooltip({ active, payload }: { active?: boolean; payload?: { value?: number; payload?: { ts: number } }[] }) {
+  const { t } = useTranslation()
+  if (!active || !payload?.length) return null
+  const p = payload[0]!
+  return (
+    <div className="rounded-lg border border-border bg-elevated px-3 py-2 text-xs shadow-lg">
+      <p className="font-mono font-semibold text-text-primary">
+        {p.value?.toFixed(1)} {t('collector.ms')}
+      </p>
+      <p className="text-text-muted">{fmtTime(p.payload?.ts ?? 0)}</p>
+    </div>
+  )
+}
+
+function LatencyChart({ metric, range }: { metric: Metric; range: Range }) {
+  const { t } = useTranslation()
+  const [data, setData] = useState<{ ts: number; value: number }[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const fetchSeries = useCallback(async () => {
+    setLoading(true)
+    const now = Math.floor(Date.now() / 1000)
+    const rangeSec = RANGES.find((r) => r.value === range)?.seconds ?? 3600
+    const from = now - rangeSec
+    try {
+      const r = await fetch(`/api/collector/series?metric=${encodeURIComponent(metric.key)}&from=${from}&to=${now}&points=300`)
+      if (r.ok) {
+        const d = (await r.json()) as { points: DataPoint[] }
+        setData((d.points ?? []).map((p) => ({ ts: p[0], value: p[1] })))
+      }
+    } catch {
+      /* ignore */
+    } finally {
+      setLoading(false)
+    }
+  }, [metric.key, range])
+
+  useEffect(() => {
+    void fetchSeries()
+  }, [fetchSeries])
+
+  const name = targetName(metric.key)
+  const avg = useMemo(() => {
+    if (!data.length) return 0
+    return data.reduce((s, p) => s + p.value, 0) / data.length
+  }, [data])
+
+  if (loading) {
+    return (
+      <div className="flex h-[140px] items-center justify-center text-xs text-text-muted">
+        {t('common.loading')}
+      </div>
+    )
+  }
+
+  if (!data.length) {
+    return (
+      <div className="flex h-[140px] items-center justify-center text-xs text-text-muted">
+        {t('collector.noData')}
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Activity className="h-3.5 w-3.5 text-accent" strokeWidth={1.75} />
+          <span className="text-sm font-medium text-text-primary">{name}</span>
+        </div>
+        <span className="font-mono text-xs text-text-muted">
+          avg {avg.toFixed(1)} {t('collector.ms')}
+        </span>
+      </div>
+      <div className="h-[120px]">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={data} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
+            <defs>
+              <linearGradient id={`coll-${name}`} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="var(--accent)" stopOpacity={0.3} />
+                <stop offset="100%" stopColor="var(--accent)" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />
+            <XAxis
+              dataKey="ts"
+              tickFormatter={fmtTime}
+              tick={{ fontSize: 10, fill: 'var(--text-muted)' }}
+              axisLine={false}
+              tickLine={false}
+              minTickGap={40}
+            />
+            <YAxis hide domain={[0, 'auto']} />
+            <Tooltip content={<ChartTooltip />} />
+            <Area
+              type="monotone"
+              dataKey="value"
+              stroke="var(--accent)"
+              strokeWidth={1.5}
+              fill={`url(#coll-${name})`}
+              isAnimationActive={false}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}
+
+export function CollectorCharts() {
+  const { t } = useTranslation()
+  const [metrics, setMetrics] = useState<Metric[]>([])
+  const [available, setAvailable] = useState(false)
+  const [range, setRange] = useState<Range>('1h')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let alive = true
+    void fetch('/api/collector/metrics')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (!alive) return
+        const m = (d?.metrics ?? []) as Metric[]
+        setMetrics(m)
+        setAvailable(!!d?.available)
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        if (alive) setLoading(false)
+      })
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  if (loading) return null
+  if (!available) return null
+
+  const latencyMetrics = metrics.filter(isLatency)
+  const availMetrics = metrics.filter(isAvailability)
+
+  if (!latencyMetrics.length) return null
+
+  const uptimeTargets = availMetrics.filter((m) => {
+    const name = targetName(m.key)
+    return latencyMetrics.some((l) => targetName(l.key) === name)
+  })
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Clock className="h-4 w-4 text-text-muted" strokeWidth={1.75} />
+          <h3 className="text-sm font-semibold text-text-primary">{t('collector.title')}</h3>
+          <span className="rounded-full bg-ok/10 px-2 py-0.5 text-[10px] font-semibold text-ok">
+            {t('collector.sidecar')}
+          </span>
+        </div>
+        <SegmentedControl
+          options={RANGES.map((r) => ({ value: r.value, label: r.label }))}
+          value={range}
+          onChange={(v) => setRange(v as Range)}
+          ariaLabel={t('collector.range')}
+        />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {latencyMetrics.map((m) => (
+          <LatencyChart key={m.key} metric={m} range={range} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/src/pages/Home.tsx
+++ b/app/src/pages/Home.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import { CollectorCharts } from '@/components/CollectorCharts'
 import { AdGuardCard, WireGuardCard } from '@/sections/GatewayServices'
 import { HeroStrip } from '@/sections/HeroStrip'
 import { RecentAlerts } from '@/sections/RecentAlerts'
@@ -44,6 +45,12 @@ export default function Home() {
       <div className="lg:col-span-12">
         <RoutersRow />
       </div>
+      {/* ④ Collector sidecar (#328): latencia TCP por router desde el daemon */}
+      {!isDemo && (
+        <div className="lg:col-span-12">
+          <CollectorCharts />
+        </div>
+      )}
       {/* Top dispositivos: solo demo (en live no hay tráfico por dispositivo) */}
       {isDemo && (
         <div className="lg:col-span-12">

--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gnacho/netpulse/server-go/internal/alerts"
 	"github.com/gnacho/netpulse/server-go/internal/apitoken"
 	"github.com/gnacho/netpulse/server-go/internal/auth"
+	"github.com/gnacho/netpulse/server-go/internal/collectorreader"
 	"github.com/gnacho/netpulse/server-go/internal/config"
 	"github.com/gnacho/netpulse/server-go/internal/db"
 	"github.com/gnacho/netpulse/server-go/internal/httpapi"
@@ -195,6 +196,15 @@ func run() error {
 		return fmt.Errorf("api tokens schema: %w", err)
 	}
 	tokenStore := apitoken.NewStore(dbHandle, secret)
+	var collReader *collectorreader.Reader
+	if collPath := os.Getenv("COLLECTOR_DB"); collPath != "" {
+		if cr, err := collectorreader.Open(collPath); err != nil {
+			log.Printf("[netpulse] aviso: collector sidecar no disponible (%v)", err)
+		} else {
+			collReader = cr
+			log.Printf("[netpulse] collector sidecar: %s", collPath)
+		}
+	}
 
 	// Clave SSH propia para sondear routers (se genera la primera vez)
 	if err := sshkey.EnsureKeypair(cfg.SSHKeyPath); err != nil {
@@ -383,20 +393,21 @@ func run() error {
 	}
 
 	handler := httpapi.NewHandler(httpapi.Deps{
-		Config:     cfg,
-		DB:         dbHandle,
-		Adapter:    adapter,
-		Hub:        hub,
-		Secret:     secret,
-		Static:     static,
-		Updater:    upd,
-		Agents:     agentReg,
-		Pool:       sshPool,
-		Rearmer:    arm,
-		AgentHub:   agentHub,
-		ServerFP:   serverFP,
-		Orchestr:   orchMgr,
-		TokenStore: tokenStore,
+		Config:          cfg,
+		DB:              dbHandle,
+		Adapter:         adapter,
+		Hub:             hub,
+		Secret:          secret,
+		Static:          static,
+		Updater:         upd,
+		Agents:          agentReg,
+		Pool:            sshPool,
+		Rearmer:         arm,
+		AgentHub:        agentHub,
+		ServerFP:        serverFP,
+		Orchestr:        orchMgr,
+		TokenStore:      tokenStore,
+		CollectorReader: collReader,
 		LastOverview: func() *adapters.Overview {
 			return p.LastOverview()
 		},

--- a/server-go/internal/collectorreader/reader.go
+++ b/server-go/internal/collectorreader/reader.go
@@ -1,0 +1,146 @@
+package collectorreader
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "modernc.org/sqlite"
+)
+
+type Metric struct {
+	ID   int64  `json:"id"`
+	Key  string `json:"key"`
+	Unit string `json:"unit"`
+	Kind string `json:"kind"`
+}
+
+type Point [2]float64
+
+type Reader struct {
+	db *sql.DB
+}
+
+func Open(path string) (*Reader, error) {
+	dsn := fmt.Sprintf("file:%s?mode=ro&_pragma=busy_timeout(3000)", path)
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return &Reader{db: db}, nil
+}
+
+func (r *Reader) Close() error {
+	return r.db.Close()
+}
+
+func (r *Reader) ListMetrics() ([]Metric, error) {
+	rows, err := r.db.Query("SELECT id, key, unit, kind FROM metrics ORDER BY key")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Metric
+	for rows.Next() {
+		var m Metric
+		if err := rows.Scan(&m.ID, &m.Key, &m.Unit, &m.Kind); err != nil {
+			return nil, err
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+func (r *Reader) Series(key string, from, to int64, points int) (string, []Point, error) {
+	var metricID int64
+	if err := r.db.QueryRow("SELECT id FROM metrics WHERE key = ?", key).Scan(&metricID); err != nil {
+		return "", nil, fmt.Errorf("unknown metric: %s", key)
+	}
+	var rows *sql.Rows
+	var err error
+	var resolution string
+	switch span := to - from; {
+	case span <= 2*86400:
+		resolution = "raw"
+		rows, err = r.db.Query("SELECT ts, value FROM samples WHERE metric_id = ? AND ts BETWEEN ? AND ? ORDER BY ts", metricID, from, to)
+	case span <= 60*86400:
+		resolution = "5m"
+		rows, err = r.db.Query("SELECT bucket_ts, avg FROM buckets WHERE metric_id = ? AND bucket_ts BETWEEN ? AND ? ORDER BY bucket_ts", metricID, from, to)
+	default:
+		resolution = "1d"
+		rows, err = r.db.Query("SELECT CAST(strftime('%s', date) AS INTEGER), avg FROM daily WHERE metric_id = ? AND date BETWEEN date(?, 'unixepoch') AND date(?, 'unixepoch') ORDER BY date", metricID, from, to)
+	}
+	if err != nil {
+		return "", nil, err
+	}
+	defer rows.Close()
+	var data []Point
+	for rows.Next() {
+		var p Point
+		if err := rows.Scan(&p[0], &p[1]); err != nil {
+			return "", nil, err
+		}
+		data = append(data, p)
+	}
+	if err := rows.Err(); err != nil {
+		return "", nil, err
+	}
+	if points > 2000 {
+		points = 2000
+	}
+	if points > 0 && len(data) > points {
+		data = lttb(data, points)
+	}
+	return resolution, data, nil
+}
+
+func lttb(data []Point, threshold int) []Point {
+	n := len(data)
+	if threshold >= n || threshold <= 0 {
+		return data
+	}
+	out := make([]Point, 0, threshold)
+	out = append(out, data[0])
+	every := float64(n-2) / float64(threshold-2)
+	a := 0
+	for i := 0; i < threshold-2; i++ {
+		rs := int(float64(i+1)*every) + 1
+		re := int(float64(i+2)*every) + 1
+		if re > n {
+			re = n
+		}
+		var ax, ay float64
+		for j := rs; j < re; j++ {
+			ax += data[j][0]
+			ay += data[j][1]
+		}
+		ax /= float64(re - rs)
+		ay /= float64(re - rs)
+		bs := int(float64(i)*every) + 1
+		be := int(float64(i+1)*every) + 1
+		px, py := data[a][0], data[a][1]
+		maxA := -1.0
+		na := bs
+		for j := bs; j < be; j++ {
+			area := abs((px-ax)*(data[j][1]-py) - (px-data[j][0])*(ay-py))
+			if area > maxA {
+				maxA = area
+				na = j
+			}
+		}
+		out = append(out, data[na])
+		a = na
+	}
+	return append(out, data[n-1])
+}
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/server-go/internal/collectorreader/reader_test.go
+++ b/server-go/internal/collectorreader/reader_test.go
@@ -1,0 +1,124 @@
+package collectorreader
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func setupTestDB(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metrics.db")
+	db, err := sql.Open("sqlite", "file:"+path+"?_pragma=journal_mode(WAL)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	_, err = db.Exec(`
+		CREATE TABLE metrics (id INTEGER PRIMARY KEY, key TEXT NOT NULL UNIQUE, unit TEXT NOT NULL, kind TEXT NOT NULL DEFAULT 'gauge', max_value REAL, max_rate REAL, max_daily REAL);
+		CREATE TABLE samples (ts INTEGER NOT NULL, metric_id INTEGER NOT NULL REFERENCES metrics(id), value REAL NOT NULL);
+		CREATE INDEX idx_samples_metric_ts ON samples(metric_id, ts);
+		CREATE TABLE buckets (bucket_ts INTEGER NOT NULL, metric_id INTEGER NOT NULL REFERENCES metrics(id), n INTEGER NOT NULL, min REAL NOT NULL, max REAL NOT NULL, avg REAL NOT NULL, sum REAL NOT NULL, PRIMARY KEY (metric_id, bucket_ts));
+		CREATE TABLE daily (date TEXT NOT NULL, metric_id INTEGER NOT NULL REFERENCES metrics(id), n INTEGER NOT NULL, min REAL NOT NULL, max REAL NOT NULL, avg REAL NOT NULL, sum REAL NOT NULL, PRIMARY KEY (metric_id, date));
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec("INSERT INTO metrics (id, key, unit, kind) VALUES (1, 'tcp_latency_ms.test', 'ms', 'gauge')")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().Unix()
+	for i := 0; i < 100; i++ {
+		ts := now - int64(100-i)*5
+		_, err = db.Exec("INSERT INTO samples (ts, metric_id, value) VALUES (?, 1, ?)", ts, float64(10+i%20))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return path
+}
+
+func TestOpenAndList(t *testing.T) {
+	path := setupTestDB(t)
+	r, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	metrics, err := r.ListMetrics()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(metrics))
+	}
+	if metrics[0].Key != "tcp_latency_ms.test" {
+		t.Fatalf("unexpected key: %s", metrics[0].Key)
+	}
+}
+
+func TestSeries(t *testing.T) {
+	path := setupTestDB(t)
+	r, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	now := time.Now().Unix()
+	res, data, err := r.Series("tcp_latency_ms.test", now-600, now, 500)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res != "raw" {
+		t.Fatalf("expected raw resolution, got %s", res)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected data points")
+	}
+}
+
+func TestSeriesUnknown(t *testing.T) {
+	path := setupTestDB(t)
+	r, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	now := time.Now().Unix()
+	_, _, err = r.Series("nonexistent", now-600, now, 500)
+	if err == nil {
+		t.Fatal("expected error for unknown metric")
+	}
+}
+
+func TestOpenNonexistent(t *testing.T) {
+	_, err := Open("/nonexistent/path/metrics.db")
+	if err == nil {
+		t.Fatal("expected error for nonexistent db")
+	}
+}
+
+func TestLTTB(t *testing.T) {
+	data := make([]Point, 100)
+	for i := range data {
+		data[i] = Point{float64(i), float64(i % 10)}
+	}
+	result := lttb(data, 20)
+	if len(result) != 20 {
+		t.Fatalf("expected 20 points, got %d", len(result))
+	}
+	if result[0][0] != data[0][0] {
+		t.Fatal("first point should be preserved")
+	}
+	if result[len(result)-1][0] != data[len(data)-1][0] {
+		t.Fatal("last point should be preserved")
+	}
+}
+
+var _ = os.Remove

--- a/server-go/internal/httpapi/collector_api.go
+++ b/server-go/internal/httpapi/collector_api.go
@@ -1,0 +1,68 @@
+package httpapi
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/collectorreader"
+)
+
+func (s *server) handleCollectorMetrics(w http.ResponseWriter, r *http.Request) {
+	if s.collectorReader == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"metrics": []any{}, "available": false})
+		return
+	}
+	metrics, err := s.collectorReader.ListMetrics()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "collector_error", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"metrics": metrics, "available": true})
+}
+
+func (s *server) handleCollectorSeries(w http.ResponseWriter, r *http.Request) {
+	if s.collectorReader == nil {
+		writeError(w, http.StatusServiceUnavailable, "collector_unavailable")
+		return
+	}
+	metric := r.URL.Query().Get("metric")
+	if metric == "" {
+		writeError(w, http.StatusBadRequest, "invalid_input", "metric required")
+		return
+	}
+	now := time.Now().Unix()
+	fromStr := r.URL.Query().Get("from")
+	toStr := r.URL.Query().Get("to")
+	pointsStr := r.URL.Query().Get("points")
+	from := now - 86400
+	to := now
+	points := 500
+	if fromStr != "" {
+		if v, err := strconv.ParseInt(fromStr, 10, 64); err == nil {
+			from = v
+		}
+	}
+	if toStr != "" {
+		if v, err := strconv.ParseInt(toStr, 10, 64); err == nil {
+			to = v
+		}
+	}
+	if pointsStr != "" {
+		if v, err := strconv.Atoi(pointsStr); err == nil && v > 0 {
+			points = v
+		}
+	}
+	resolution, data, err := s.collectorReader.Series(metric, from, to, points)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "series_error", err.Error())
+		return
+	}
+	if data == nil {
+		data = []collectorreader.Point{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"metric": metric, "resolution": resolution, "points": data,
+		"from": from, "to": to,
+	})
+}

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gnacho/netpulse/server-go/internal/adapters"
 	"github.com/gnacho/netpulse/server-go/internal/apitoken"
 	"github.com/gnacho/netpulse/server-go/internal/auth"
+	"github.com/gnacho/netpulse/server-go/internal/collectorreader"
 	"github.com/gnacho/netpulse/server-go/internal/config"
 	"github.com/gnacho/netpulse/server-go/internal/db"
 	"github.com/gnacho/netpulse/server-go/internal/orchestr"
@@ -79,6 +80,8 @@ type Deps struct {
 	Orchestr *orchestr.Manager
 	// TokenStore: bearer tokens de API con scopes (#330). nil → sin tokens.
 	TokenStore *apitoken.Store
+	// CollectorReader: lector read-only de metrics.db del sidecar (#328).
+	CollectorReader *collectorreader.Reader
 }
 
 type server struct {
@@ -124,6 +127,9 @@ type server struct {
 
 	// TokenStore: bearer tokens de API (#330). nil = sin tokens.
 	tokenStore *apitoken.Store
+
+	// CollectorReader: lector read-only de metrics.db del sidecar (#328).
+	collectorReader *collectorreader.Reader
 }
 
 // NewHandler ensambla el handler HTTP completo (API + estáticos + SPA).
@@ -133,10 +139,11 @@ func NewHandler(d Deps) http.Handler {
 		secret: d.Secret, agents: d.Agents, pool: d.Pool,
 		lastOv: d.LastOverview, pollNow: d.PollNow, started: d.Started,
 		agentHub:    d.AgentHub,
-		serverFP:    d.ServerFP,
-		ingestLimit: newIPRateLimit(ingestRateLimit, ingestRateWindow),
-		upgrades:    newUpgradeTracker(),
-		tokenStore:  d.TokenStore,
+		serverFP:        d.ServerFP,
+		ingestLimit:     newIPRateLimit(ingestRateLimit, ingestRateWindow),
+		upgrades:        newUpgradeTracker(),
+		tokenStore:      d.TokenStore,
+		collectorReader: d.CollectorReader,
 	}
 	// Rearmer compartido entre el endpoint manual y el supervisor de
 	// auto-rearme (cmd/netpulse lo construye y lo pasa para que ambos
@@ -284,6 +291,10 @@ func NewHandler(d Deps) http.Handler {
 	mux.HandleFunc("GET /api/tokens", s.handleTokensList)
 	mux.HandleFunc("POST /api/tokens", s.handleTokensCreate)
 	mux.HandleFunc("DELETE /api/tokens/{id}", s.handleTokensDelete)
+
+	// --- Collector sidecar (#328): series de latencia/disponibilidad ---
+	mux.HandleFunc("GET /api/collector/metrics", s.handleCollectorMetrics)
+	mux.HandleFunc("GET /api/collector/series", s.handleCollectorSeries)
 
 	// --- Config (sesión; /api/config/adguard solo admin) ---
 	s.registerConfigRoutes(mux)


### PR DESCRIPTION
Closes #328

## What

Surface the collector sidecar's TCP latency/availability time series in the main NetPulse UI, eliminating the two-sources-of-truth problem documented in ARCHITECTURE.md.

## Changes

- **New package `collectorreader`**: Read-only access to the collector's `metrics.db` SQLite — never writes, never locks the daemon
- **Activation**: Set `COLLECTOR_DB=/path/to/metrics.db` env var; reader opens in `mode=ro` with busy_timeout
- **API**:
  - `GET /api/collector/metrics` — list available metrics (tcp_latency_ms.*, tcp_ok.*, collector_uptime_s)
  - `GET /api/collector/series?metric=X&from=Y&to=Z&points=N` — downsampled series (auto raw/5m/daily based on range, LTTB to cap points)
- **Frontend**: `CollectorCharts` component on Home page — per-router latency charts with 1h/24h/7d range selector, recharts area graphs
- **i18n**: ES + EN keys for collector section
- **Tests**: 5 tests (open, list, series, unknown metric, LTTB downsampling)
- **Graceful degradation**: Without `COLLECTOR_DB` set, endpoints return `available: false` / 503; UI component renders nothing

## Deployment

Set in the NetPulse service environment:
```
COLLECTOR_DB=/opt/netpulse-collector/data/metrics.db
```
