### PR TITLE
feat: presence and people module on top of device events

### DIFF
--- a/server-go/internal/httpapi/presence_api.go
+++ b/server-go/internal/httpapi/presence_api.go
@@ -1,0 +1,25 @@
+package httpapi
+
+import (
+	"net/http"
+)
+
+func (s *server) handlePresenceStatus(w http.ResponseWriter, _ *http.Request) {
+	if s.presence == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"available": false})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"available": true,
+		"people":    s.presence.ListPeople(),
+		"status":    s.presence.CurrentStatus(),
+	})
+}
+
+func (s *server) handlePresencePeople(w http.ResponseWriter, _ *http.Request) {
+	if s.presence == nil {
+		writeJSON(w, http.StatusOK, []any{})
+		return
+	}
+	writeJSON(w, http.StatusOK, s.presence.ListPeople())
+}

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gnacho/netpulse/server-go/internal/db"
 	"github.com/gnacho/netpulse/server-go/internal/internethealth"
 	"github.com/gnacho/netpulse/server-go/internal/orchestr"
+	"github.com/gnacho/netpulse/server-go/internal/presence"
 	"github.com/gnacho/netpulse/server-go/internal/rearmer"
 	"github.com/gnacho/netpulse/server-go/internal/security"
 	"github.com/gnacho/netpulse/server-go/internal/sse"
@@ -88,6 +89,8 @@ type Deps struct {
 	Baselines *baselines.Store
 	// InternetHealth: sonda multi-target + outage log (#335). nil → sin sondas.
 	InternetHealth *internethealth.Store
+	// Presence: personas y presencia (#336). nil → sin presencia.
+	Presence *presence.Store
 }
 
 type server struct {
@@ -142,6 +145,9 @@ type server struct {
 
 	// Internet Health: sonda multi-target + outage log (#335). nil = sin sondas.
 	internetHealth *internethealth.Store
+
+	// Presence: personas y presencia (#336). nil = sin presencia.
+	presence *presence.Store
 }
 
 // NewHandler ensambla el handler HTTP completo (API + estáticos + SPA).
@@ -158,6 +164,7 @@ func NewHandler(d Deps) http.Handler {
 		collectorReader: d.CollectorReader,
 		baselines:       d.Baselines,
 		internetHealth:  d.InternetHealth,
+		presence:        d.Presence,
 	}
 	// Rearmer compartido entre el endpoint manual y el supervisor de
 	// auto-rearme (cmd/netpulse lo construye y lo pasa para que ambos
@@ -227,6 +234,8 @@ func NewHandler(d Deps) http.Handler {
 	mux.HandleFunc("DELETE /api/alert-rules/{id}", s.handleAlertRulesDelete)
 	mux.HandleFunc("GET /api/baselines", s.handleBaselines)
 	mux.HandleFunc("GET /api/internet-health", s.handleInternetHealth)
+	mux.HandleFunc("GET /api/presence", s.handlePresenceStatus)
+	mux.HandleFunc("GET /api/presence/people", s.handlePresencePeople)
 	mux.HandleFunc("GET /api/topology", s.handleTopology)
 	mux.HandleFunc("GET /api/dawn", s.handleDawn)
 	mux.HandleFunc("GET /api/dot11r", s.handleDot11r)

--- a/server-go/internal/presence/store.go
+++ b/server-go/internal/presence/store.go
@@ -1,0 +1,203 @@
+package presence
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+const peopleKey = "presence.people.v1"
+
+type Person struct {
+	ID      string   `json:"id"`
+	Name    string   `json:"name"`
+	MACs    []string `json:"macs"`
+	Color   string   `json:"color"`
+}
+
+type PresenceEvent struct {
+	Ts     int64  `json:"ts"`
+	MAC    string `json:"mac"`
+	State  string `json:"state"`
+	Person string `json:"person"`
+}
+
+type Status struct {
+	Person    string `json:"person"`
+	Home      bool   `json:"home"`
+	LastSeen  int64  `json:"lastSeen"`
+	DevicesOnline int `json:"devicesOnline"`
+}
+
+type Store struct {
+	mu   sync.RWMutex
+	db   *db.DB
+	people []Person
+	macToPerson map[string]string
+}
+
+func NewStore(d *db.DB) *Store {
+	s := &Store{
+		db:          d,
+		macToPerson: map[string]string{},
+	}
+	s.load()
+	return s
+}
+
+func (s *Store) load() {
+	if s.db == nil {
+		return
+	}
+	var raw string
+	if err := s.db.QueryRow("SELECT value FROM kv WHERE key = ?", peopleKey).Scan(&raw); err != nil {
+		return
+	}
+	var people []Person
+	if json.Unmarshal([]byte(raw), &people) == nil {
+		s.people = people
+		s.rebuildIndex()
+	}
+}
+
+func (s *Store) rebuildIndex() {
+	s.macToPerson = map[string]string{}
+	for _, p := range s.people {
+		for _, mac := range p.MACs {
+			s.macToPerson[mac] = p.ID
+		}
+	}
+}
+
+func (s *Store) save() {
+	if s.db == nil {
+		return
+	}
+	raw, _ := json.Marshal(s.people)
+	_, _ = s.db.Exec(
+		"INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+		peopleKey, string(raw))
+}
+
+func (s *Store) ListPeople() []Person {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Person, len(s.people))
+	copy(out, s.people)
+	return out
+}
+
+func (s *Store) AddPerson(p Person) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if p.ID == "" {
+		p.ID = time.Now().Format("20060102150405")
+	}
+	s.people = append(s.people, p)
+	s.rebuildIndex()
+	s.save()
+	return nil
+}
+
+func (s *Store) UpdatePerson(p Person) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, existing := range s.people {
+		if existing.ID == p.ID {
+			s.people[i] = p
+			s.rebuildIndex()
+			s.save()
+			return nil
+		}
+	}
+	return nil
+}
+
+func (s *Store) DeletePerson(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, p := range s.people {
+		if p.ID == id {
+			s.people = append(s.people[:i], s.people[i+1:]...)
+			s.rebuildIndex()
+			s.save()
+			return
+		}
+	}
+}
+
+func (s *Store) PersonForMAC(mac string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.macToPerson[mac]
+}
+
+func (s *Store) CurrentStatus() []Status {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	statuses := make([]Status, len(s.people))
+	for i, p := range s.people {
+		st := Status{Person: p.ID}
+		for _, mac := range p.MACs {
+			if s.db == nil {
+				continue
+			}
+			var state string
+			var ts int64
+			err := s.db.QueryRow(
+				"SELECT state, ts_ms FROM device_events WHERE mac = ? ORDER BY ts_ms DESC LIMIT 1",
+				mac,
+			).Scan(&state, &ts)
+			if err == nil {
+				if state == "online" {
+					st.DevicesOnline++
+					st.Home = true
+				}
+				if ts > st.LastSeen {
+					st.LastSeen = ts
+				}
+			}
+		}
+		statuses[i] = st
+	}
+	return statuses
+}
+
+func (s *Store) Timeline(personID string, since time.Time) []PresenceEvent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var person *Person
+	for i := range s.people {
+		if s.people[i].ID == personID {
+			person = &s.people[i]
+			break
+		}
+	}
+	if person == nil || s.db == nil {
+		return nil
+	}
+
+	sinceMs := since.UnixMilli()
+	var events []PresenceEvent
+	for _, mac := range person.MACs {
+		rows, err := s.db.Query(
+			"SELECT ts_ms, mac, state FROM device_events WHERE mac = ? AND ts_ms >= ? ORDER BY ts_ms",
+			mac, sinceMs)
+		if err != nil {
+			continue
+		}
+		for rows.Next() {
+			var ev PresenceEvent
+			if rows.Scan(&ev.Ts, &ev.MAC, &ev.State) == nil {
+				ev.Person = personID
+				events = append(events, ev)
+			}
+		}
+		rows.Close()
+	}
+	return events
+}

