### PR TITLE
feat: Internet Health multi-target probe and outage log

### DIFF
--- a/server-go/internal/httpapi/internet_health_api.go
+++ b/server-go/internal/httpapi/internet_health_api.go
@@ -1,0 +1,18 @@
+package httpapi
+
+import (
+	"net/http"
+)
+
+func (s *server) handleInternetHealth(w http.ResponseWriter, _ *http.Request) {
+	if s.internetHealth == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"available": false})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"available": true,
+		"summary":   s.internetHealth.Summary(),
+		"probes":    s.internetHealth.RecentProbes(24),
+		"outages":   s.internetHealth.RecentOutages(10),
+	})
+}

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gnacho/netpulse/server-go/internal/collectorreader"
 	"github.com/gnacho/netpulse/server-go/internal/config"
 	"github.com/gnacho/netpulse/server-go/internal/db"
+	"github.com/gnacho/netpulse/server-go/internal/internethealth"
 	"github.com/gnacho/netpulse/server-go/internal/orchestr"
 	"github.com/gnacho/netpulse/server-go/internal/rearmer"
 	"github.com/gnacho/netpulse/server-go/internal/security"
@@ -85,6 +86,8 @@ type Deps struct {
 	CollectorReader *collectorreader.Reader
 	// Baselines: EWMA+sigma por franja horaria (#333). nil → sin baselines.
 	Baselines *baselines.Store
+	// InternetHealth: sonda multi-target + outage log (#335). nil → sin sondas.
+	InternetHealth *internethealth.Store
 }
 
 type server struct {
@@ -136,6 +139,9 @@ type server struct {
 
 	// Baselines EWMA+sigma por franja horaria (#333). nil = sin baselines.
 	baselines *baselines.Store
+
+	// Internet Health: sonda multi-target + outage log (#335). nil = sin sondas.
+	internetHealth *internethealth.Store
 }
 
 // NewHandler ensambla el handler HTTP completo (API + estáticos + SPA).
@@ -151,6 +157,7 @@ func NewHandler(d Deps) http.Handler {
 		tokenStore:      d.TokenStore,
 		collectorReader: d.CollectorReader,
 		baselines:       d.Baselines,
+		internetHealth:  d.InternetHealth,
 	}
 	// Rearmer compartido entre el endpoint manual y el supervisor de
 	// auto-rearme (cmd/netpulse lo construye y lo pasa para que ambos
@@ -219,6 +226,7 @@ func NewHandler(d Deps) http.Handler {
 	mux.HandleFunc("PUT /api/alert-rules/{id}", s.handleAlertRulesUpdate)
 	mux.HandleFunc("DELETE /api/alert-rules/{id}", s.handleAlertRulesDelete)
 	mux.HandleFunc("GET /api/baselines", s.handleBaselines)
+	mux.HandleFunc("GET /api/internet-health", s.handleInternetHealth)
 	mux.HandleFunc("GET /api/topology", s.handleTopology)
 	mux.HandleFunc("GET /api/dawn", s.handleDawn)
 	mux.HandleFunc("GET /api/dot11r", s.handleDot11r)

--- a/server-go/internal/internethealth/store.go
+++ b/server-go/internal/internethealth/store.go
@@ -1,0 +1,252 @@
+package internethealth
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+const (
+	schemaSQL = `
+CREATE TABLE IF NOT EXISTS internet_probes (
+  ts INTEGER NOT NULL,
+  target TEXT NOT NULL,
+  latency_ms REAL NOT NULL,
+  loss_pct REAL NOT NULL,
+  success INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_internet_probes_ts ON internet_probes(ts DESC);
+
+CREATE TABLE IF NOT EXISTS internet_outages (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  started_at INTEGER NOT NULL,
+  ended_at INTEGER,
+  duration_s INTEGER,
+  targets_down TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_internet_outages_ts ON internet_outages(started_at DESC);
+`
+	retentionDays = 30
+	maxProbes     = 10000
+)
+
+type ProbeResult struct {
+	Ts        int64   `json:"ts"`
+	Target    string  `json:"target"`
+	LatencyMs float64 `json:"latencyMs"`
+	LossPct   float64 `json:"lossPct"`
+	Success   bool    `json:"success"`
+}
+
+type Outage struct {
+	ID         int64    `json:"id"`
+	StartedAt  int64    `json:"startedAt"`
+	EndedAt    *int64   `json:"endedAt"`
+	DurationS  *int64   `json:"durationS"`
+	TargetsDown []string `json:"targetsDown"`
+}
+
+type Summary struct {
+	LastProbe  *ProbeResult `json:"lastProbe"`
+	CurrentOutage *Outage   `json:"currentOutage"`
+	TotalOutages24h int     `json:"totalOutages24h"`
+	AvgLatency24h   float64 `json:"avgLatency24h"`
+}
+
+type Store struct {
+	mu   sync.Mutex
+	db   *db.DB
+	outage *Outage
+}
+
+func NewStore(d *db.DB) (*Store, error) {
+	if d != nil {
+		if _, err := d.Exec(schemaSQL); err != nil {
+			return nil, fmt.Errorf("internet_health schema: %w", err)
+		}
+	}
+	s := &Store{db: d}
+	if d != nil {
+		s.loadActiveOutage()
+	}
+	return s, nil
+}
+
+func (s *Store) loadActiveOutage() {
+	var id int64
+	var startedAt int64
+	var targetsDown string
+	err := s.db.QueryRow(
+		"SELECT id, started_at, targets_down FROM internet_outages WHERE ended_at IS NULL ORDER BY id DESC LIMIT 1",
+	).Scan(&id, &startedAt, &targetsDown)
+	if err != nil {
+		return
+	}
+	var targets []string
+	_ = json.Unmarshal([]byte(targetsDown), &targets)
+	s.outage = &Outage{ID: id, StartedAt: startedAt, TargetsDown: targets}
+}
+
+func (s *Store) RecordProbe(p ProbeResult) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db != nil {
+		_, _ = s.db.Exec(
+			"INSERT INTO internet_probes (ts, target, latency_ms, loss_pct, success) VALUES (?,?,?,?,?)",
+			p.Ts, p.Target, p.LatencyMs, p.LossPct, boolToInt(p.Success))
+	}
+
+	if !p.Success && s.outage == nil {
+		s.startOutage(p)
+	} else if p.Success && s.outage != nil {
+		s.endOutage(p.Ts)
+	}
+}
+
+func (s *Store) startOutage(p ProbeResult) {
+	now := p.Ts
+	targets := []string{p.Target}
+	targetsJSON, _ := json.Marshal(targets)
+
+	if s.db != nil {
+		res, err := s.db.Exec(
+			"INSERT INTO internet_outages (started_at, targets_down) VALUES (?,?)",
+			now, string(targetsJSON))
+		if err == nil {
+			id, _ := res.LastInsertId()
+			s.outage = &Outage{ID: id, StartedAt: now, TargetsDown: targets}
+		}
+	} else {
+		s.outage = &Outage{ID: 0, StartedAt: now, TargetsDown: targets}
+	}
+}
+
+func (s *Store) endOutage(ts int64) {
+	if s.outage == nil {
+		return
+	}
+	dur := ts - s.outage.StartedAt
+	if s.db != nil {
+		_, _ = s.db.Exec(
+			"UPDATE internet_outages SET ended_at = ?, duration_s = ? WHERE id = ?",
+			ts, dur, s.outage.ID)
+	}
+	s.outage = nil
+}
+
+func (s *Store) Summary() Summary {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sum := Summary{}
+	if s.db == nil {
+		return sum
+	}
+
+	var ts int64
+	var target string
+	var lat, loss float64
+	var success int
+	err := s.db.QueryRow(
+		"SELECT ts, target, latency_ms, loss_pct, success FROM internet_probes ORDER BY ts DESC LIMIT 1",
+	).Scan(&ts, &target, &lat, &loss, &success)
+	if err == nil {
+		sum.LastProbe = &ProbeResult{Ts: ts, Target: target, LatencyMs: lat, LossPct: loss, Success: success == 1}
+	}
+
+	sum.CurrentOutage = s.outage
+
+	cutoff := time.Now().Add(-24 * time.Hour).UnixMilli()
+	var count int
+	var avgLat sql.NullFloat64
+	_ = s.db.QueryRow(
+		"SELECT COUNT(*), AVG(latency_ms) FROM internet_probes WHERE ts >= ? AND success = 1",
+		cutoff,
+	).Scan(&count, &avgLat)
+	if avgLat.Valid {
+		sum.AvgLatency24h = avgLat.Float64
+	}
+
+	var outages int
+	_ = s.db.QueryRow(
+		"SELECT COUNT(*) FROM internet_outages WHERE started_at >= ?",
+		cutoff,
+	).Scan(&outages)
+	sum.TotalOutages24h = outages
+
+	return sum
+}
+
+func (s *Store) RecentProbes(limit int) []ProbeResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	rows, err := s.db.Query(
+		"SELECT ts, target, latency_ms, loss_pct, success FROM internet_probes ORDER BY ts DESC LIMIT ?",
+		limit)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var out []ProbeResult
+	for rows.Next() {
+		var p ProbeResult
+		var success int
+		if rows.Scan(&p.Ts, &p.Target, &p.LatencyMs, &p.LossPct, &success) == nil {
+			p.Success = success == 1
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func (s *Store) RecentOutages(limit int) []Outage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	rows, err := s.db.Query(
+		"SELECT id, started_at, ended_at, duration_s, targets_down FROM internet_outages ORDER BY started_at DESC LIMIT ?",
+		limit)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var out []Outage
+	for rows.Next() {
+		var o Outage
+		var endedAt sql.NullInt64
+		var dur sql.NullInt64
+		var targetsJSON string
+		if rows.Scan(&o.ID, &o.StartedAt, &endedAt, &dur, &targetsJSON) == nil {
+			if endedAt.Valid {
+				o.EndedAt = &endedAt.Int64
+			}
+			if dur.Valid {
+				o.DurationS = &dur.Int64
+			}
+			_ = json.Unmarshal([]byte(targetsJSON), &o.TargetsDown)
+			out = append(out, o)
+		}
+	}
+	return out
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/server-go/internal/internethealth/store_test.go
+++ b/server-go/internal/internethealth/store_test.go
@@ -1,0 +1,101 @@
+package internethealth
+
+import (
+	"testing"
+
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+func TestRecordProbeAndSummary(t *testing.T) {
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	defer d.Close()
+
+	s, err := NewStore(d)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	s.RecordProbe(ProbeResult{Ts: 1000, Target: "8.8.8.8", LatencyMs: 10, LossPct: 0, Success: true})
+	s.RecordProbe(ProbeResult{Ts: 2000, Target: "1.1.1.1", LatencyMs: 15, LossPct: 0, Success: true})
+
+	sum := s.Summary()
+	if sum.LastProbe == nil || sum.LastProbe.Target != "1.1.1.1" {
+		t.Fatalf("last probe: %+v", sum.LastProbe)
+	}
+	if sum.CurrentOutage != nil {
+		t.Fatal("should have no outage")
+	}
+}
+
+func TestOutageDetection(t *testing.T) {
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	defer d.Close()
+
+	s, err := NewStore(d)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	s.RecordProbe(ProbeResult{Ts: 1000, Target: "8.8.8.8", LatencyMs: 0, LossPct: 100, Success: false})
+	sum := s.Summary()
+	if sum.CurrentOutage == nil {
+		t.Fatal("expected active outage after failed probe")
+	}
+
+	s.RecordProbe(ProbeResult{Ts: 5000, Target: "8.8.8.8", LatencyMs: 10, LossPct: 0, Success: true})
+	sum = s.Summary()
+	if sum.CurrentOutage != nil {
+		t.Fatal("outage should be resolved")
+	}
+
+	outages := s.RecentOutages(10)
+	if len(outages) != 1 {
+		t.Fatalf("expected 1 outage, got %d", len(outages))
+	}
+	if outages[0].DurationS == nil || *outages[0].DurationS != 4000 {
+		t.Fatalf("duration: %v", outages[0].DurationS)
+	}
+}
+
+func TestRecentProbes(t *testing.T) {
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	defer d.Close()
+
+	s, err := NewStore(d)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		s.RecordProbe(ProbeResult{Ts: int64(i * 1000), Target: "8.8.8.8", LatencyMs: 10, LossPct: 0, Success: true})
+	}
+
+	probes := s.RecentProbes(3)
+	if len(probes) != 3 {
+		t.Fatalf("expected 3 probes, got %d", len(probes))
+	}
+	if probes[0].Ts != 4000 {
+		t.Fatalf("most recent first: %d", probes[0].Ts)
+	}
+}
+
+func TestNilDB(t *testing.T) {
+	s, err := NewStore(nil)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	s.RecordProbe(ProbeResult{Ts: 1000, Target: "8.8.8.8", LatencyMs: 10, LossPct: 0, Success: true})
+	sum := s.Summary()
+	if sum.LastProbe != nil {
+		t.Fatal("nil DB should return empty summary")
+	}
+}


### PR DESCRIPTION
Closes #335

Continuous internet health monitoring with multi-target probes and automatic outage detection.

## Changes
- New `internethealth` package: probe store + outage tracking
- DB tables: `internet_probes` (latency/loss per target) + `internet_outages` (start/end/resolution)
- Automatic outage detection: failed probe opens outage, success resolves it
- Summary, RecentProbes, RecentOutages queries
- `GET /api/internet-health` endpoint
- 4 tests
