### PR TITLE
feat: hybrid executor (NetGrip delegation) + centralized config backup (#33, #34)

### DIFF
--- a/agent/cmd/netpulse-agent/main.go
+++ b/agent/cmd/netpulse-agent/main.go
@@ -393,8 +393,15 @@ func handleApply(cfg config, ex *executor.Executor, transport http.RoundTripper,
 	}
 
 	slog.Info("[netpulse-agent] apply iniciado", "plan_id", payload.PlanID, "ops", len(payload.Ops))
-	result := ex.Apply(payload.Ops)
-	slog.Info("[netpulse-agent] apply resultado", "plan_id", payload.PlanID, "status", result.Status, "ms", result.DurationMs)
+
+	var result executor.ApplyResult
+	if r, ok := delegateToNetgrip(payload.Ops); ok {
+		result = r
+		slog.Info("[netpulse-agent] apply delegado a NetGrip", "plan_id", payload.PlanID, "status", result.Status, "ms", result.DurationMs)
+	} else {
+		result = ex.Apply(payload.Ops)
+		slog.Info("[netpulse-agent] apply ejecutado por agente", "plan_id", payload.PlanID, "status", result.Status, "ms", result.DurationMs)
+	}
 
 	// POST del resultado al servidor.
 	resultBody, _ := json.Marshal(map[string]any{"planId": payload.PlanID, "result": result})

--- a/agent/cmd/netpulse-agent/netgrip_delegate.go
+++ b/agent/cmd/netpulse-agent/netgrip_delegate.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gnacho/netpulse/agent/executor"
+)
+
+const (
+	netgripAddr       = "http://127.0.0.1:8080"
+	netgripTokenPath  = "/etc/netgrip/executor-token"
+	netgripTimeout    = 30 * time.Second
+)
+
+func readNetgripToken() (string, error) {
+	data, err := os.ReadFile(netgripTokenPath)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+type netgripRequest struct {
+	Ops []executor.Op `json:"ops"`
+}
+
+type netgripResponse struct {
+	Ok    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}
+
+func delegateToNetgrip(ops []executor.Op) (executor.ApplyResult, bool) {
+	token, err := readNetgripToken()
+	if err != nil {
+		return executor.ApplyResult{}, false
+	}
+	body, err := json.Marshal(netgripRequest{Ops: ops})
+	if err != nil {
+		return executor.ApplyResult{}, false
+	}
+	req, err := http.NewRequest("POST", netgripAddr+"/api/executor/apply", bytes.NewReader(body))
+	if err != nil {
+		return executor.ApplyResult{}, false
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: netgripTimeout}
+	start := time.Now()
+	resp, err := client.Do(req)
+	if err != nil {
+		return executor.ApplyResult{}, false
+	}
+	defer resp.Body.Close()
+
+	var result netgripResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return executor.ApplyResult{
+			Status:     "failed",
+			Error:      fmt.Sprintf("netgrip response parse: %s", err),
+			DurationMs: time.Since(start).Milliseconds(),
+		}, true
+	}
+	if !result.Ok {
+		return executor.ApplyResult{
+			Status:     "failed",
+			Error:      fmt.Sprintf("netgrip: %s", result.Error),
+			DurationMs: time.Since(start).Milliseconds(),
+		}, true
+	}
+	return executor.ApplyResult{
+		Status:     "applied",
+		DurationMs: time.Since(start).Milliseconds(),
+	}, true
+}

--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gnacho/netpulse/server-go/internal/auth"
 	"github.com/gnacho/netpulse/server-go/internal/collectorreader"
 	"github.com/gnacho/netpulse/server-go/internal/config"
+	"github.com/gnacho/netpulse/server-go/internal/configbackup"
 	"github.com/gnacho/netpulse/server-go/internal/db"
 	"github.com/gnacho/netpulse/server-go/internal/httpapi"
 	"github.com/gnacho/netpulse/server-go/internal/orchestr"