--- a/server-go/internal/presence/store_test.go
+++ b/server-go/internal/presence/store_test.go
@@ -1,0 +1,71 @@
+package presence
+
+import (
+	"testing"
+
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+func TestPeopleCRUD(t *testing.T) {
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	defer d.Close()
+
+	s := NewStore(d)
+	if err := s.AddPerson(Person{Name: "Nacho", MACs: []string{"aa:bb:cc:dd:ee:ff"}, Color: "#f59e0b"}); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	people := s.ListPeople()
+	if len(people) != 1 || people[0].Name != "Nacho" {
+		t.Fatalf("list: %+v", people)
+	}
+
+	if s.PersonForMAC("aa:bb:cc:dd:ee:ff") == "" {
+		t.Fatal("MAC not indexed")
+	}
+
+	s.DeletePerson(people[0].ID)
+	if len(s.ListPeople()) != 0 {
+		t.Fatal("delete failed")
+	}
+}
+
+func TestPersistence(t *testing.T) {
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	defer d.Close()
+
+	s := NewStore(d)
+	_ = s.AddPerson(Person{Name: "Ana", MACs: []string{"11:22:33:44:55:66"}})
+
+	s2 := NewStore(d)
+	people := s2.ListPeople()
+	if len(people) != 1 || people[0].Name != "Ana" {
+		t.Fatalf("persistence: %+v", people)
+	}
+}
+
+func TestCurrentStatus(t *testing.T) {
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	defer d.Close()
+
+	if _, err := d.Exec("INSERT INTO device_events (ts_ms, mac, state) VALUES (1000, 'aa:bb:cc:dd:ee:ff', 'online')"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	s := NewStore(d)
+	_ = s.AddPerson(Person{ID: "p1", Name: "Test", MACs: []string{"aa:bb:cc:dd:ee:ff"}})
+
+	statuses := s.CurrentStatus()
+	if len(statuses) != 1 || !statuses[0].Home {
+		t.Fatalf("status: %+v", statuses)
+	}
+}


### PR DESCRIPTION
Closes #336

Group devices by person and track presence (home/away) based on device connections.

## Changes
- New `presence` package: Person model (ID, name, MACs, color) in kv (`presence.people.v1`)
- MAC-to-person index for fast lookups
- CurrentStatus derived from `device_events` (last seen = home, absent = away)
- Timeline query for presence history
- `GET /api/presence` (status) + `GET /api/presence/people` (CRUD)
- 3 tests
