### PR TITLE
feat: WiFi SLE metrics - connect time, DHCP success, DNS latency

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1445,5 +1445,11 @@
   "alertSuppression": {
     "suppressedBy": "Suppressed by {{router}}",
     "suppressedHint": "This alert is suppressed because a parent router is offline."
+  },
+  "wifiSle": {
+    "title": "WiFi SLE",
+    "connectTime": "Connect",
+    "dhcpSuccess": "DHCP",
+    "dnsLatency": "DNS"
   }
 }

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1445,5 +1445,11 @@
   "alertSuppression": {
     "suppressedBy": "Suprimida por {{router}}",
     "suppressedHint": "Esta alerta está suprimida porque un router padre está offline."
+  },
+  "wifiSle": {
+    "title": "WiFi SLE",
+    "connectTime": "Conexion",
+    "dhcpSuccess": "DHCP",
+    "dnsLatency": "DNS"
   }
 }

--- a/app/src/components/WiFiSLECard.tsx
+++ b/app/src/components/WiFiSLECard.tsx
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Wifi, Clock, Server, Gauge } from 'lucide-react'
+import { HealthRing } from '@/components/HealthRing'
+
+type SLEItem = {
+  routerId: string
+  connectCount: number
+  avgConnectMs: number
+  dhcpSuccessPct: number
+  avgDnsMs: number
+  score: number
+  label: string
+}
+
+function SLEMetric({
+  icon: Icon,
+  label,
+  value,
+  unit,
+  tone,
+}: {
+  icon: React.ComponentType<{ className?: string; strokeWidth?: number }>
+  label: string
+  value: string
+  unit: string
+  tone: string
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <Icon className={`h-3.5 w-3.5 ${tone}`} strokeWidth={1.75} />
+      <div>
+        <span className="text-[10px] uppercase text-text-muted">{label}</span>
+        <div className="font-mono text-sm font-semibold text-text-primary">
+          {value} <span className="text-[10px] font-normal text-text-muted">{unit}</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SLECard({ sle }: { sle: SLEItem }) {
+  const { t } = useTranslation()
+  const connectTone = sle.avgConnectMs > 1000 ? 'text-warn' : sle.avgConnectMs > 500 ? 'text-info' : 'text-ok'
+  const dhcpTone = sle.dhcpSuccessPct < 95 ? 'text-danger' : sle.dhcpSuccessPct < 99 ? 'text-warn' : 'text-ok'
+  const dnsTone = sle.avgDnsMs > 100 ? 'text-danger' : sle.avgDnsMs > 50 ? 'text-warn' : 'text-ok'
+
+  return (
+    <div className="flex items-center gap-4 rounded-xl border border-border bg-surface p-4">
+      <HealthRing value={sle.score} size={56} stroke={5} animateIn={false}
+        ariaLabel={`${sle.routerId} WiFi SLE: ${sle.score}/100`}
+        center={<span className="font-mono text-xs font-bold text-text-primary">{sle.score}</span>}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-semibold text-text-primary">{sle.routerId}</span>
+          <span className="text-[10px] text-text-muted">{sle.label}</span>
+        </div>
+        <div className="mt-2 grid grid-cols-3 gap-3">
+          <SLEMetric icon={Clock} label={t('wifiSle.connectTime')} value={sle.avgConnectMs.toFixed(0)} unit="ms" tone={connectTone} />
+          <SLEMetric icon={Server} label={t('wifiSle.dhcpSuccess')} value={sle.dhcpSuccessPct.toFixed(1)} unit="%" tone={dhcpTone} />
+          <SLEMetric icon={Gauge} label={t('wifiSle.dnsLatency')} value={sle.avgDnsMs.toFixed(1)} unit="ms" tone={dnsTone} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function WiFiSLECard() {
+  const { t } = useTranslation()
+  const [sles, setSles] = useState<SLEItem[]>([])
+  const [available, setAvailable] = useState(false)
+  const [loading, setLoading] = useState(true)
+
+  const fetchSLEs = useCallback(async () => {
+    try {
+      const r = await fetch('/api/wifi-sles?hours=24')
+      if (r.ok) {
+        const d = (await r.json()) as { sles: SLEItem[]; available: boolean }
+        setSles(d.sles ?? [])
+        setAvailable(!!d.available)
+      }
+    } catch {
+      /* ignore */
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetchSLEs()
+  }, [fetchSLEs])
+
+  if (loading || !available || sles.length === 0) return null
+
+  return (
+    <div className="rounded-2xl border border-border bg-surface p-5">
+      <div className="mb-4 flex items-center gap-2">
+        <Wifi className="h-4 w-4 text-accent" strokeWidth={1.75} />
+        <h3 className="text-sm font-semibold text-text-primary">{t('wifiSle.title')}</h3>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {sles.map((sle) => (
+          <SLECard key={sle.routerId} sle={sle} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/src/pages/Home.tsx
+++ b/app/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { CollectorCharts } from '@/components/CollectorCharts'
+import { WiFiSLECard } from '@/components/WiFiSLECard'
 import { AdGuardCard, WireGuardCard } from '@/sections/GatewayServices'
 import { HeroStrip } from '@/sections/HeroStrip'
 import { RecentAlerts } from '@/sections/RecentAlerts'
@@ -49,6 +50,12 @@ export default function Home() {
       {!isDemo && (
         <div className="lg:col-span-12">
           <CollectorCharts />
+        </div>
+      )}
+      {/* ⑤ WiFi SLEs (#342): Service Level Expectations por router */}
+      {!isDemo && (
+        <div className="lg:col-span-12">
+          <WiFiSLECard />
         </div>
       )}
       {/* Top dispositivos: solo demo (en live no hay tráfico por dispositivo) */}

--- a/app/src/sections/HeroStrip.tsx
+++ b/app/src/sections/HeroStrip.tsx
@@ -10,7 +10,6 @@ import { StatusPill } from '@/components/StatusPill'
 import { useNetPulse } from '@/data/DataProvider'
 import { useAuth } from '@/data/AuthContext'
 import { useDashboard } from '@/hooks/useDashboard'
-import { cn } from '@/lib/utils'
 
 function greetingKey(): string {
   const h = new Date().getHours()

--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -52,6 +52,7 @@ import (
 	"github.com/gnacho/netpulse/server-go/internal/tlscert"
 	"github.com/gnacho/netpulse/server-go/internal/updater"
 	"github.com/gnacho/netpulse/server-go/internal/webhook"
+	"github.com/gnacho/netpulse/server-go/internal/wifisle"
 )
 
 // Timeouts de http.Server (issue #210): ReadTimeout/WriteTimeout acotan una
@@ -205,6 +206,10 @@ func run() error {
 			log.Printf("[netpulse] collector sidecar: %s", collPath)
 		}
 	}
+	if err := wifisle.EnsureSchema(dbHandle); err != nil {
+		return fmt.Errorf("wifi sle schema: %w", err)
+	}
+	wifiSLE := wifisle.NewStore(dbHandle)
 
 	// Clave SSH propia para sondear routers (se genera la primera vez)
 	if err := sshkey.EnsureKeypair(cfg.SSHKeyPath); err != nil {
@@ -408,6 +413,7 @@ func run() error {
 		Orchestr:        orchMgr,
 		TokenStore:      tokenStore,
 		CollectorReader: collReader,
+		WiFiSLE:         wifiSLE,
 		LastOverview: func() *adapters.Overview {
 			return p.LastOverview()
 		},

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gnacho/netpulse/server-go/internal/sse"
 	"github.com/gnacho/netpulse/server-go/internal/staticspa"
 	"github.com/gnacho/netpulse/server-go/internal/updater"
+	"github.com/gnacho/netpulse/server-go/internal/wifisle"
 )
 
 // Version es la versión del backend (app.js:18). Es una var (no const) para
@@ -91,6 +92,8 @@ type Deps struct {
 	InternetHealth *internethealth.Store
 	// Presence: personas y presencia (#336). nil → sin presencia.
 	Presence *presence.Store
+	// WiFiSLE: WiFi Service Level Expectations (#342). nil → sin SLEs.
+	WiFiSLE *wifisle.Store
 }
 
 type server struct {
@@ -148,6 +151,9 @@ type server struct {
 
 	// Presence: personas y presencia (#336). nil = sin presencia.
 	presence *presence.Store
+
+	// WiFiSLE: WiFi Service Level Expectations (#342). nil = sin SLEs.
+	wifiSLE *wifisle.Store
 }
 
 // NewHandler ensambla el handler HTTP completo (API + estáticos + SPA).
@@ -165,6 +171,7 @@ func NewHandler(d Deps) http.Handler {
 		baselines:       d.Baselines,
 		internetHealth:  d.InternetHealth,
 		presence:        d.Presence,
+		wifiSLE:         d.WiFiSLE,
 	}
 	// Rearmer compartido entre el endpoint manual y el supervisor de
 	// auto-rearme (cmd/netpulse lo construye y lo pasa para que ambos
@@ -236,6 +243,8 @@ func NewHandler(d Deps) http.Handler {
 	mux.HandleFunc("GET /api/internet-health", s.handleInternetHealth)
 	mux.HandleFunc("GET /api/presence", s.handlePresenceStatus)
 	mux.HandleFunc("GET /api/presence/people", s.handlePresencePeople)
+	mux.HandleFunc("GET /api/wifi-sles", s.handleWiFiSLESummary)
+	mux.HandleFunc("GET /api/wifi-sles/series", s.handleWiFiSLESeries)
 	mux.HandleFunc("GET /api/metrics", s.handleMetrics)
 	mux.HandleFunc("GET /api/topology", s.handleTopology)
 	mux.HandleFunc("GET /api/dawn", s.handleDawn)

--- a/server-go/internal/httpapi/wifi_sle_api.go
+++ b/server-go/internal/httpapi/wifi_sle_api.go
@@ -1,0 +1,57 @@
+package httpapi
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+func (s *server) handleWiFiSLESummary(w http.ResponseWriter, r *http.Request) {
+	if s.wifiSLE == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"sles": []any{}, "available": false})
+		return
+	}
+	hours := 24
+	if v := r.URL.Query().Get("hours"); v != "" {
+		if h, err := strconv.Atoi(v); err == nil && h > 0 {
+			hours = h
+		}
+	}
+	summaries, err := s.wifiSLE.AllSummaries(hours)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "sle_error", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"sles": summaries, "available": true, "windowHours": hours})
+}
+
+func (s *server) handleWiFiSLESeries(w http.ResponseWriter, r *http.Request) {
+	if s.wifiSLE == nil {
+		writeError(w, http.StatusServiceUnavailable, "sle_unavailable")
+		return
+	}
+	routerID := r.URL.Query().Get("router")
+	if routerID == "" {
+		writeError(w, http.StatusBadRequest, "invalid_input", "router required")
+		return
+	}
+	now := time.Now().UnixMilli()
+	from := now - 86400000
+	to := now
+	if v := r.URL.Query().Get("from"); v != "" {
+		if f, err := strconv.ParseInt(v, 10, 64); err == nil {
+			from = f
+		}
+	}
+	if v := r.URL.Query().Get("to"); v != "" {
+		if t, err := strconv.ParseInt(v, 10, 64); err == nil {
+			to = t
+		}
+	}
+	series, err := s.wifiSLE.Series(routerID, from, to)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "series_error", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"router": routerID, "series": series, "from": from, "to": to})
+}

--- a/server-go/internal/wifisle/store.go
+++ b/server-go/internal/wifisle/store.go
@@ -1,0 +1,194 @@
+package wifisle
+
+import (
+	"database/sql"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+type SLEReport struct {
+	RouterID       string  `json:"routerId"`
+	TS             int64   `json:"ts"`
+	ConnectCount   int     `json:"connectCount"`
+	AvgConnectMs   float64 `json:"avgConnectMs"`
+	DHCPRequests   int     `json:"dhcpRequests"`
+	DHCPAcks       int     `json:"dhcpAcks"`
+	DHCPSuccessPct float64 `json:"dhcpSuccessPct"`
+	DNSQueries     int     `json:"dnsQueries"`
+	AvgDNSMs       float64 `json:"avgDnsMs"`
+}
+
+type Summary struct {
+	RouterID       string  `json:"routerId"`
+	ConnectCount   int     `json:"connectCount"`
+	AvgConnectMs   float64 `json:"avgConnectMs"`
+	DHCPSuccessPct float64 `json:"dhcpSuccessPct"`
+	AvgDNSMs       float64 `json:"avgDnsMs"`
+	Score          int     `json:"score"`
+	Label          string  `json:"label"`
+}
+
+type Store struct {
+	db *db.DB
+}
+
+func NewStore(d *db.DB) *Store {
+	return &Store{db: d}
+}
+
+func EnsureSchema(d *db.DB) error {
+	_, err := d.Exec(`
+		CREATE TABLE IF NOT EXISTS wifi_sles (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			router_id TEXT NOT NULL,
+			ts INTEGER NOT NULL,
+			connect_count INTEGER NOT NULL DEFAULT 0,
+			avg_connect_ms REAL NOT NULL DEFAULT 0,
+			dhcp_requests INTEGER NOT NULL DEFAULT 0,
+			dhcp_acks INTEGER NOT NULL DEFAULT 0,
+			dns_queries INTEGER NOT NULL DEFAULT 0,
+			avg_dns_ms REAL NOT NULL DEFAULT 0
+		);
+		CREATE INDEX IF NOT EXISTS idx_wifi_sles_router_ts ON wifi_sles(router_id, ts DESC);
+	`)
+	return err
+}
+
+func (s *Store) Insert(r SLEReport) error {
+	_, err := s.db.Exec(
+		`INSERT INTO wifi_sles (router_id, ts, connect_count, avg_connect_ms, dhcp_requests, dhcp_acks, dns_queries, avg_dns_ms)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.RouterID, r.TS, r.ConnectCount, r.AvgConnectMs, r.DHCPRequests, r.DHCPAcks, r.DNSQueries, r.AvgDNSMs,
+	)
+	return err
+}
+
+func (s *Store) Summary(routerID string, windowHours int) (*Summary, error) {
+	cutoff := db.NowMS() - int64(windowHours)*3600000
+	var sc Summary
+	sc.RouterID = routerID
+	var dhcpReqs, dhcpAcks int
+	err := s.db.QueryRow(`
+		SELECT COALESCE(SUM(connect_count),0),
+		       CASE WHEN SUM(connect_count) > 0 THEN SUM(avg_connect_ms * connect_count) / SUM(connect_count) ELSE 0 END,
+		       COALESCE(SUM(dhcp_requests),0),
+		       COALESCE(SUM(dhcp_acks),0),
+		       CASE WHEN SUM(dns_queries) > 0 THEN SUM(avg_dns_ms * dns_queries) / SUM(dns_queries) ELSE 0 END
+		FROM wifi_sles WHERE router_id = ? AND ts >= ?`,
+		routerID, cutoff,
+	).Scan(&sc.ConnectCount, &sc.AvgConnectMs, &dhcpReqs, &dhcpAcks, &sc.AvgDNSMs)
+	if err != nil {
+		return nil, err
+	}
+	if dhcpReqs > 0 {
+		sc.DHCPSuccessPct = math.Round(float64(dhcpAcks) / float64(dhcpReqs) * 1000) / 10
+	} else {
+		sc.DHCPSuccessPct = 100
+	}
+	sc.Score = computeScore(sc)
+	sc.Label = scoreLabel(sc.Score)
+	return &sc, nil
+}
+
+func (s *Store) AllSummaries(windowHours int) ([]Summary, error) {
+	rows, err := s.db.Query("SELECT DISTINCT router_id FROM wifi_sles")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Summary
+	for rows.Next() {
+		var rid string
+		if err := rows.Scan(&rid); err != nil {
+			continue
+		}
+		sc, err := s.Summary(rid, windowHours)
+		if err == nil {
+			out = append(out, *sc)
+		}
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) Series(routerID string, from, to int64) ([]SLEReport, error) {
+	rows, err := s.db.Query(
+		`SELECT router_id, ts, connect_count, avg_connect_ms, dhcp_requests, dhcp_acks, dns_queries, avg_dns_ms
+		 FROM wifi_sles WHERE router_id = ? AND ts BETWEEN ? AND ? ORDER BY ts`,
+		routerID, from, to,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []SLEReport
+	for rows.Next() {
+		var r SLEReport
+		if err := rows.Scan(&r.RouterID, &r.TS, &r.ConnectCount, &r.AvgConnectMs, &r.DHCPRequests, &r.DHCPAcks, &r.DNSQueries, &r.AvgDNSMs); err != nil {
+			return nil, err
+		}
+		if r.DHCPRequests > 0 {
+			r.DHCPSuccessPct = math.Round(float64(r.DHCPAcks) / float64(r.DHCPRequests) * 1000) / 10
+		} else {
+			r.DHCPSuccessPct = 100
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) Purge(olderThan time.Duration) (int64, error) {
+	cutoff := db.NowMS() - olderThan.Milliseconds()
+	res, err := s.db.Exec("DELETE FROM wifi_sles WHERE ts < ?", cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+func computeScore(sc Summary) int {
+	score := 100
+	if sc.AvgConnectMs > 2000 {
+		score -= 20
+	} else if sc.AvgConnectMs > 1000 {
+		score -= 10
+	} else if sc.AvgConnectMs > 500 {
+		score -= 5
+	}
+	if sc.DHCPSuccessPct < 90 {
+		score -= 25
+	} else if sc.DHCPSuccessPct < 95 {
+		score -= 15
+	} else if sc.DHCPSuccessPct < 99 {
+		score -= 5
+	}
+	if sc.AvgDNSMs > 100 {
+		score -= 20
+	} else if sc.AvgDNSMs > 50 {
+		score -= 10
+	} else if sc.AvgDNSMs > 20 {
+		score -= 5
+	}
+	if score < 0 {
+		score = 0
+	}
+	return score
+}
+
+func scoreLabel(score int) string {
+	switch {
+	case score >= 90:
+		return "Excellent"
+	case score >= 70:
+		return "Good"
+	case score >= 50:
+		return "Fair"
+	default:
+		return "Poor"
+	}
+}
+
+var _ = sql.ErrNoRows
+var _ = fmt.Sprintf

--- a/server-go/internal/wifisle/store_test.go
+++ b/server-go/internal/wifisle/store_test.go
@@ -1,0 +1,117 @@
+package wifisle
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+func setup(t *testing.T) *Store {
+	t.Helper()
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	if err := EnsureSchema(d); err != nil {
+		t.Fatal(err)
+	}
+	return NewStore(d)
+}
+
+func TestInsertAndSummary(t *testing.T) {
+	s := setup(t)
+	now := db.NowMS()
+	for i := 0; i < 5; i++ {
+		err := s.Insert(SLEReport{
+			RouterID: "patio", TS: now - int64(i)*3600000,
+			ConnectCount: 10, AvgConnectMs: 150 + float64(i*10),
+			DHCPRequests: 20, DHCPAcks: 19, DNSQueries: 100, AvgDNSMs: 5.5,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	sc, err := s.Summary("patio", 24)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sc.ConnectCount != 50 {
+		t.Fatalf("expected 50 connects, got %d", sc.ConnectCount)
+	}
+	if sc.DHCPSuccessPct < 94 || sc.DHCPSuccessPct > 96 {
+		t.Fatalf("unexpected DHCP success: %.1f%%", sc.DHCPSuccessPct)
+	}
+	if sc.Score < 80 {
+		t.Fatalf("score too low: %d", sc.Score)
+	}
+}
+
+func TestSummaryEmpty(t *testing.T) {
+	s := setup(t)
+	sc, err := s.Summary("nonexistent", 24)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sc.ConnectCount != 0 {
+		t.Fatalf("expected 0 connects, got %d", sc.ConnectCount)
+	}
+	if sc.DHCPSuccessPct != 100 {
+		t.Fatalf("expected 100%% DHCP (no data), got %.1f%%", sc.DHCPSuccessPct)
+	}
+}
+
+func TestSeries(t *testing.T) {
+	s := setup(t)
+	now := db.NowMS()
+	for i := 0; i < 3; i++ {
+		_ = s.Insert(SLEReport{
+			RouterID: "patio", TS: now - int64(i)*3600000,
+			ConnectCount: 5, AvgConnectMs: 100, DHCPRequests: 10, DHCPAcks: 10,
+		})
+	}
+	series, err := s.Series("patio", now-7200000, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(series) != 3 {
+		t.Fatalf("expected 3 points, got %d", len(series))
+	}
+}
+
+func TestPurge(t *testing.T) {
+	s := setup(t)
+	now := db.NowMS()
+	_ = s.Insert(SLEReport{RouterID: "r1", TS: now - 86400000*30, ConnectCount: 1})
+	_ = s.Insert(SLEReport{RouterID: "r1", TS: now, ConnectCount: 1})
+	n, err := s.Purge(7 * 24 * time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 purged, got %d", n)
+	}
+}
+
+func TestComputeScore(t *testing.T) {
+	tests := []struct {
+		name     string
+		sc       Summary
+		minScore int
+	}{
+		{"perfect", Summary{AvgConnectMs: 100, DHCPSuccessPct: 100, AvgDNSMs: 5}, 95},
+		{"slow connect", Summary{AvgConnectMs: 2500, DHCPSuccessPct: 100, AvgDNSMs: 5}, 70},
+		{"dhcp failures", Summary{AvgConnectMs: 100, DHCPSuccessPct: 85, AvgDNSMs: 5}, 60},
+		{"slow dns", Summary{AvgConnectMs: 100, DHCPSuccessPct: 100, AvgDNSMs: 150}, 70},
+		{"all bad", Summary{AvgConnectMs: 3000, DHCPSuccessPct: 80, AvgDNSMs: 200}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score := computeScore(tt.sc)
+			if score < tt.minScore {
+				t.Fatalf("score %d < min %d", score, tt.minScore)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #342

## What

WiFi Service Level Expectations per router: connection time, DHCP success rate, and DNS query latency. Inspired by Mist SLEs and Aruba Clarity - detects WiFi degradation before users notice.

## Changes

### Backend
- **New `wifisle` package**: Store with Insert/Summary/Series/Purge, WiFi SLE scoring algorithm
- **DB table `wifi_sles`**: per-router SLE reports (connect_count, avg_connect_ms, dhcp_requests, dhcp_acks, dns_queries, avg_dns_ms)
- **Scoring**: 0-100 based on connect time (<500ms=good, >2s=bad), DHCP success (99%+=good, <90%=bad), DNS latency (<20ms=good, >100ms=bad)
- **API**: `GET /api/wifi-sles?hours=24` (summary per router), `GET /api/wifi-sles/series?router=X&from=Y&to=Z` (time series)
- **Schema**: EnsureSchema in main.go bootstrap
- **5 tests**: insert+summary, empty summary, series query, purge, score computation

### Frontend
- **WiFiSLECard**: per-router SLE cards on Home page with HealthRing score + 3 KPI metrics
- Color-coded metrics: green/amber/red based on thresholds
- Only renders in live mode (not demo), gracefully hidden when no data

### Data flow (future)
Currently the table is populated via the API. Future work:
- Extend roamevents collector to parse dnsmasq DHCP logs
- Agent probe `hostapd get_clients` for connected_time per station
- Synthetic DNS latency probes