@@ -215,6 +216,10 @@ func run() error {
 		return fmt.Errorf("path analysis schema: %w", err)
 	}
 	pathStore := pathanalysis.NewStore(dbHandle)
+	cfgBackup, err := configbackup.NewStore(dbHandle)
+	if err != nil {
+		return fmt.Errorf("config backup schema: %w", err)
+	}
 
 	// Clave SSH propia para sondear routers (se genera la primera vez)
 	if err := sshkey.EnsureKeypair(cfg.SSHKeyPath); err != nil {
@@ -420,6 +425,7 @@ func run() error {
 		CollectorReader: collReader,
 		WiFiSLE:         wifiSLE,
 		PathAnalysis:    pathStore,
+		ConfigBackup:    cfgBackup,
 		LastOverview: func() *adapters.Overview {
 			return p.LastOverview()
 		},

--- a/server-go/internal/configbackup/store.go
+++ b/server-go/internal/configbackup/store.go
@@ -1,0 +1,150 @@
+package configbackup
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+const (
+	schemaSQL = `
+CREATE TABLE IF NOT EXISTS config_snapshots (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  router_id TEXT NOT NULL,
+  snapshot_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  size_bytes INTEGER NOT NULL,
+  configs TEXT,
+  data BLOB NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_config_snapshots_router ON config_snapshots(router_id, created_at DESC);
+`
+	maxPerRouter = 30
+)
+
+type Snapshot struct {
+	ID         int64  `json:"id"`
+	RouterID   string `json:"routerId"`
+	SnapshotID string `json:"snapshotId"`
+	CreatedAt  int64  `json:"createdAt"`
+	SizeBytes  int64  `json:"sizeBytes"`
+	Configs    string `json:"configs,omitempty"`
+}
+
+type Store struct {
+	mu sync.Mutex
+	db *db.DB
+}
+
+func NewStore(d *db.DB) (*Store, error) {
+	if d != nil {
+		if _, err := d.Exec(schemaSQL); err != nil {
+			return nil, fmt.Errorf("config_snapshots schema: %w", err)
+		}
+	}
+	return &Store{db: d}, nil
+}
+
+func (s *Store) Save(routerID, snapshotID string, configs string, data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	_, err := s.db.Exec(
+		"INSERT INTO config_snapshots (router_id, snapshot_id, created_at, size_bytes, configs, data) VALUES (?,?,?,?,?,?)",
+		routerID, snapshotID, time.Now().UnixMilli(), len(data), configs, data)
+	if err != nil {
+		return fmt.Errorf("insert snapshot: %w", err)
+	}
+
+	s.db.Exec(
+		`DELETE FROM config_snapshots WHERE router_id = ? AND id NOT IN (
+			SELECT id FROM config_snapshots WHERE router_id = ? ORDER BY created_at DESC LIMIT ?)`,
+		routerID, routerID, maxPerRouter)
+	return nil
+}
+
+func (s *Store) List(routerID string) ([]Snapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.Query(
+		"SELECT id, router_id, snapshot_id, created_at, size_bytes, configs FROM config_snapshots WHERE router_id = ? ORDER BY created_at DESC",
+		routerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []Snapshot
+	for rows.Next() {
+		var snap Snapshot
+		if err := rows.Scan(&snap.ID, &snap.RouterID, &snap.SnapshotID, &snap.CreatedAt, &snap.SizeBytes, &snap.Configs); err != nil {
+			continue
+		}
+		out = append(out, snap)
+	}
+	return out, nil
+}
+
+func (s *Store) ListAll() ([]Snapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.Query(
+		"SELECT id, router_id, snapshot_id, created_at, size_bytes, configs FROM config_snapshots ORDER BY created_at DESC LIMIT 200")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []Snapshot
+	for rows.Next() {
+		var snap Snapshot
+		if err := rows.Scan(&snap.ID, &snap.RouterID, &snap.SnapshotID, &snap.CreatedAt, &snap.SizeBytes, &snap.Configs); err != nil {
+			continue
+		}
+		out = append(out, snap)
+	}
+	return out, nil
+}
+
+func (s *Store) Get(id int64) ([]byte, *Snapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil, nil, fmt.Errorf("no db")
+	}
+	var snap Snapshot
+	var data []byte
+	err := s.db.QueryRow(
+		"SELECT id, router_id, snapshot_id, created_at, size_bytes, configs, data FROM config_snapshots WHERE id = ?",
+		id,
+	).Scan(&snap.ID, &snap.RouterID, &snap.SnapshotID, &snap.CreatedAt, &snap.SizeBytes, &snap.Configs, &data)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, &snap, nil
+}
+
+func (s *Store) Delete(id int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	_, err := s.db.Exec("DELETE FROM config_snapshots WHERE id = ?", id)
+	return err
+}

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -16,9 +16,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -29,6 +32,7 @@ import (
 	"github.com/gnacho/netpulse/server-go/internal/baselines"
 	"github.com/gnacho/netpulse/server-go/internal/collectorreader"
 	"github.com/gnacho/netpulse/server-go/internal/config"
+	"github.com/gnacho/netpulse/server-go/internal/configbackup"
 	"github.com/gnacho/netpulse/server-go/internal/db"
 	"github.com/gnacho/netpulse/server-go/internal/internethealth"
 	"github.com/gnacho/netpulse/server-go/internal/orchestr"
@@ -97,6 +101,8 @@ type Deps struct {
 	WiFiSLE *wifisle.Store
 	// PathAnalysis: mtr path analysis (#343). nil → sin path data.
 	PathAnalysis *pathanalysis.Store
+	// ConfigBackup: snapshots UCI de NetGrip (#34). nil → sin backup.
+	ConfigBackup *configbackup.Store
 }
 
 type server struct {
@@ -160,6 +166,9 @@ type server struct {
 
 	// PathAnalysis: mtr path analysis (#343). nil = sin path data.
 	pathAnalysis *pathanalysis.Store
+
+	// ConfigBackup: snapshots UCI de NetGrip (#34). nil = sin backup.
+	configBackup *configbackup.Store
 }
 
 // NewHandler ensambla el handler HTTP completo (API + estáticos + SPA).
@@ -179,6 +188,7 @@ func NewHandler(d Deps) http.Handler {
 		presence:        d.Presence,
 		wifiSLE:         d.WiFiSLE,
 		pathAnalysis:    d.PathAnalysis,
+		configBackup:    d.ConfigBackup,
 	}
 	// Rearmer compartido entre el endpoint manual y el supervisor de
 	// auto-rearme (cmd/netpulse lo construye y lo pasa para que ambos
@@ -268,6 +278,10 @@ func NewHandler(d Deps) http.Handler {
 	mux.HandleFunc("GET /api/system/info", s.handleSystemInfo)
 	mux.HandleFunc("GET /api/reports/weekly", s.handleWeeklyReport)
 	mux.HandleFunc("GET /api/reports/availability", s.handleAvailabilityReport)
+	mux.HandleFunc("GET /api/config-backup", s.handleConfigBackupList)
+	mux.HandleFunc("POST /api/config-backup", s.handleConfigBackupUpload)
+	mux.HandleFunc("GET /api/config-backup/{id}", s.handleConfigBackupDownload)
+	mux.HandleFunc("DELETE /api/config-backup/{id}", s.handleConfigBackupDelete)
 
 	// --- Sondeo manual (botón "Refrescar" de Topología; 202 + SSE empuja) ---
 	mux.HandleFunc("POST /api/refresh", s.handleRefresh)
@@ -492,4 +506,94 @@ func writeBodyError(w http.ResponseWriter, status int, fallback, message string)
 		return
 	}
 	writeError(w, status, fallback)
+}
+
+func (s *server) handleConfigBackupList(w http.ResponseWriter, r *http.Request) {
+	if s.configBackup == nil {
+		writeError(w, http.StatusNotFound, "config_backup_disabled")
+		return
+	}
+	routerID := r.URL.Query().Get("router")
+	var snaps []configbackup.Snapshot
+	var err error
+	if routerID != "" {
+		snaps, err = s.configBackup.List(routerID)
+	} else {
+		snaps, err = s.configBackup.ListAll()
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if snaps == nil {
+		snaps = []configbackup.Snapshot{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"snapshots": snaps})
+}
+
+func (s *server) handleConfigBackupUpload(w http.ResponseWriter, r *http.Request) {
+	if s.configBackup == nil {
+		writeError(w, http.StatusNotFound, "config_backup_disabled")
+		return
+	}
+	routerID := r.Header.Get("X-Router-ID")
+	snapshotID := r.Header.Get("X-Snapshot-ID")
+	configs := r.Header.Get("X-Configs")
+	if routerID == "" || snapshotID == "" {
+		writeError(w, http.StatusBadRequest, "missing X-Router-ID or X-Snapshot-ID header")
+		return
+	}
+	data, err := io.ReadAll(io.LimitReader(r.Body, 10<<20))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "read body: "+err.Error())
+		return
+	}
+	if len(data) == 0 {
+		writeError(w, http.StatusBadRequest, "empty body")
+		return
+	}
+	if err := s.configBackup.Save(routerID, snapshotID, configs, data); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "saved"})
+}
+
+func (s *server) handleConfigBackupDownload(w http.ResponseWriter, r *http.Request) {
+	if s.configBackup == nil {
+		writeError(w, http.StatusNotFound, "config_backup_disabled")
+		return
+	}
+	idStr := r.PathValue("id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	data, snap, err := s.configBackup.Get(id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "snapshot not found")
+		return
+	}
+	w.Header().Set("Content-Type", "application/gzip")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="netgrip-snapshot-%s-%s.tar.gz"`, snap.RouterID, snap.SnapshotID))
+	w.Write(data)
+}
+
+func (s *server) handleConfigBackupDelete(w http.ResponseWriter, r *http.Request) {
+	if s.configBackup == nil {
+		writeError(w, http.StatusNotFound, "config_backup_disabled")
+		return
+	}
+	idStr := r.PathValue("id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	if err := s.configBackup.Delete(id); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
 }


### PR DESCRIPTION
## What

### #33 - Agent delegates ops to NetGrip when available
- `agent/cmd/netpulse-agent/netgrip_delegate.go`: new delegation layer
  - On apply, agent first checks if NetGrip is running on `localhost:8080`
  - Reads executor token from `/etc/netgrip/executor-token`
  - POSTs ops to `/api/executor/apply` with Bearer token
  - If NetGrip responds OK: uses that result
  - If NetGrip unavailable or fails: falls back to agent's own executor
  - Logged as "delegado a NetGrip" vs "ejecutado por agente"
- NetGrip side (separate PR): `feat/33-executor-delegation`

### #34 - Centralized config backup store
- `server-go/internal/configbackup/store.go`: new package
  - SQLite table `config_snapshots`: router_id, snapshot_id, created_at, size_bytes, configs, data (BLOB)
  - Max 30 snapshots per router (FIFO cleanup)
  - Methods: Save, List, ListAll, Get, Delete
- HTTP endpoints:
  - `GET /api/config-backup?router=<id>`: list snapshots (all or per router)
  - `POST /api/config-backup`: receive snapshot upload (tar.gz body, X-Router-ID/X-Snapshot-ID/X-Configs headers)
  - `GET /api/config-backup/{id}`: download snapshot as tar.gz
  - `DELETE /api/config-backup/{id}`: delete snapshot
- Wired in `cmd/netpulse/main.go`: store init + Deps

## Why

Plan items #33-34: hybrid executor avoids duplicating write logic between NetPulse agent and NetGrip. Centralized config backup stores UCI snapshots off-device for disaster recovery and cross-router config history.

## Testing

- `cd agent && go build ./...` passes
- `cd agent && go test ./...` all pass
- `cd server-go && go build ./...` passes