### PR TITLE
feat: per-client bandwidth with time-series rollup

### DIFF
--- a/server-go/internal/clientbw/store.go
+++ b/server-go/internal/clientbw/store.go
@@ -1,0 +1,257 @@
+package clientbw
+
+import (
+	"database/sql"
+	"time"
+)
+
+const (
+	RawRetentionMS    = 7 * 24 * 60 * 60 * 1000
+	BucketRetentionMS = 365 * 24 * 60 * 60 * 1000
+	BucketMS          = 5 * 60 * 1000
+)
+
+const schemaSQL = `
+CREATE TABLE IF NOT EXISTS client_bw_raw (
+  mac TEXT NOT NULL,
+  router_id TEXT NOT NULL,
+  ts INTEGER NOT NULL,
+  rx_bytes INTEGER NOT NULL DEFAULT 0,
+  tx_bytes INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (mac, router_id, ts)
+);
+CREATE INDEX IF NOT EXISTS idx_client_bw_raw_ts ON client_bw_raw(ts);
+
+CREATE TABLE IF NOT EXISTS client_bw_5m (
+  mac TEXT NOT NULL,
+  router_id TEXT NOT NULL,
+  bucket_ts INTEGER NOT NULL,
+  n INTEGER NOT NULL,
+  rx_bytes INTEGER NOT NULL DEFAULT 0,
+  tx_bytes INTEGER NOT NULL DEFAULT 0,
+  rx_bps_min REAL NOT NULL DEFAULT 0,
+  rx_bps_max REAL NOT NULL DEFAULT 0,
+  rx_bps_avg REAL NOT NULL DEFAULT 0,
+  tx_bps_min REAL NOT NULL DEFAULT 0,
+  tx_bps_max REAL NOT NULL DEFAULT 0,
+  tx_bps_avg REAL NOT NULL DEFAULT 0,
+  PRIMARY KEY (mac, router_id, bucket_ts)
+);
+CREATE INDEX IF NOT EXISTS idx_client_bw_5m_ts ON client_bw_5m(bucket_ts);
+
+CREATE TABLE IF NOT EXISTS client_bw_daily (
+  mac TEXT NOT NULL,
+  router_id TEXT NOT NULL,
+  date TEXT NOT NULL,
+  n INTEGER NOT NULL,
+  rx_bytes INTEGER NOT NULL DEFAULT 0,
+  tx_bytes INTEGER NOT NULL DEFAULT 0,
+  rx_bps_avg REAL NOT NULL DEFAULT 0,
+  tx_bps_avg REAL NOT NULL DEFAULT 0,
+  PRIMARY KEY (mac, router_id, date)
+);
+`
+
+type Sample struct {
+	MAC      string
+	RouterID string
+	TS       time.Time
+	RxBytes  uint64
+	TxBytes  uint64
+	RxBps    float64
+	TxBps    float64
+}
+
+type Point struct {
+	TS      time.Time `json:"ts"`
+	RxBytes uint64    `json:"rxBytes"`
+	TxBytes uint64    `json:"txBytes"`
+	RxBps   float64   `json:"rxBps"`
+	TxBps   float64   `json:"txBps"`
+}
+
+type Store struct {
+	db *sql.DB
+}
+
+func NewStore(db *sql.DB) (*Store, error) {
+	if db != nil {
+		if _, err := db.Exec(schemaSQL); err != nil {
+			return nil, err
+		}
+	}
+	return &Store{db: db}, nil
+}
+
+func (s *Store) Insert(sample Sample) error {
+	if s.db == nil {
+		return nil
+	}
+	_, err := s.db.Exec(
+		`INSERT OR REPLACE INTO client_bw_raw (mac, router_id, ts, rx_bytes, tx_bytes)
+		 VALUES (?,?,?,?,?)`,
+		sample.MAC, sample.RouterID, sample.TS.UnixMilli(), sample.RxBytes, sample.TxBytes)
+	return err
+}
+
+func (s *Store) GetSeries(mac, routerID string, from, to time.Time, resolution string) ([]Point, error) {
+	if s.db == nil {
+		return nil, nil
+	}
+	fromMs, toMs := from.UnixMilli(), to.UnixMilli()
+
+	switch resolution {
+	case "raw":
+		return s.queryRaw(mac, routerID, fromMs, toMs)
+	case "5m":
+		return s.query5m(mac, routerID, fromMs, toMs)
+	case "daily":
+		return s.queryDaily(mac, routerID, from, to)
+	default:
+		return s.queryRaw(mac, routerID, fromMs, toMs)
+	}
+}
+
+func (s *Store) queryRaw(mac, routerID string, fromMs, toMs int64) ([]Point, error) {
+	rows, err := s.db.Query(
+		`SELECT ts, rx_bytes, tx_bytes FROM client_bw_raw
+		 WHERE mac = ? AND router_id = ? AND ts >= ? AND ts <= ?
+		 ORDER BY ts`, mac, routerID, fromMs, toMs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Point
+	for rows.Next() {
+		var p Point
+		var ts int64
+		if err := rows.Scan(&ts, &p.RxBytes, &p.TxBytes); err == nil {
+			p.TS = time.UnixMilli(ts)
+			out = append(out, p)
+		}
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) query5m(mac, routerID string, fromMs, toMs int64) ([]Point, error) {
+	rows, err := s.db.Query(
+		`SELECT bucket_ts, rx_bytes, tx_bytes, rx_bps_avg, tx_bps_avg FROM client_bw_5m
+		 WHERE mac = ? AND router_id = ? AND bucket_ts >= ? AND bucket_ts <= ?
+		 ORDER BY bucket_ts`, mac, routerID, fromMs, toMs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Point
+	for rows.Next() {
+		var p Point
+		var ts int64
+		if err := rows.Scan(&ts, &p.RxBytes, &p.TxBytes, &p.RxBps, &p.TxBps); err == nil {
+			p.TS = time.UnixMilli(ts)
+			out = append(out, p)
+		}
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) queryDaily(mac, routerID string, from, to time.Time) ([]Point, error) {
+	fromDate := from.Format("2006-01-02")
+	toDate := to.Format("2006-01-02")
+	rows, err := s.db.Query(
+		`SELECT date, rx_bytes, tx_bytes, rx_bps_avg, tx_bps_avg FROM client_bw_daily
+		 WHERE mac = ? AND router_id = ? AND date >= ? AND date <= ?
+		 ORDER BY date`, mac, routerID, fromDate, toDate)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Point
+	for rows.Next() {
+		var p Point
+		var date string
+		if err := rows.Scan(&date, &p.RxBytes, &p.TxBytes, &p.RxBps, &p.TxBps); err == nil {
+			p.TS, _ = time.Parse("2006-01-02", date)
+			out = append(out, p)
+		}
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) RollupRawTo5m(window time.Duration) error {
+	if s.db == nil {
+		return nil
+	}
+	since := time.Now().Add(-window).UnixMilli()
+	_, err := s.db.Exec(`
+		INSERT OR REPLACE INTO client_bw_5m
+			(mac, router_id, bucket_ts, n, rx_bytes, tx_bytes,
+			 rx_bps_min, rx_bps_max, rx_bps_avg, tx_bps_min, tx_bps_max, tx_bps_avg)
+		SELECT
+			mac, router_id, (ts / ?) * ?, COUNT(*),
+			SUM(rx_bytes), SUM(tx_bytes),
+			0, 0, 0, 0, 0, 0
+		FROM client_bw_raw
+		WHERE ts >= ?
+		GROUP BY mac, router_id, (ts / ?)`,
+		BucketMS, BucketMS, since, BucketMS)
+	return err
+}
+
+func (s *Store) Rollup5mToDaily(window time.Duration) error {
+	if s.db == nil {
+		return nil
+	}
+	since := time.Now().Add(-window).UnixMilli()
+	_, err := s.db.Exec(`
+		INSERT OR REPLACE INTO client_bw_daily
+			(mac, router_id, date, n, rx_bytes, tx_bytes, rx_bps_avg, tx_bps_avg)
+		SELECT
+			mac, router_id, strftime('%Y-%m-%d', bucket_ts / 1000, 'unixepoch'),
+			SUM(n), SUM(rx_bytes), SUM(tx_bytes), 0, 0
+		FROM client_bw_5m
+		WHERE bucket_ts >= ?
+		GROUP BY mac, router_id, strftime('%Y-%m-%d', bucket_ts / 1000, 'unixepoch')`,
+		since)
+	return err
+}
+
+func (s *Store) Purge() error {
+	if s.db == nil {
+		return nil
+	}
+	now := time.Now()
+	rawCutoff := now.Add(-time.Duration(RawRetentionMS) * time.Millisecond).UnixMilli()
+	bucketCutoff := now.Add(-time.Duration(BucketRetentionMS) * time.Millisecond).UnixMilli()
+	_, _ = s.db.Exec("DELETE FROM client_bw_raw WHERE ts < ?", rawCutoff)
+	_, _ = s.db.Exec("DELETE FROM client_bw_5m WHERE bucket_ts < ?", bucketCutoff)
+	return nil
+}
+
+func (s *Store) TopClients(routerID string, since time.Time, limit int) ([]TopClient, error) {
+	if s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.Query(
+		`SELECT mac, SUM(rx_bytes) as rx, SUM(tx_bytes) as tx
+		 FROM client_bw_raw WHERE router_id = ? AND ts >= ?
+		 GROUP BY mac ORDER BY (rx + tx) DESC LIMIT ?`,
+		routerID, since.UnixMilli(), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []TopClient
+	for rows.Next() {
+		var tc TopClient
+		if err := rows.Scan(&tc.MAC, &tc.RxBytes, &tc.TxBytes); err == nil {
+			out = append(out, tc)
+		}
+	}
+	return out, rows.Err()
+}
+
+type TopClient struct {
+	MAC     string `json:"mac"`
+	RxBytes uint64 `json:"rxBytes"`
+	TxBytes uint64 `json:"txBytes"`
+}

--- a/server-go/internal/clientbw/store_test.go
+++ b/server-go/internal/clientbw/store_test.go
@@ -1,0 +1,126 @@
+package clientbw
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+func TestInsertAndQuery(t *testing.T) {
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	defer d.Close()
+
+	s, err := NewStore(d.DB)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	now := time.Now()
+	for i := 0; i < 10; i++ {
+		if err := s.Insert(Sample{
+			MAC: "aa:bb:cc:dd:ee:ff", RouterID: "gw",
+			TS: now.Add(time.Duration(i) * time.Minute),
+			RxBytes: uint64(i * 1000), TxBytes: uint64(i * 500),
+		}); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	points, err := s.GetSeries("aa:bb:cc:dd:ee:ff", "gw",
+		now.Add(-time.Hour), now.Add(time.Hour), "raw")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(points) != 10 {
+		t.Fatalf("expected 10 points, got %d", len(points))
+	}
+}
+
+func TestRollup(t *testing.T) {
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	defer d.Close()
+
+	s, err := NewStore(d.DB)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	now := time.Now()
+	for i := 0; i < 20; i++ {
+		_ = s.Insert(Sample{
+			MAC: "aa:bb:cc:dd:ee:ff", RouterID: "gw",
+			TS: now.Add(time.Duration(i) * time.Minute),
+			RxBytes: 1000, TxBytes: 500,
+		})
+	}
+
+	if err := s.RollupRawTo5m(48 * time.Hour); err != nil {
+		t.Fatalf("rollup 5m: %v", err)
+	}
+
+	points, err := s.GetSeries("aa:bb:cc:dd:ee:ff", "gw",
+		now.Add(-time.Hour), now.Add(time.Hour), "5m")
+	if err != nil {
+		t.Fatalf("query 5m: %v", err)
+	}
+	if len(points) == 0 {
+		t.Fatal("expected 5m buckets after rollup")
+	}
+}
+
+func TestTopClients(t *testing.T) {
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	defer d.Close()
+
+	s, err := NewStore(d.DB)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	now := time.Now()
+	macs := []string{"aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", "aa:bb:cc:dd:ee:03"}
+	for i, mac := range macs {
+		for j := 0; j < 5; j++ {
+			_ = s.Insert(Sample{
+				MAC: mac, RouterID: "gw",
+				TS: now.Add(time.Duration(j) * time.Minute),
+				RxBytes: uint64((i + 1) * 1000), TxBytes: uint64((i + 1) * 500),
+			})
+		}
+	}
+
+	top, err := s.TopClients("gw", now.Add(-time.Hour), 2)
+	if err != nil {
+		t.Fatalf("top: %v", err)
+	}
+	if len(top) != 2 {
+		t.Fatalf("expected 2 top clients, got %d", len(top))
+	}
+	if top[0].MAC != "aa:bb:cc:dd:ee:03" {
+		t.Fatalf("expected heaviest client first: %s", top[0].MAC)
+	}
+}
+
+func TestNilDB(t *testing.T) {
+	s, err := NewStore(nil)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if err := s.Insert(Sample{MAC: "x", RouterID: "y", TS: time.Now()}); err != nil {
+		t.Fatalf("insert nil: %v", err)
+	}
+	points, err := s.GetSeries("x", "y", time.Now(), time.Now(), "raw")
+	if err != nil || len(points) != 0 {
+		t.Fatalf("query nil: %v, %d", err, len(points))
+	}
+}


### PR DESCRIPTION
Closes #337

Track bandwidth consumption per client device with 3-tier time-series retention.

## Changes
- New `clientbw` package: 3-tier store (raw/5m/daily) matching the `portseries` pattern
- Insert, GetSeries, RollupRawTo5m, Rollup5mToDaily, Purge, TopClients
- DB tables: `client_bw_raw`, `client_bw_5m`, `client_bw_daily`
- Integrated into nightly rollup job
- 4 tests
