### PR TITLE
feat: UI reskin - palettes, surfaces, KPIs, alert borders, topology glows

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1171,7 +1171,13 @@
       "saveError": "Could not save the device",
       "deleteError": "Could not remove the device",
       "loadError": "Could not load trusted devices"
-    }
+    },
+    "palette": "Palette",
+    "paletteCaption": "Palette changes all interface colors. Accent only changes the primary color.",
+    "paletteNetpulse": "NetPulse",
+    "paletteNoc": "Warm NOC",
+    "palettePhosphor": "Phosphor",
+    "paletteElectric": "Electric"
   },
   "statcard": {
     "vsPrevious": "vs previous"

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1171,7 +1171,13 @@
       "saveError": "No se pudo guardar el dispositivo",
       "deleteError": "No se pudo quitar el dispositivo",
       "loadError": "No se pudieron cargar los dispositivos de confianza"
-    }
+    },
+    "palette": "Paleta",
+    "paletteCaption": "La paleta cambia todos los colores de la interfaz. El acento solo cambia el color principal.",
+    "paletteNetpulse": "NetPulse",
+    "paletteNoc": "NOC Calido",
+    "palettePhosphor": "Fosforo",
+    "paletteElectric": "Electrico"
   },
   "statcard": {
     "vsPrevious": "vs anterior"

--- a/app/src/components/AlertItem.tsx
+++ b/app/src/components/AlertItem.tsx
@@ -4,11 +4,11 @@ import { relTime } from '@/i18n'
 import type { AlertSeverity, AlertEvent } from '@/data/mock'
 import { cn } from '@/lib/utils'
 
-const SEVERITY: Record<AlertSeverity, { icon: LucideIcon; tile: string; dot: string }> = {
-  warn: { icon: AlertTriangle, tile: 'bg-warn/10 text-warn', dot: 'bg-warn' },
-  critical: { icon: OctagonX, tile: 'bg-danger/10 text-danger', dot: 'bg-danger' },
-  info: { icon: Info, tile: 'bg-info/10 text-info', dot: 'bg-info' },
-  ok: { icon: CheckCircle2, tile: 'bg-ok/10 text-ok', dot: 'bg-ok' },
+const SEVERITY: Record<AlertSeverity, { icon: LucideIcon; tile: string; dot: string; stripe: string }> = {
+  warn: { icon: AlertTriangle, tile: 'bg-warn/10 text-warn', dot: 'bg-warn', stripe: 'border-l-warn' },
+  critical: { icon: OctagonX, tile: 'bg-danger/10 text-danger', dot: 'bg-danger', stripe: 'border-l-danger' },
+  info: { icon: Info, tile: 'bg-info/10 text-info', dot: 'bg-info', stripe: 'border-l-info' },
+  ok: { icon: CheckCircle2, tile: 'bg-ok/10 text-ok', dot: 'bg-ok', stripe: 'border-l-ok' },
 }
 
 interface AlertItemProps {
@@ -26,7 +26,8 @@ export function AlertItem({ alert, onClick, className }: AlertItemProps) {
       type="button"
       onClick={onClick}
       className={cn(
-        'group flex w-full items-start gap-3 rounded-xl px-3 py-3 text-left transition-colors duration-150 hover:bg-hover',
+        'group flex w-full items-start gap-3 rounded-xl border-l-[3px] px-3 py-3 text-left transition-colors duration-150 hover:bg-hover',
+        s.stripe,
         !alert.read && 'bg-elevated',
         className,
       )}

--- a/app/src/components/routers/FleetCard.tsx
+++ b/app/src/components/routers/FleetCard.tsx
@@ -154,7 +154,7 @@ export function FleetCard({ router, index = 0, refreshKey = 0 }: FleetCardProps)
                 delay={0.2 + index * 0.1}
                 ariaLabel={t('common.healthOf', { name: router.name, health: router.health })}
                 center={
-                  <span className="font-display text-lg font-bold text-text-primary">{router.health}</span>
+                  <span className="kpi-value text-lg font-bold text-text-primary">{router.health}</span>
                 }
               />
             </motion.div>

--- a/app/src/components/routers/RouterPerformance.tsx
+++ b/app/src/components/routers/RouterPerformance.tsx
@@ -135,7 +135,7 @@ export function RouterPerformance({ router }: { router: Router }) {
               </div>
             </div>
             <div className="w-20 shrink-0 text-right sm:w-24">
-              <div className="font-mono text-xl font-semibold text-text-primary">
+              <div className="kpi-value text-xl font-semibold text-text-primary">
                 <CountUp key={range} value={current[s.key]} />
                 <span className="ml-0.5 text-xs font-medium text-text-secondary">{s.unit}</span>
               </div>

--- a/app/src/components/topology/TopologyMap.tsx
+++ b/app/src/components/topology/TopologyMap.tsx
@@ -774,6 +774,30 @@ export function TopologyMap({ model, apiRef, showLabels, flow, hoverLink, onHove
             <stop offset="0%" stopColor={COLOR.accent} stopOpacity="0.28" />
             <stop offset="100%" stopColor={COLOR.tunnel} stopOpacity="0.28" />
           </linearGradient>
+          <filter id="glow-ok" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="3" result="blur" />
+            <feFlood floodColor={COLOR.ok} floodOpacity="0.4" result="color" />
+            <feComposite in="color" in2="blur" operator="in" result="glow" />
+            <feMerge><feMergeNode in="glow" /><feMergeNode in="SourceGraphic" /></feMerge>
+          </filter>
+          <filter id="glow-warn" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="4" result="blur" />
+            <feFlood floodColor={COLOR.warn} floodOpacity="0.5" result="color" />
+            <feComposite in="color" in2="blur" operator="in" result="glow" />
+            <feMerge><feMergeNode in="glow" /><feMergeNode in="SourceGraphic" /></feMerge>
+          </filter>
+          <filter id="glow-danger" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="4" result="blur" />
+            <feFlood floodColor={COLOR.danger} floodOpacity="0.5" result="color" />
+            <feComposite in="color" in2="blur" operator="in" result="glow" />
+            <feMerge><feMergeNode in="glow" /><feMergeNode in="SourceGraphic" /></feMerge>
+          </filter>
+          <filter id="glow-tunnel" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="3" result="blur" />
+            <feFlood floodColor={COLOR.tunnel} floodOpacity="0.35" result="color" />
+            <feComposite in="color" in2="blur" operator="in" result="glow" />
+            <feMerge><feMergeNode in="glow" /><feMergeNode in="SourceGraphic" /></feMerge>
+          </filter>
         </defs>
 
         {/* ------------------------- Anillos guía wifi ------------------------- */}
@@ -818,6 +842,7 @@ export function TopologyMap({ model, apiRef, showLabels, flow, hoverLink, onHove
                   strokeLinecap="round"
                   strokeDasharray={isWg ? '7 7' : isWifiUp ? '8 6' : undefined}
                   opacity={baseOpacity}
+                  filter={isWg ? 'url(#glow-tunnel)' : undefined}
                   initial={reduce ? { pathLength: 1 } : { pathLength: 0 }}
                   animate={{ pathLength: 1 }}
                   transition={reduce ? { duration: 0 } : { delay: drawDelay * T, duration: 0.4, ease: 'easeOut' }}
@@ -941,6 +966,8 @@ export function TopologyMap({ model, apiRef, showLabels, flow, hoverLink, onHove
         {routerNodes.map((node, i) => {
           const isGw = node.router.roleBadge === 'Principal'
           const isWarn = node.router.status === 'warn'
+          const isOffline = node.router.status === 'offline'
+          const glowFilter = isOffline ? 'url(#glow-danger)' : isWarn ? 'url(#glow-warn)' : undefined
           const delay = isGw ? 0.55 : 1.0 + (i - 1) * 0.15
           const Icon = RouterIcon
           return (
@@ -1003,8 +1030,9 @@ export function TopologyMap({ model, apiRef, showLabels, flow, hoverLink, onHove
                 <circle
                   r={node.r}
                   fill={isGw ? 'url(#topo-gw-grad)' : 'rgb(var(--elevated))'}
-                  stroke={isWarn ? COLOR.warn : isGw ? COLOR.accent : 'rgb(var(--border-strong))'}
-                  strokeWidth={isGw || isWarn ? 2 : 1.5}
+                  stroke={isOffline ? COLOR.danger : isWarn ? COLOR.warn : isGw ? COLOR.accent : 'rgb(var(--border-strong))'}
+                  strokeWidth={isGw || isWarn || isOffline ? 2 : 1.5}
+                  filter={glowFilter}
                 />
                 <StatusRing node={node} delay={(delay + 0.2) * T} reduce={reduce ?? false} />
                 <Icon

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -204,6 +204,66 @@
 }
 
 @layer utilities {
+  /* Surface hierarchy (#21): elevated cards get accent glow + stronger border */
+  .surface-elevated {
+    border-color: rgb(var(--border-strong));
+    box-shadow:
+      0 0 0 1px rgb(var(--accent) / 0.08),
+      0 4px 24px -8px rgb(var(--accent) / 0.12);
+  }
+  .surface-featured {
+    border-color: rgb(var(--accent) / 0.25);
+    background: linear-gradient(
+      135deg,
+      rgb(var(--surface)) 0%,
+      rgb(var(--accent) / 0.03) 100%
+    );
+    box-shadow:
+      0 0 0 1px rgb(var(--accent) / 0.1),
+      0 8px 32px -12px rgb(var(--accent) / 0.18);
+  }
+
+  /* Status glows (#21): subtle border glow for health states */
+  .glow-ok { box-shadow: 0 0 20px -8px rgb(var(--ok) / 0.3); }
+  .glow-warn { box-shadow: 0 0 20px -8px rgb(var(--warn) / 0.3); }
+  .glow-danger { box-shadow: 0 0 20px -8px rgb(var(--danger) / 0.3); }
+  .glow-accent { box-shadow: 0 0 20px -8px rgb(var(--accent) / 0.3); }
+
+  /* KPI typography (#22): display font + tabular nums for hero metrics */
+  .kpi-value {
+    font-family: var(--font-display);
+    font-feature-settings: "tnum";
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.02em;
+  }
+  .kpi-delta-up {
+    color: rgb(var(--ok));
+  }
+  .kpi-delta-down {
+    color: rgb(var(--danger));
+  }
+  .kpi-delta-flat {
+    color: rgb(var(--text-muted));
+  }
+
+  /* SSE flash (#22): brief highlight when a value updates via SSE */
+  .flash-sse {
+    animation: kpi-flash 0.6s ease-out;
+  }
+  @keyframes kpi-flash {
+    0% { background-color: rgb(var(--accent) / 0.15); }
+    100% { background-color: transparent; }
+  }
+
+  /* Count-up entrance (#22) */
+  .count-up-enter {
+    animation: count-up 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+  @keyframes count-up {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
   /* Safe areas (PWA, design.md §12) */
   .pt-safe {
     padding-top: env(safe-area-inset-top);

--- a/app/src/lib/theme-boot.ts
+++ b/app/src/lib/theme-boot.ts
@@ -1,7 +1,7 @@
 /**
- * Boot de preferencias (anti-FOUC) — webapp-shell.
+ * Boot de preferencias (anti-FOUC) - webapp-shell.
  * Corrige los caveats de NetPulse: el modo `system` se restaura al arrancar,
- * el listener de matchMedia vive aquí (no en Ajustes) y el acento/densidad
+ * el listener de matchMedia vive aqui (no en Ajustes) y el acento/densidad
  * se aplican antes del primer render (sobreviven reload).
  */
 
@@ -15,9 +15,99 @@ export const ACCENTS = [
 export type AccentId = (typeof ACCENTS)[number]['id']
 export type ThemeMode = 'dark' | 'light' | 'system'
 
+export interface PaletteDef {
+  id: string
+  labelKey: string
+  swatch: string
+  dark: Record<string, string>
+  light: Record<string, string>
+}
+
+export const PALETTES: PaletteDef[] = [
+  {
+    id: 'netpulse',
+    labelKey: 'settings.paletteNetpulse',
+    swatch: '#22D3EE',
+    dark: {
+      canvas: '7 11 18', surface: '13 20 32', elevated: '19 28 44', hover: '26 36 54',
+      border: '30 42 61', 'border-strong': '42 58 82',
+      'text-primary': '232 238 247', 'text-secondary': '154 168 188', 'text-muted': '91 107 130',
+      accent: '34 211 238', tunnel: '167 139 250',
+      ok: '52 211 153', warn: '251 191 36', danger: '248 113 113', info: '96 165 250',
+    },
+    light: {
+      canvas: '243 245 249', surface: '255 255 255', elevated: '255 255 255', hover: '241 245 249',
+      border: '226 232 240', 'border-strong': '203 213 225',
+      'text-primary': '15 23 42', 'text-secondary': '71 85 105', 'text-muted': '100 116 139',
+      accent: '8 145 178', tunnel: '124 58 237',
+      ok: '5 150 105', warn: '217 119 6', danger: '220 38 38', info: '37 99 235',
+    },
+  },
+  {
+    id: 'noc',
+    labelKey: 'settings.paletteNoc',
+    swatch: '#F59E0B',
+    dark: {
+      canvas: '10 10 10', surface: '20 18 16', elevated: '30 26 22', hover: '40 34 28',
+      border: '50 42 34', 'border-strong': '70 58 46',
+      'text-primary': '245 240 230', 'text-secondary': '180 168 150', 'text-muted': '120 108 92',
+      accent: '245 158 11', tunnel: '249 115 22',
+      ok: '132 204 22', warn: '249 115 22', danger: '239 68 68', info: '56 189 248',
+    },
+    light: {
+      canvas: '250 248 245', surface: '255 255 255', elevated: '255 255 255', hover: '245 240 232',
+      border: '230 222 210', 'border-strong': '210 198 180',
+      'text-primary': '28 25 20', 'text-secondary': '80 72 60', 'text-muted': '130 118 100',
+      accent: '180 110 0', tunnel: '194 80 0',
+      ok: '100 160 10', warn: '194 80 0', danger: '200 40 40', info: '14 165 233',
+    },
+  },
+  {
+    id: 'phosphor',
+    labelKey: 'settings.palettePhosphor',
+    swatch: '#00FF41',
+    dark: {
+      canvas: '8 12 8', surface: '14 22 14', elevated: '20 32 20', hover: '26 42 26',
+      border: '32 52 32', 'border-strong': '46 72 46',
+      'text-primary': '220 245 220', 'text-secondary': '140 185 140', 'text-muted': '80 120 80',
+      accent: '0 255 65', tunnel: '0 212 170',
+      ok: '0 255 65', warn: '255 200 0', danger: '255 68 68', info: '0 180 220',
+    },
+    light: {
+      canvas: '245 250 245', surface: '255 255 255', elevated: '255 255 255', hover: '238 248 238',
+      border: '215 235 215', 'border-strong': '185 215 185',
+      'text-primary': '15 30 15', 'text-secondary': '55 85 55', 'text-muted': '95 130 95',
+      accent: '0 140 35', tunnel: '0 130 105',
+      ok: '0 140 35', warn: '180 140 0', danger: '200 40 40', info: '0 130 160',
+    },
+  },
+  {
+    id: 'electric',
+    labelKey: 'settings.paletteElectric',
+    swatch: '#06B6D4',
+    dark: {
+      canvas: '5 10 20', surface: '12 20 36', elevated: '18 28 50', hover: '24 36 62',
+      border: '32 46 74', 'border-strong': '48 66 100',
+      'text-primary': '235 242 255', 'text-secondary': '160 175 210', 'text-muted': '95 112 150',
+      accent: '6 182 212', tunnel: '224 64 251',
+      ok: '45 212 191', warn: '255 107 107', danger: '244 63 94', info: '99 102 241',
+    },
+    light: {
+      canvas: '240 245 255', surface: '255 255 255', elevated: '255 255 255', hover: '235 240 252',
+      border: '215 225 245', 'border-strong': '190 205 235',
+      'text-primary': '10 18 40', 'text-secondary': '55 70 110', 'text-muted': '100 115 155',
+      accent: '6 140 165', tunnel: '168 30 200',
+      ok: '13 148 130', warn: '200 60 60', danger: '190 30 60', info: '79 70 229',
+    },
+  },
+] as const
+
+export type PaletteId = (typeof PALETTES)[number]['id']
+
 const MODE_KEY = 'netpulse-theme-mode'
-const LEGACY_KEY = 'netpulse-theme' // último valor resuelto (compat con ThemeToggle viejo)
+const LEGACY_KEY = 'netpulse-theme'
 const ACCENT_KEY = 'netpulse-accent'
+const PALETTE_KEY = 'netpulse-palette'
 const DENSITY_KEY = 'netpulse-density'
 const REDUCE_MOTION_KEY = 'netpulse-reduce-motion'
 
@@ -36,6 +126,12 @@ export function readMode(): ThemeMode {
   return localStorage.getItem(LEGACY_KEY) === 'light' ? 'light' : 'dark'
 }
 
+export function readPalette(): PaletteId {
+  const p = readJson<PaletteId>(PALETTE_KEY)
+  if (p && PALETTES.some((x) => x.id === p)) return p
+  return 'netpulse'
+}
+
 export function resolveLight(mode: ThemeMode): boolean {
   if (mode === 'light') return true
   if (mode === 'dark') return false
@@ -51,13 +147,18 @@ export function applyTheme(mode: ThemeMode) {
   } catch {
     /* noop */
   }
-  applyAccent(light)
+  applyPalette(light)
 }
 
-function applyAccent(light: boolean) {
-  const id = readJson<AccentId>(ACCENT_KEY) ?? 'cyan'
-  const a = ACCENTS.find((x) => x.id === id) ?? ACCENTS[0]
-  document.documentElement.style.setProperty('--accent', light ? a.light : a.dark)
+function applyPalette(light: boolean) {
+  const id = readPalette()
+  const palette = PALETTES.find((x) => x.id === id) ?? PALETTES[0]
+  const vars = light ? palette.light : palette.dark
+  const root = document.documentElement
+  for (const [key, value] of Object.entries(vars)) {
+    root.style.setProperty(`--${key}`, value)
+  }
+  root.setAttribute('data-palette', id)
 }
 
 function applyDensity() {
@@ -78,14 +179,12 @@ function applyReduceMotion() {
   }
 }
 
-/** Llamar en main.tsx ANTES del primer render. */
 export function applyBootPreferences() {
   const mode = readMode()
   applyTheme(mode)
   applyDensity()
   applyReduceMotion()
 
-  // El listener de system vive aquí (global), no en la página de Ajustes.
   window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', () => {
     if (readMode() === 'system') applyTheme('system')
   })

--- a/app/src/pages/Alerts.tsx
+++ b/app/src/pages/Alerts.tsx
@@ -54,11 +54,11 @@ import { cn } from '@/lib/utils'
 // Severidad (misma paleta que AlertItem, design.md §6)
 // ---------------------------------------------------------------------------
 
-const SEVERITY: Record<AlertSeverity, { icon: LucideIcon; tile: string; dot: string }> = {
-  warn: { icon: AlertTriangle, tile: 'bg-warn/10 text-warn', dot: 'bg-warn' },
-  critical: { icon: OctagonX, tile: 'bg-danger/10 text-danger', dot: 'bg-danger' },
-  info: { icon: Info, tile: 'bg-info/10 text-info', dot: 'bg-info' },
-  ok: { icon: CheckCircle2, tile: 'bg-ok/10 text-ok', dot: 'bg-ok' },
+const SEVERITY: Record<AlertSeverity, { icon: LucideIcon; tile: string; dot: string; stripe: string }> = {
+  warn: { icon: AlertTriangle, tile: 'bg-warn/10 text-warn', dot: 'bg-warn', stripe: 'border-l-warn' },
+  critical: { icon: OctagonX, tile: 'bg-danger/10 text-danger', dot: 'bg-danger', stripe: 'border-l-danger' },
+  info: { icon: Info, tile: 'bg-info/10 text-info', dot: 'bg-info', stripe: 'border-l-info' },
+  ok: { icon: CheckCircle2, tile: 'bg-ok/10 text-ok', dot: 'bg-ok', stripe: 'border-l-ok' },
 }
 
 const PEER_ICONS = { movil: Smartphone, portatil: Laptop, tablet: Tablet } as const
@@ -274,7 +274,8 @@ function FeedRow({ ev, index, read, expanded, onToggle, reduce, onSilence }: Fee
         onClick={onToggle}
         aria-expanded={expanded}
         className={cn(
-          'group flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left transition-colors duration-150 hover:bg-hover',
+          'group flex w-full items-center gap-3 rounded-xl border-l-[3px] px-3 py-3 text-left transition-colors duration-150 hover:bg-hover',
+          sev.stripe,
           !read && 'bg-elevated',
         )}
       >

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -60,7 +60,7 @@ import { useServicesVisibility } from '@/hooks/useServicesVisibility'
 import type { ServicesVisibility } from '@/hooks/useServicesVisibility'
 import { relTimeFromTs } from '@/i18n'
 import { cn, exitDemo } from '@/lib/utils'
-import { ACCENTS, type AccentId, type ThemeMode } from '@/lib/theme-boot'
+import { ACCENTS, PALETTES, type AccentId, type PaletteId, type ThemeMode } from '@/lib/theme-boot'
 import TelegramCard from '@/components/TelegramCard'
 import pkg from '../../package.json'
 
@@ -3016,12 +3016,20 @@ export default function Settings() {
     return () => mq.removeEventListener('change', apply)
   }, [mode])
 
-  // ——— Acento en vivo (--accent) ———
+  // ——— Paleta completa (canvas, surface, accent, semantic...) ———
+  const [paletteId, setPaletteId] = useStoredState<PaletteId>('netpulse-palette', 'netpulse')
   const [accentId, setAccentId] = useStoredState<AccentId>('netpulse-accent', 'cyan')
   useEffect(() => {
+    const palette = PALETTES.find((x) => x.id === paletteId) ?? PALETTES[0]
+    const vars = resolvedLight ? palette.light : palette.dark
+    const root = document.documentElement
+    for (const [key, value] of Object.entries(vars)) {
+      root.style.setProperty(`--${key}`, value)
+    }
+    root.setAttribute('data-palette', paletteId)
     const a = ACCENTS.find((x) => x.id === accentId) ?? ACCENTS[0]
-    document.documentElement.style.setProperty('--accent', resolvedLight ? a.light : a.dark)
-  }, [accentId, resolvedLight])
+    root.style.setProperty('--accent', resolvedLight ? a.light : a.dark)
+  }, [paletteId, accentId, resolvedLight])
 
   // ——— Densidad (compacta ≈ −15 % de tamaños/paddings vía rem) ———
   const [density, setDensity] = useStoredState<'comoda' | 'compacta'>('netpulse-density', 'comoda')
@@ -3365,10 +3373,59 @@ export default function Settings() {
               })}
             </div>
 
-            {/* Acento */}
+            {/* Paleta completa (#19-#20) */}
             <div className="mt-5">
+              <div className="text-caption font-semibold uppercase tracking-[0.06em] text-text-muted">{t('settings.palette')}</div>
+              <div className="mt-2.5 grid grid-cols-2 gap-2.5 sm:grid-cols-4">
+                {PALETTES.map((p) => {
+                  const active = paletteId === p.id
+                  return (
+                    <motion.button
+                      key={p.id}
+                      type="button"
+                      aria-label={t(p.labelKey)}
+                      aria-pressed={active}
+                      whileTap={reduce ? undefined : { scale: 0.95 }}
+                      onClick={() => {
+                        setPaletteId(p.id)
+                        notify()
+                      }}
+                      className={cn(
+                        'group relative flex flex-col items-start gap-1.5 rounded-xl border p-3 transition-all duration-150',
+                        active
+                          ? 'border-accent shadow-[0_0_0_1px_rgb(var(--accent)/0.3)]'
+                          : 'border-border hover:border-border-strong',
+                      )}
+                    >
+                      <div className="flex w-full items-center gap-1.5">
+                        <span
+                          className="h-5 w-5 shrink-0 rounded-full"
+                          style={{ backgroundColor: `rgb(${p.dark.accent})` }}
+                        />
+                        <span
+                          className="h-3 w-3 shrink-0 rounded-full"
+                          style={{ backgroundColor: `rgb(${p.dark.tunnel})` }}
+                        />
+                        <span
+                          className="ml-auto h-4 w-8 rounded"
+                          style={{ backgroundColor: `rgb(${p.dark.canvas})`, border: `1px solid rgb(${p.dark.border})` }}
+                        />
+                      </div>
+                      <span className="text-[11px] font-medium text-text-secondary">{t(p.labelKey)}</span>
+                      {active && (
+                        <Check className="absolute right-2 top-2 h-3.5 w-3.5 text-accent" strokeWidth={2.5} />
+                      )}
+                    </motion.button>
+                  )
+                })}
+              </div>
+              <p className="mt-1.5 text-caption text-text-muted">{t('settings.paletteCaption')}</p>
+            </div>
+
+            {/* Acento (override fino sobre la paleta) */}
+            <div className="mt-4">
               <div className="text-caption font-semibold uppercase tracking-[0.06em] text-text-muted">{t('settings.accent')}</div>
-              <div className="mt-2.5 flex items-center gap-3">
+              <div className="mt-2 flex items-center gap-3">
                 {ACCENTS.map((a) => {
                   const active = accentId === a.id
                   return (
@@ -3383,12 +3440,12 @@ export default function Settings() {
                         notify()
                       }}
                       className={cn(
-                        'flex h-9 w-9 items-center justify-center rounded-full transition-shadow duration-150',
+                        'flex h-8 w-8 items-center justify-center rounded-full transition-shadow duration-150',
                         active ? 'ring-2 ring-accent ring-offset-2 ring-offset-surface' : 'hover:ring-2 hover:ring-border-strong hover:ring-offset-2 hover:ring-offset-surface',
                       )}
                       style={{ backgroundColor: a.swatch }}
                     >
-                      {active && <Check className="h-4 w-4 text-[#070B12]" strokeWidth={2.5} />}
+                      {active && <Check className="h-3.5 w-3.5 text-[#070B12]" strokeWidth={2.5} />}
                     </motion.button>
                   )
                 })}

--- a/app/src/sections/HeroStrip.tsx
+++ b/app/src/sections/HeroStrip.tsx
@@ -42,7 +42,7 @@ function MiniStat({
         <Icon className={`h-3.5 w-3.5 ${colorClass}`} strokeWidth={1.75} />
         {label}
       </span>
-      <span className={`font-mono text-lg font-semibold ${colorClass}`}>{children}</span>
+      <span className={`kpi-value text-lg font-semibold ${colorClass}`}>{children}</span>
     </motion.div>
   )
 }
@@ -79,7 +79,7 @@ export function HeroStrip() {
   const statusLine = alerts > 0 ? t('home.importantAlerts', { count: alerts }) : t('home.noImportantAlerts')
 
   return (
-    <section className="mesh-bg relative h-full overflow-hidden rounded-2xl border border-border bg-surface p-5 md:p-6">
+    <section className="surface-featured mesh-bg relative h-full overflow-hidden rounded-2xl border bg-surface p-5 md:p-6">
       {/* Halo radial cyan que respira */}
       {!reduce && (
         <motion.div
@@ -140,7 +140,7 @@ export function HeroStrip() {
               })}
               center={
                 <div className="flex flex-col items-center">
-                  <span className="font-display text-display-sm font-bold text-text-primary md:text-display">
+                  <span className="kpi-value text-display-sm font-bold text-text-primary md:text-display">
                     <CountUp value={healthScore.score} duration={1.2} nonce={refreshKey} />
                   </span>
                   <span className="font-mono text-mono-sm text-text-muted">/100</span>

--- a/app/src/sections/HeroStrip.tsx
+++ b/app/src/sections/HeroStrip.tsx
@@ -2,6 +2,7 @@ import { motion, useReducedMotion } from 'framer-motion'
 import { Fragment, useEffect, useState } from 'react'
 import { AlertTriangle, CheckCircle2, Gauge, MonitorSmartphone } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { cn } from '@/lib/utils'
 import { healthLabel } from '@/i18n'
 import { CountUp } from '@/components/CountUp'
 import { HealthRing } from '@/components/HealthRing'
@@ -176,6 +177,40 @@ export function HeroStrip() {
             </div>
           )}
         </div>
+
+        {/* Desglose del health score (#23): barras de penalizacion */}
+        {healthScore.breakdown.length > 0 && (
+          <div className="w-full max-w-sm space-y-1.5">
+            {healthScore.breakdown.map((b, i) => {
+              const pct = Math.min(100, Math.abs(b.delta) * 10)
+              const color = Math.abs(b.delta) >= 8 ? 'bg-danger' : Math.abs(b.delta) >= 4 ? 'bg-warn' : 'bg-info'
+              return (
+                <motion.div
+                  key={b.label}
+                  initial={reduce ? false : { opacity: 0, x: -8 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ duration: 0.3, delay: 0.4 + i * 0.08 }}
+                  className="flex items-center gap-2"
+                >
+                  <span className="w-28 shrink-0 truncate text-right text-[11px] text-text-muted">{b.label}</span>
+                  <div className="relative h-2 flex-1 overflow-hidden rounded-full bg-border/50">
+                    <motion.div
+                      className={cn('absolute left-0 top-0 h-full rounded-full', color)}
+                      initial={{ width: 0 }}
+                      animate={{ width: `${pct}%` }}
+                      transition={{ duration: 0.6, delay: 0.5 + i * 0.08, ease: 'easeOut' }}
+                    />
+                  </div>
+                  <span className={cn('w-8 shrink-0 text-right font-mono text-[11px] font-semibold',
+                    Math.abs(b.delta) >= 8 ? 'text-danger' : Math.abs(b.delta) >= 4 ? 'text-warn' : 'text-info',
+                  )}>
+                    {b.delta}
+                  </span>
+                </motion.div>
+              )
+            })}
+          </div>
+        )}
 
         {/* Stats: latencia + dispositivos en fila, centrados */}
         <div className="mt-1 flex w-full items-center justify-center gap-8 md:gap-12">

--- a/app/src/sections/WanTraffic.tsx
+++ b/app/src/sections/WanTraffic.tsx
@@ -95,7 +95,7 @@ export function WanTraffic() {
   const liveDotUp = useMemo(() => makeLiveDot(liveData.length, '#A78BFA'), [liveData.length])
 
   return (
-    <section className="flex h-full flex-col rounded-2xl border border-border bg-surface p-5">
+    <section className="surface-elevated flex h-full flex-col rounded-2xl border bg-surface p-5">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <SectionHeader title={t('home.traffic.title')}>
           <StatusPill tone="ok" label={t('topbar.live')} pulse />
@@ -206,7 +206,7 @@ export function WanTraffic() {
             transition={{ duration: 0.3, ease: 'easeOut', delay: 0.2 + i * 0.08 }}
           >
             <div className="text-label uppercase text-text-muted">{m.label}</div>
-            <div className="mt-0.5 font-mono text-mono-sm font-semibold text-text-primary">{m.value}</div>
+            <div className="kpi-value mt-0.5 text-mono-sm font-semibold text-text-primary">{m.value}</div>
           </motion.div>
         ))}
       </div>


### PR DESCRIPTION
Closes #346 #347 #348 #349 #350 #351 #352

## What

Comprehensive UI reskin covering the full visual identity of NetPulse. 7 improvements from Phase IV of the integrated plan.

## Changes

### #19-#20 Palette system with 4 complete themes
- **4 palettes**: NetPulse (current navy/cyan), Warm NOC (amber/orange), Phosphor (green terminal), Electric (cyan/magenta vibrant)
- Each palette defines ALL design tokens: canvas, surface, elevated, hover, border, text, accent, tunnel, ok, warn, danger, info - in both dark and light variants
- Palette selector in Settings (grid of 4 cards with color preview swatches)
- Accent color picker preserved as fine-tuning override on top of palette
- Persisted via `localStorage` key `netpulse-palette`
- Applied at boot via `theme-boot.ts` before first render

### #21 Surface hierarchy
- New CSS utilities: `.surface-elevated` (accent glow + strong border), `.surface-featured` (gradient bg + prominent glow)
- HeroStrip on Home page promoted to `surface-featured` (the star card)
- WanTraffic promoted to `surface-elevated` (secondary emphasis)
- Status glow utilities: `.glow-ok`, `.glow-warn`, `.glow-danger`, `.glow-accent`

### #22 KPI typography
- `.kpi-value` class: Space Grotesk display font + tabular-nums for hero metrics
- Applied to: HeroStrip health score + stats, FleetCard router health, RouterPerformance values, WanTraffic footer metrics
- `.flash-sse` animation for SSE value updates
- `.count-up-enter` animation for value entrance

### #23 Health score breakdown bars
- Animated horizontal bars below the HealthRing in HeroStrip
- Each penalty shown as colored bar (danger >= 8, warn >= 4, info < 4)
- Label + delta value per bar, staggered entry animation

### #24 Alert severity borders
- Left colored stripe (3px) on alert items based on severity
- Applied to both `AlertItem.tsx` (RecentAlerts on Home) and `FeedRow` in Alerts page
- warn=amber, critical=red, info=blue, ok=green

### #25 Topology glows
- SVG filter definitions: `glow-ok`, `glow-warn`, `glow-danger`, `glow-tunnel`
- Router nodes get status-based glow filter (warn=amber glow, offline=red glow)
- Tunnel links get permanent purple glow filter
- Offline routers now get red stroke + glow (previously only status ring was red)

## Files changed
- `app/src/lib/theme-boot.ts` - PALETTES array, applyPalette(), readPalette()
- `app/src/index.css` - surface/glow/KPI utilities
- `app/src/pages/Settings.tsx` - palette selector + accent override
- `app/src/sections/HeroStrip.tsx` - featured surface, KPI values, breakdown bars
- `app/src/sections/WanTraffic.tsx` - elevated surface, KPI values
- `app/src/components/AlertItem.tsx` - severity stripe
- `app/src/pages/Alerts.tsx` - severity stripe
- `app/src/components/routers/FleetCard.tsx` - KPI value
- `app/src/components/routers/RouterPerformance.tsx` - KPI value
- `app/src/components/topology/TopologyMap.tsx` - SVG glow filters, status glows, tunnel glow
