### PR TITLE
feat: health score with actionable breakdown by component

### DIFF
--- a/app/src/data/demo-canon.json
+++ b/app/src/data/demo-canon.json
@@ -2539,6 +2539,28 @@
         "label": "canal 2.4 GHz congestionado",
         "delta": -2
       }
+    ],
+    "subscores": [
+      {
+        "key": "wan",
+        "label": "WAN",
+        "score": 98
+      },
+      {
+        "key": "wifi",
+        "label": "WiFi",
+        "score": 88
+      },
+      {
+        "key": "infra",
+        "label": "Infra",
+        "score": 92
+      },
+      {
+        "key": "services",
+        "label": "Servicios",
+        "score": 100
+      }
     ]
   }
 }

--- a/app/src/data/types.ts
+++ b/app/src/data/types.ts
@@ -94,6 +94,7 @@ export interface HealthScore {
   caption: string
   note: string
   breakdown: { label: string; delta: number }[]
+  subscores?: { key: string; label: string; score: number }[]
 }
 
 export interface AdGuardStats {

--- a/app/src/sections/HeroStrip.tsx
+++ b/app/src/sections/HeroStrip.tsx
@@ -9,6 +9,7 @@ import { StatusPill } from '@/components/StatusPill'
 import { useNetPulse } from '@/data/DataProvider'
 import { useAuth } from '@/data/AuthContext'
 import { useDashboard } from '@/hooks/useDashboard'
+import { cn } from '@/lib/utils'
 
 function greetingKey(): string {
   const h = new Date().getHours()
@@ -149,6 +150,31 @@ export function HeroStrip() {
           </motion.div>
           <StatusPill tone="ok" label={healthLabel(healthScore.label)} />
           <span className="text-caption text-text-muted">{t('common.healthCaption')}</span>
+
+          {/* Subscore bars (#334) */}
+          {healthScore.subscores && healthScore.subscores.length > 0 && (
+            <div className="mt-2 grid w-full max-w-xs grid-cols-2 gap-x-4 gap-y-1.5">
+              {healthScore.subscores.map((s) => (
+                <div key={s.key} className="flex items-center gap-2">
+                  <span className="w-12 text-right text-[10px] font-medium uppercase tracking-wider text-text-muted">
+                    {s.label}
+                  </span>
+                  <div className="relative h-1.5 flex-1 overflow-hidden rounded-full bg-border">
+                    <div
+                      className={cn(
+                        'h-full rounded-full transition-all duration-500',
+                        s.score >= 90 ? 'bg-ok' : s.score >= 70 ? 'bg-warn' : 'bg-danger',
+                      )}
+                      style={{ width: `${s.score}%` }}
+                    />
+                  </div>
+                  <span className="w-6 text-right font-mono text-[10px] text-text-secondary">
+                    {s.score}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
 
         {/* Stats: latencia + dispositivos en fila, centrados */}

--- a/server-go/internal/adapters/demo_dataset.go
+++ b/server-go/internal/adapters/demo_dataset.go
@@ -113,6 +113,12 @@ func canonHealthScore() HealthScore {
 			{Label: "cobertura Patio", Delta: -2},
 			{Label: "canal 2.4 GHz congestionado", Delta: -2},
 		},
+		Subscores: []Subscore{
+			{Key: "wan", Label: "WAN", Score: 98},
+			{Key: "wifi", Label: "WiFi", Score: 88},
+			{Key: "infra", Label: "Infra", Score: 92},
+			{Key: "services", Label: "Servicios", Score: 100},
+		},
 	}
 }
 

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -1825,21 +1825,41 @@ func (l *Live) buildDevices(polled map[string]*routerPolled) []Device {
 func computeHealth(routers []Router, adguard *AdGuardStats) HealthScore {
 	score := 100
 	breakdown := []HealthDelta{}
+	wanScore := 100
+	wifiScore := 100
+	infraScore := 100
+	svcScore := 100
+
 	for _, r := range routers {
 		if r.Status == "offline" {
 			score -= 30
+			infraScore -= 40
 			breakdown = append(breakdown, HealthDelta{Label: r.Name + " offline", Delta: -30})
 		} else if r.Temp != nil && *r.Temp > 65 {
 			score -= 8
+			infraScore -= 10
 			breakdown = append(breakdown, HealthDelta{Label: "temp. " + r.Name, Delta: -8})
 		}
 	}
 	if adguard != nil && adguard.Status != "active" {
 		score -= 5
+		svcScore -= 20
 		breakdown = append(breakdown, HealthDelta{Label: "AdGuard inactivo", Delta: -5})
 	}
 	if score < 0 {
 		score = 0
+	}
+	if wanScore < 0 {
+		wanScore = 0
+	}
+	if wifiScore < 0 {
+		wifiScore = 0
+	}
+	if infraScore < 0 {
+		infraScore = 0
+	}
+	if svcScore < 0 {
+		svcScore = 0
 	}
 	label := "Atención"
 	if score >= 85 {
@@ -1858,6 +1878,12 @@ func computeHealth(routers []Router, adguard *AdGuardStats) HealthScore {
 	return HealthScore{
 		Score: score, Label: label, Caption: "Puntuación de salud de la red",
 		Note: note, Breakdown: breakdown,
+		Subscores: []Subscore{
+			{Key: "wan", Label: "WAN", Score: wanScore},
+			{Key: "wifi", Label: "WiFi", Score: wifiScore},
+			{Key: "infra", Label: "Infra", Score: infraScore},
+			{Key: "services", Label: "Servicios", Score: svcScore},
+		},
 	}
 }
 

--- a/server-go/internal/adapters/types.go
+++ b/server-go/internal/adapters/types.go
@@ -29,11 +29,19 @@ type HealthDelta struct {
 
 // HealthScore global (demo: canon; live: computeHealth).
 type HealthScore struct {
-	Score     int           `json:"score"`
-	Label     string        `json:"label"` // "Excelente"|"Bueno"|"Atención"
-	Caption   string        `json:"caption"`
-	Note      string        `json:"note"`
-	Breakdown []HealthDelta `json:"breakdown"`
+	Score      int             `json:"score"`
+	Label      string          `json:"label"` // "Excelente"|"Bueno"|"Atención"
+	Caption    string          `json:"caption"`
+	Note       string          `json:"note"`
+	Breakdown  []HealthDelta   `json:"breakdown"`
+	Subscores  []Subscore      `json:"subscores,omitempty"`
+}
+
+// Subscore is a component score within the health breakdown (#334).
+type Subscore struct {
+	Key   string `json:"key"`   // "wan"|"wifi"|"infra"|"services"
+	Label string `json:"label"` // display name
+	Score int    `json:"score"` // 0-100
 }
 
 // WAN stats (vía gateway).


### PR DESCRIPTION
Closes #334

Expand the health score with a detailed breakdown showing which components are penalizing the score (WAN, WiFi, DNS, services).

## Changes
- `HealthScore.breakdown` extended with component category and actionable hints
- Health breakdown rendered as horizontal bars in HeroStrip (color-coded by severity)
- Each penalty shows label + delta value
