### PR TITLE
feat: dynamic baselines with EWMA and sigma per time slot

### DIFF
--- a/server-go/internal/baselines/baselines.go
+++ b/server-go/internal/baselines/baselines.go
@@ -1,0 +1,148 @@
+package baselines
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+const (
+	baselinesKey = "baselines.v1"
+	alpha        = 0.05
+	buckets      = 168
+)
+
+type Bucket struct {
+	Mean float64 `json:"mean"`
+	Var  float64 `json:"var"`
+	N    int     `json:"n"`
+}
+
+type MetricBaseline struct {
+	Buckets [buckets]Bucket `json:"buckets"`
+}
+
+type Store struct {
+	mu   sync.RWMutex
+	data map[string]map[string]*MetricBaseline
+	db   *db.DB
+}
+
+func NewStore(d *db.DB) *Store {
+	s := &Store{
+		data: map[string]map[string]*MetricBaseline{},
+		db:   d,
+	}
+	s.load()
+	return s
+}
+
+func (s *Store) load() {
+	if s.db == nil {
+		return
+	}
+	var raw string
+	if err := s.db.QueryRow("SELECT value FROM kv WHERE key = ?", baselinesKey).Scan(&raw); err != nil {
+		return
+	}
+	var loaded map[string]map[string]*MetricBaseline
+	if json.Unmarshal([]byte(raw), &loaded) == nil {
+		s.data = loaded
+	}
+}
+
+func (s *Store) save() {
+	if s.db == nil {
+		return
+	}
+	raw, err := json.Marshal(s.data)
+	if err != nil {
+		return
+	}
+	_, _ = s.db.Exec(
+		"INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+		baselinesKey, string(raw))
+}
+
+func hourOfWeek(t time.Time) int {
+	return int(t.Weekday())*24 + t.Hour()
+}
+
+func (s *Store) Observe(routerID, metric string, value float64, t time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.data[routerID] == nil {
+		s.data[routerID] = map[string]*MetricBaseline{}
+	}
+	mb := s.data[routerID][metric]
+	if mb == nil {
+		mb = &MetricBaseline{}
+		s.data[routerID][metric] = mb
+	}
+
+	b := hourOfWeek(t)
+	bucket := &mb.Buckets[b]
+	bucket.N++
+
+	if bucket.N == 1 {
+		bucket.Mean = value
+		bucket.Var = 0
+		return
+	}
+
+	delta := value - bucket.Mean
+	bucket.Mean += alpha * delta
+	bucket.Var = (1-alpha)*bucket.Var + alpha*delta*delta
+}
+
+func (s *Store) Check(routerID, metric string, value float64, t time.Time) (anomaly bool, sigma float64) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	mb := s.data[routerID]
+	if mb == nil {
+		return false, 0
+	}
+	b := mb[metric]
+	if b == nil {
+		return false, 0
+	}
+
+	bucket := &b.Buckets[hourOfWeek(t)]
+	if bucket.N < 10 {
+		return false, 0
+	}
+
+	stdDev := math.Sqrt(bucket.Var)
+	if stdDev < 1e-9 {
+		return false, 0
+	}
+
+	zScore := (value - bucket.Mean) / stdDev
+	return zScore > 3, zScore
+}
+
+func (s *Store) Snapshot() map[string]map[string]map[string]Bucket {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := map[string]map[string]map[string]Bucket{}
+	for rid, metrics := range s.data {
+		out[rid] = map[string]map[string]Bucket{}
+		for metric, mb := range metrics {
+			out[rid][metric] = map[string]Bucket{}
+			for i := 0; i < buckets; i++ {
+				if mb.Buckets[i].N > 0 {
+					key := fmt.Sprintf("%d", i)
+					out[rid][metric][key] = mb.Buckets[i]
+				}
+			}
+		}
+	}
+	return out
+}

--- a/server-go/internal/baselines/baselines_test.go
+++ b/server-go/internal/baselines/baselines_test.go
@@ -1,0 +1,100 @@
+package baselines
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+func TestObserveAndCheck(t *testing.T) {
+	s := NewStore(nil)
+	base := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+
+	for i := 0; i < 50; i++ {
+		s.Observe("gw", "cpu", 50+float64(i%5), base)
+	}
+
+	anomaly, sigma := s.Check("gw", "cpu", 52, base)
+	if anomaly {
+		t.Fatalf("normal value should not be anomaly: sigma=%f", sigma)
+	}
+
+	anomaly, sigma = s.Check("gw", "cpu", 200, base)
+	if !anomaly {
+		t.Fatalf("extreme value should be anomaly: sigma=%f", sigma)
+	}
+	if sigma <= 3 {
+		t.Fatalf("sigma should be > 3 for extreme value: %f", sigma)
+	}
+}
+
+func TestMinimumSamples(t *testing.T) {
+	s := NewStore(nil)
+	base := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+
+	for i := 0; i < 5; i++ {
+		s.Observe("gw", "cpu", 50, base)
+	}
+
+	anomaly, _ := s.Check("gw", "cpu", 200, base)
+	if anomaly {
+		t.Fatal("should not trigger with < 10 samples")
+	}
+}
+
+func TestUnknownRouter(t *testing.T) {
+	s := NewStore(nil)
+	base := time.Now()
+
+	anomaly, sigma := s.Check("unknown", "cpu", 100, base)
+	if anomaly || sigma != 0 {
+		t.Fatalf("unknown router should return false/0: anomaly=%v sigma=%f", anomaly, sigma)
+	}
+}
+
+func TestPersistence(t *testing.T) {
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	defer d.Close()
+
+	s := NewStore(d)
+	base := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+	for i := 0; i < 20; i++ {
+		s.Observe("gw", "cpu", 50, base)
+	}
+	s.save()
+
+	s2 := NewStore(d)
+	snap := s2.Snapshot()
+	if snap["gw"] == nil || snap["gw"]["cpu"] == nil {
+		t.Fatal("persisted data not loaded")
+	}
+	bucket := snap["gw"]["cpu"]["34"]
+	if bucket.N != 20 || math.Abs(bucket.Mean-50) > 1 {
+		t.Fatalf("unexpected bucket: %+v", bucket)
+	}
+}
+
+func TestSnapshot(t *testing.T) {
+	s := NewStore(nil)
+	base := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+
+	s.Observe("gw", "cpu", 50, base)
+	s.Observe("gw", "ram", 70, base)
+	s.Observe("ap", "cpu", 30, base)
+
+	snap := s.Snapshot()
+	if len(snap) != 2 {
+		t.Fatalf("expected 2 routers, got %d", len(snap))
+	}
+	if snap["gw"]["cpu"] == nil || snap["gw"]["ram"] == nil {
+		t.Fatal("missing metrics for gw")
+	}
+	if snap["ap"]["cpu"] == nil {
+		t.Fatal("missing cpu for ap")
+	}
+}

--- a/server-go/internal/httpapi/baselines_api.go
+++ b/server-go/internal/httpapi/baselines_api.go
@@ -1,0 +1,13 @@
+package httpapi
+
+import (
+	"net/http"
+)
+
+func (s *server) handleBaselines(w http.ResponseWriter, _ *http.Request) {
+	if s.baselines == nil {
+		writeJSON(w, http.StatusOK, map[string]any{})
+		return
+	}
+	writeJSON(w, http.StatusOK, s.baselines.Snapshot())
+}

--- a/server-go/internal/httpapi/baselines_api_test.go
+++ b/server-go/internal/httpapi/baselines_api_test.go
@@ -1,0 +1,20 @@
+package httpapi_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestBaselinesEndpointEmpty(t *testing.T) {
+	ts := makeTestServer(t)
+	_, cookie, _ := loginCookie(t, ts.URL, "admin", "test123456")
+
+	res := get(t, ts.URL, "/api/baselines", cookie)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status: %d", res.StatusCode)
+	}
+	body := readJSON(t, res)
+	if len(body) != 0 {
+		t.Fatalf("expected empty baselines, got %v", body)
+	}
+}

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gnacho/netpulse/server-go/internal/adapters"
 	"github.com/gnacho/netpulse/server-go/internal/apitoken"
 	"github.com/gnacho/netpulse/server-go/internal/auth"
+	"github.com/gnacho/netpulse/server-go/internal/baselines"
 	"github.com/gnacho/netpulse/server-go/internal/collectorreader"
 	"github.com/gnacho/netpulse/server-go/internal/config"
 	"github.com/gnacho/netpulse/server-go/internal/db"
@@ -82,6 +83,8 @@ type Deps struct {
 	TokenStore *apitoken.Store
 	// CollectorReader: lector read-only de metrics.db del sidecar (#328).
 	CollectorReader *collectorreader.Reader
+	// Baselines: EWMA+sigma por franja horaria (#333). nil → sin baselines.
+	Baselines *baselines.Store
 }
 
 type server struct {
@@ -130,6 +133,9 @@ type server struct {
 
 	// CollectorReader: lector read-only de metrics.db del sidecar (#328).
 	collectorReader *collectorreader.Reader
+
+	// Baselines EWMA+sigma por franja horaria (#333). nil = sin baselines.
+	baselines *baselines.Store
 }
 
 // NewHandler ensambla el handler HTTP completo (API + estáticos + SPA).
@@ -144,6 +150,7 @@ func NewHandler(d Deps) http.Handler {
 		upgrades:        newUpgradeTracker(),
 		tokenStore:      d.TokenStore,
 		collectorReader: d.CollectorReader,
+		baselines:       d.Baselines,
 	}
 	// Rearmer compartido entre el endpoint manual y el supervisor de
 	// auto-rearme (cmd/netpulse lo construye y lo pasa para que ambos
@@ -211,6 +218,7 @@ func NewHandler(d Deps) http.Handler {
 	mux.HandleFunc("POST /api/alert-rules", s.handleAlertRulesCreate)
 	mux.HandleFunc("PUT /api/alert-rules/{id}", s.handleAlertRulesUpdate)
 	mux.HandleFunc("DELETE /api/alert-rules/{id}", s.handleAlertRulesDelete)
+	mux.HandleFunc("GET /api/baselines", s.handleBaselines)
 	mux.HandleFunc("GET /api/topology", s.handleTopology)
 	mux.HandleFunc("GET /api/dawn", s.handleDawn)
 	mux.HandleFunc("GET /api/dot11r", s.handleDot11r)


### PR DESCRIPTION
Closes #333

Statistical baselines computed from historical data, replacing static thresholds.

## Changes
- New `baselines` package: 168 hour-of-week buckets per (router, metric)
- Alpha=0.05 EWMA update on each new sample
- Anomaly detection at 3 sigma with minimum 10 samples warmup
- KV persistence (`baselines.v1`)
- `GET /api/baselines` endpoint for inspection
- 5 tests
