### PR TITLE
Public runtime package so the agent can run embedded

### DIFF
--- a/agent/cmd/netpulse-agent/main.go
+++ b/agent/cmd/netpulse-agent/main.go
@@ -1,11 +1,9 @@
-// netpulse-agent — agente nativo OpenWrt (SPEC-AGENTE-PILOTO §2): sondea
+// netpulse-agent - agente nativo OpenWrt (SPEC-AGENTE-PILOTO §2): sondea
 // LOCALMENTE el equipo (los mismos comandos que el servidor lanza por SSH,
 // package probe compartido) y empuja el resultado a POST /api/ingest/agent
 // con Bearer + backoff + buffer RAM acotado. Stateless: NADA en flash; logs
-// a stderr (procd los manda a syslog).
-//
-// Fase 7.1: eventos ubus en tiempo real (hostapd assoc/disassoc) → push
-// inmediato de wireless + DHCP, sin esperar al ciclo de sondeo (30s).
+// a stderr (procd los manda a syslog). Todo el bucle vive en
+// agent/runtime; este binario es un wrapper fino (flags + config + señales).
 //
 // Config (env o /etc/netpulse-agent.env; el env gana):
 //
@@ -14,7 +12,7 @@
 //	NETPULSE_SLUG          slug del equipo (agent.token.<slug> en el servidor)
 //	NETPULSE_SERVER_FP     SHA-256 del SPKI del servidor en hex (obligatorio si la URL es https://)
 //	NETPULSE_PAIRING_TOKEN token de pairing (modo bootstrap: contacta /api/agents/pair para
-//	                       obtener el token real, lo escribe al env file y sale — procd reinicia)
+//	                       obtener el token real, lo escribe al env file y sale - procd reinicia)
 //	NETPULSE_INTERVAL      intervalo de push (default 30s; "30", "15s", "1m")
 //	NETPULSE_ENV_FILE      fichero env alternativo (default /etc/netpulse-agent.env)
 //	NETPULSE_LOG_LEVEL     nivel de log: "info" (default) o "debug"
@@ -24,128 +22,20 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"log/slog"
-	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"strings"
-	"sync"
 	"syscall"
-	"time"
 
-	"github.com/gnacho/netpulse/agent/executor"
-	"github.com/gnacho/netpulse/agent/internal/heartbeat"
-	"github.com/gnacho/netpulse/agent/internal/iwevents"
-	"github.com/gnacho/netpulse/agent/internal/push"
-	"github.com/gnacho/netpulse/agent/internal/sseclient"
-	"github.com/gnacho/netpulse/agent/internal/tlspin"
-	"github.com/gnacho/netpulse/agent/probe"
+	"github.com/gnacho/netpulse/agent/runtime"
 )
 
 // Version del agente (la reporta cada push; se puede fijar con
 // -ldflags "-X main.Version=x.y.z").
 var Version = "0.1.0"
-
-const (
-	// pollInterval: ciclo completo de sistema + wireless + DHCP + FDB (30s).
-	pollInterval = 30 * time.Second
-	// ubusMinGap: tiempo mínimo entre pushes wireless consecutivos disparados
-	// por eventos ubus (evita martillear al servidor con ráfagas assoc/disassoc
-	// — p. ej. un cliente que entra y sale repetidamente).
-	ubusMinGap = 3 * time.Second
-)
-
-type config struct {
-	server, token, slug string
-	serverFP            string // SPKI hash hex (obligatorio si la URL es https://)
-	pairingToken        string // si está puesto: modo bootstrap (pairing)
-	interval            time.Duration
-	wanTarget, gwTarget string
-	heartbeatFile       string
-	envFile             string // ruta del env file (para escribir el token tras pairing)
-}
-
-// loadEnvFile lee KEY=VALUE de un fichero env (líneas # = comentario).
-func loadEnvFile(path string) map[string]string {
-	out := map[string]string{}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return out
-	}
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		k, v, ok := strings.Cut(line, "=")
-		if !ok {
-			continue
-		}
-		out[strings.TrimSpace(k)] = strings.Trim(strings.TrimSpace(v), `"'`)
-	}
-	return out
-}
-
-	// loadConfig: env del proceso > fichero env; fail-fast si falta lo obligatorio.
-func loadConfig() (config, error) {
-	file := os.Getenv("NETPULSE_ENV_FILE")
-	if file == "" {
-		file = "/etc/netpulse-agent.env"
-	}
-	fromFile := loadEnvFile(file)
-	get := func(key string) string {
-		if v := os.Getenv(key); v != "" {
-			return v
-		}
-		return fromFile[key]
-	}
-	cfg := config{
-		server:        strings.TrimRight(get("NETPULSE_SERVER"), "/"),
-		token:         get("NETPULSE_TOKEN"),
-		slug:          get("NETPULSE_SLUG"),
-		serverFP:      tlspin.Normalize(get("NETPULSE_SERVER_FP")),
-		pairingToken:  get("NETPULSE_PAIRING_TOKEN"),
-		interval:      pollInterval,
-		wanTarget:     get("NETPULSE_WAN_TARGET"),
-		gwTarget:      get("NETPULSE_GW_TARGET"),
-		heartbeatFile: get("NETPULSE_HEARTBEAT_FILE"),
-		envFile:       file,
-	}
-	if v := get("NETPULSE_INTERVAL"); v != "" {
-		if sec, err := strconv.Atoi(v); err == nil && sec > 0 {
-			cfg.interval = time.Duration(sec) * time.Second
-		} else if d, err := time.ParseDuration(v); err == nil && d > 0 {
-			cfg.interval = d
-		} else {
-			slog.Warn("[netpulse-agent] NETPULSE_INTERVAL inválido, usando 30s", "value", v)
-		}
-	}
-	// Validación: SERVER y SLUG siempre obligatorios. TOKEN obligatorio salvo
-	// en modo pairing (donde PAIRING_TOKEN sustituye a TOKEN).
-	for _, kv := range [][2]string{
-		{"NETPULSE_SERVER", cfg.server},
-		{"NETPULSE_SLUG", cfg.slug},
-	} {
-		if kv[1] == "" {
-			return config{}, &configError{kv[0]}
-		}
-	}
-	if cfg.token == "" && cfg.pairingToken == "" {
-		return config{}, &configError{"NETPULSE_TOKEN (o NETPULSE_PAIRING_TOKEN para bootstrap)"}
-	}
-	return cfg, nil
-}
-
-type configError struct{ key string }
-
-func (e *configError) Error() string {
-	return "falta " + e.key + " (env o /etc/netpulse-agent.env)"
-}
 
 func main() {
 	// Niveles de log (P7): Info por defecto, Debug con NETPULSE_LOG_LEVEL=debug.
@@ -162,260 +52,21 @@ func main() {
 		os.Exit(0)
 	}
 
-	if err := run(); err != nil {
+	opts, err := runtime.LoadConfigFromEnv("")
+	if err != nil {
 		slog.Error("[netpulse-agent] error fatal", "err", err)
 		os.Exit(1)
 	}
-}
-
-// pushOnce envía el payload y toca el heartbeat; si falla, lo loguea.
-func pushOnce(ctx context.Context, client *push.Client, payload *probe.Payload, hbFile string) {
-	if err := client.Push(ctx, payload); err != nil {
-		slog.Warn("[netpulse-agent] push falló", "err", err, "buffered", client.Buffered(), "dropped", client.Dropped())
-		return
-	}
-	if err := heartbeat.Touch(hbFile, time.Now()); err != nil {
-		slog.Warn("[netpulse-agent] heartbeat error", "err", err)
-	}
-}
-
-func run() error {
-	cfg, err := loadConfig()
-	if err != nil {
-		return err
-	}
-
-	// Fase 9 R3: modo pairing (bootstrap). Si hay pairing_token en vez de
-	// token, contactar al servidor una vez, obtener el token real, escribirlo
-	// al env file y salir. procd reinicia el agente, que arranca en modo normal.
-	if cfg.pairingToken != "" {
-		return pairWithServer(cfg)
-	}
-
-	transport, err := tlspin.BuildTransport(cfg.server, cfg.serverFP)
-	if err != nil {
-		return err
-	}
-	client := push.New(cfg.server, cfg.token, &http.Client{Timeout: 10 * time.Second, Transport: transport})
-	client.SetLogger(func(format string, args ...any) { slog.Debug("[netpulse-agent] "+fmt.Sprintf(format, args...)) })
-
-	prober := probe.NewProber(probe.ShellRunner{}, probe.Options{
-		WanPingTarget: cfg.wanTarget,
-		GwPingTarget:  cfg.gwTarget,
-	})
+	opts.Version = Version
+	// La delegación a NetGrip (si hay token local) se decide aquí; el bucle
+	// cae al executor local cuando el delegado no está disponible.
+	opts.ApplyDelegate = delegateToNetgrip
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
-	slog.Info("[netpulse-agent] agente iniciado", "version", Version, "slug", cfg.slug, "server", cfg.server, "interval", cfg.interval)
-
-	hbFile := cfg.heartbeatFile
-	if hbFile == "" {
-		hbFile = heartbeat.DefaultFile
+	if err := runtime.Run(ctx, opts); err != nil {
+		slog.Error("[netpulse-agent] error fatal", "err", err)
+		os.Exit(1)
 	}
-
-	// Fase 7.1: eventos nl80211 en tiempo real (new/del station).
-	if iwevents.Available() {
-		slog.Info("[netpulse-agent] iw detectado: suscribiendo a eventos nl80211")
-		var lastEventPush time.Time
-		var evMu sync.Mutex
-		go func() {
-			if err := iwevents.Listen(ctx, func(ev iwevents.Event) {
-				evMu.Lock()
-				since := time.Since(lastEventPush)
-				if since < ubusMinGap {
-					evMu.Unlock()
-					return
-				}
-				lastEventPush = time.Now()
-				evMu.Unlock()
-				action := "assoc"
-				if !ev.Connected {
-					action = "disassoc"
-				}
-				slog.Info("[netpulse-agent] iw evento", "action", action, "mac", ev.MAC, "iface", ev.Iface)
-				payload := prober.BuildWireless(ctx, cfg.slug, Version)
-				pushOnce(ctx, client, payload, hbFile)
-			}); err != nil {
-				slog.Warn("[netpulse-agent] iw event terminó", "err", err)
-			}
-		}()
-	}
-
-	// Fase 10: ejecutor de Ops (allowlist UCI/servicio con snapshot+rollback).
-	ex := executor.New(cfg.gwTarget, cfg.wanTarget)
-
-	// Fase 7.3: SSE bidireccional — el servidor envía comandos al agente.
-	// El SSE reutiliza el mismo transporte (mismo pinning SPKI que el push).
-	refreshCh := make(chan struct{}, 1)
-	go func() {
-		sse := sseclient.New(cfg.server, cfg.slug, cfg.token,
-			&http.Client{Timeout: 0, Transport: transport},
-			func(ev sseclient.Event) {
-			if ev.Name == "refresh" {
-				select {
-				case refreshCh <- struct{}{}:
-				default:
-				}
-			}
-			if ev.Name == "apply" && ev.Data != "" {
-				go handleApply(cfg, ex, transport, ev.Data)
-			}
-			if ev.Name == "upgrade" {
-				go handleUpgrade(cfg, transport, ev.Data)
-			}
-			slog.Debug("[netpulse-agent] SSE evento", "event", ev.Name)
-		})
-		sse.SetLogger(func(format string, args ...any) { slog.Debug("[netpulse-agent] "+fmt.Sprintf(format, args...)) })
-		sse.Run(ctx)
-	}()
-
-	// Ciclo principal: sondeo completo cada 30s o cuando el servidor lo pide.
-	for {
-		payload := prober.Build(ctx, cfg.slug, Version)
-		pushOnce(ctx, client, payload, hbFile)
-		select {
-		case <-ctx.Done():
-			slog.Info("[netpulse-agent] saliendo")
-			return nil
-		case <-refreshCh:
-			// refresh inmediato pedido por el servidor
-		case <-time.After(client.Delay(cfg.interval)):
-		}
-	}
-}
-
-// pairWithServer contacta POST /api/agents/pair con el pairing token, recibe
-// el token real del agente, lo escribe al env file y sale (procd reinicia).
-// Usa el server_fp para validar TLS (el admin lo proporciona junto con el
-// pairing token).
-func pairWithServer(cfg config) error {
-	transport, err := tlspin.BuildTransport(cfg.server, cfg.serverFP)
-	if err != nil {
-		return err
-	}
-
-	body := fmt.Sprintf(`{"pairing_token":%q,"slug":%q}`, cfg.pairingToken, cfg.slug)
-	req, err := http.NewRequest("POST", cfg.server+"/api/agents/pair", strings.NewReader(body))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	hc := &http.Client{Transport: transport, Timeout: 15 * time.Second}
-	slog.Info("[netpulse-agent] pairing", "server", cfg.server, "slug", cfg.slug)
-	res, err := hc.Do(req)
-	if err != nil {
-		return fmt.Errorf("pairing: %w", err)
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != 201 {
-		respBody, _ := io.ReadAll(io.LimitReader(res.Body, 512))
-		return fmt.Errorf("pairing fallido (HTTP %d): %s", res.StatusCode, respBody)
-	}
-
-	var pr struct {
-		Slug     string `json:"slug"`
-		Token    string `json:"token"`
-		ServerFP string `json:"server_fp"`
-	}
-	if err := json.NewDecoder(res.Body).Decode(&pr); err != nil {
-		return fmt.Errorf("parsear respuesta pairing: %w", err)
-	}
-	if pr.Token == "" {
-		return fmt.Errorf("pairing: token vacío en respuesta")
-	}
-
-	// Escribir el token real al env file (reemplaza PAIRING_TOKEN por TOKEN).
-	if err := writePairedToken(cfg.envFile, pr.Token); err != nil {
-		return fmt.Errorf("escribir token al env file: %w", err)
-	}
-
-	slog.Info("[netpulse-agent] pairing OK", "slug", pr.Slug, "env_file", cfg.envFile)
-	// Salir limpiamente: procd reinicia el agente, que ahora lee NETPULSE_TOKEN
-	// del env file y arranca en modo normal.
-	return nil
-}
-
-// writePairedToken reescribe el env file: quita NETPULSE_PAIRING_TOKEN y
-// añade/actualiza NETPULSE_TOKEN. Conserva el resto de líneas.
-func writePairedToken(path, token string) error {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		// Si no existe, crear uno nuevo con el token.
-		return os.WriteFile(path, []byte("NETPULSE_TOKEN="+token+"\n"), 0o600)
-	}
-	var out []string
-	haveToken := false
-	for _, line := range strings.Split(string(data), "\n") {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
-			out = append(out, line)
-			continue
-		}
-		k, _, ok := strings.Cut(trimmed, "=")
-		if !ok {
-			out = append(out, line)
-			continue
-		}
-		key := strings.TrimSpace(k)
-		if key == "NETPULSE_PAIRING_TOKEN" {
-			continue // eliminar
-		}
-		if key == "NETPULSE_TOKEN" {
-			out = append(out, "NETPULSE_TOKEN="+token)
-			haveToken = true
-			continue
-		}
-		out = append(out, line)
-	}
-	if !haveToken {
-		out = append(out, "NETPULSE_TOKEN="+token)
-	}
-	return os.WriteFile(path, []byte(strings.Join(out, "\n")+"\n"), 0o600)
-}
-
-// handleApply procesa un comando apply del servidor (Fase 10): parsea las
-// Ops, las ejecuta con snapshot+healthcheck+rollback, y POSTea el resultado.
-func handleApply(cfg config, ex *executor.Executor, transport http.RoundTripper, data string) {
-	var payload struct {
-		PlanID string        `json:"plan_id"`
-		Ops    []executor.Op `json:"ops"`
-	}
-	if err := json.Unmarshal([]byte(data), &payload); err != nil {
-		slog.Warn("[netpulse-agent] apply: parse error", "err", err)
-		return
-	}
-	if len(payload.Ops) == 0 {
-		slog.Warn("[netpulse-agent] apply: sin ops", "plan_id", payload.PlanID)
-		return
-	}
-
-	slog.Info("[netpulse-agent] apply iniciado", "plan_id", payload.PlanID, "ops", len(payload.Ops))
-
-	var result executor.ApplyResult
-	if r, ok := delegateToNetgrip(payload.Ops); ok {
-		result = r
-		slog.Info("[netpulse-agent] apply delegado a NetGrip", "plan_id", payload.PlanID, "status", result.Status, "ms", result.DurationMs)
-	} else {
-		result = ex.Apply(payload.Ops)
-		slog.Info("[netpulse-agent] apply ejecutado por agente", "plan_id", payload.PlanID, "status", result.Status, "ms", result.DurationMs)
-	}
-
-	// POST del resultado al servidor.
-	resultBody, _ := json.Marshal(map[string]any{"planId": payload.PlanID, "result": result})
-	req, err := http.NewRequest("POST", cfg.server+"/api/agents/"+cfg.slug+"/apply-result", strings.NewReader(string(resultBody)))
-	if err != nil {
-		return
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+cfg.token)
-	hc := &http.Client{Transport: transport, Timeout: 10 * time.Second}
-	resp, err := hc.Do(req)
-	if err != nil {
-		slog.Warn("[netpulse-agent] apply: result POST falló", "err", err)
-		return
-	}
-	resp.Body.Close()
 }

--- a/agent/runtime/config.go
+++ b/agent/runtime/config.go
@@ -1,0 +1,106 @@
+// config.go: carga de config del agente desde el entorno del proceso y el
+// env file (KEY=VALUE), extraída de cmd/netpulse-agent para que los
+// embedders reutilicen el mismo formato y validación.
+package runtime
+
+import (
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gnacho/netpulse/agent/internal/tlspin"
+)
+
+// DefaultEnvFile: env file por defecto del agente standalone.
+const DefaultEnvFile = "/etc/netpulse-agent.env"
+
+// ConfigError: falta una key obligatoria (env o env file).
+type ConfigError struct{ Key string }
+
+func (e *ConfigError) Error() string {
+	return "falta " + e.Key + " (env o " + DefaultEnvFile + ")"
+}
+
+// LoadConfigFromEnv lee la config del entorno del proceso y del env file
+// (el env del proceso gana). envFile vacío respeta NETPULSE_ENV_FILE y, en
+// su defecto, DefaultEnvFile. Fail-fast si falta lo obligatorio.
+func LoadConfigFromEnv(envFile string) (Options, error) {
+	if envFile == "" {
+		envFile = os.Getenv("NETPULSE_ENV_FILE")
+		if envFile == "" {
+			envFile = DefaultEnvFile
+		}
+	}
+	fromFile := loadEnvFile(envFile)
+	get := func(key string) string {
+		if v := os.Getenv(key); v != "" {
+			return v
+		}
+		return fromFile[key]
+	}
+	opts := Options{
+		Server:        strings.TrimRight(get("NETPULSE_SERVER"), "/"),
+		Token:         get("NETPULSE_TOKEN"),
+		Slug:          get("NETPULSE_SLUG"),
+		ServerFP:      tlspin.Normalize(get("NETPULSE_SERVER_FP")),
+		PairingToken:  get("NETPULSE_PAIRING_TOKEN"),
+		Interval:      DefaultInterval,
+		WanTarget:     get("NETPULSE_WAN_TARGET"),
+		GwTarget:      get("NETPULSE_GW_TARGET"),
+		HeartbeatFile: get("NETPULSE_HEARTBEAT_FILE"),
+		EnvFile:       envFile,
+	}
+	if v := get("NETPULSE_INTERVAL"); v != "" {
+		if sec, err := strconv.Atoi(v); err == nil && sec > 0 {
+			opts.Interval = time.Duration(sec) * time.Second
+		} else if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			opts.Interval = d
+		} else {
+			slog.Warn("[netpulse-agent] NETPULSE_INTERVAL inválido, usando 30s", "value", v)
+		}
+	}
+	if err := opts.Validate(); err != nil {
+		return Options{}, err
+	}
+	return opts, nil
+}
+
+// Validate comprueba lo obligatorio: SERVER y SLUG siempre; TOKEN salvo en
+// modo pairing (donde PAIRING_TOKEN lo sustituye).
+func (o Options) Validate() error {
+	for _, kv := range [][2]string{
+		{"NETPULSE_SERVER", o.Server},
+		{"NETPULSE_SLUG", o.Slug},
+	} {
+		if strings.TrimSpace(kv[1]) == "" {
+			return &ConfigError{kv[0]}
+		}
+	}
+	if o.Token == "" && o.PairingToken == "" {
+		return &ConfigError{"NETPULSE_TOKEN (o NETPULSE_PAIRING_TOKEN para bootstrap)"}
+	}
+	return nil
+}
+
+// loadEnvFile lee KEY=VALUE de un fichero env (líneas # = comentario).
+func loadEnvFile(path string) map[string]string {
+	out := map[string]string{}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return out
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		out[strings.TrimSpace(k)] = strings.Trim(strings.TrimSpace(v), `"'`)
+	}
+	return out
+}

--- a/agent/runtime/helpers.go
+++ b/agent/runtime/helpers.go
@@ -1,0 +1,41 @@
+// helpers.go: utilidades HTTP compartidas por apply y upgrade.
+package runtime
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/gnacho/netpulse/agent/internal/tlspin"
+)
+
+func buildTransport(opts Options) (*http.Transport, error) {
+	return tlspin.BuildTransport(opts.Server, opts.ServerFP)
+}
+
+func jsonUnmarshal(data string, v any) error {
+	return json.Unmarshal([]byte(data), v)
+}
+
+// postJSON envía un POST JSON autenticado (Bearer) al servidor; los
+// fallos se loguean y se descartan (fire-and-forget).
+func postJSON(opts Options, transport http.RoundTripper, path string, body any) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequest("POST", opts.Server+path, bytes.NewReader(payload))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+opts.Token)
+	hc := &http.Client{Transport: transport, Timeout: 10 * time.Second}
+	resp, err := hc.Do(req)
+	if err != nil {
+		opts.logger().Warn("[netpulse-agent] POST falló", "path", path, "err", err)
+		return
+	}
+	resp.Body.Close()
+}

--- a/agent/runtime/pairing.go
+++ b/agent/runtime/pairing.go
@@ -1,0 +1,107 @@
+// pairing.go: modo bootstrap (Fase 9 R3). Con pairing_token en vez de
+// token, el agente contacta al servidor una vez, obtiene el token real, lo
+// escribe al env file y sale. procd (o el embedder) reinicia, y el agente
+// arranca en modo normal.
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// pairWithServer contacta POST /api/agents/pair con el pairing token,
+// recibe el token real del agente y lo escribe al env file. Usa el
+// server_fp para validar TLS (el admin lo proporciona junto con el
+// pairing token).
+func pairWithServer(opts Options) error {
+	transport, err := buildTransport(opts)
+	if err != nil {
+		return err
+	}
+
+	body := fmt.Sprintf(`{"pairing_token":%q,"slug":%q}`, opts.PairingToken, opts.Slug)
+	req, err := http.NewRequest("POST", opts.Server+"/api/agents/pair", strings.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	hc := &http.Client{Transport: transport, Timeout: 15 * time.Second}
+	log := opts.logger()
+	log.Info("[netpulse-agent] pairing", "server", opts.Server, "slug", opts.Slug)
+	res, err := hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("pairing: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(io.LimitReader(res.Body, 512))
+		return fmt.Errorf("pairing fallido (HTTP %d): %s", res.StatusCode, respBody)
+	}
+
+	var pr struct {
+		Slug     string `json:"slug"`
+		Token    string `json:"token"`
+		ServerFP string `json:"server_fp"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&pr); err != nil {
+		return fmt.Errorf("parsear respuesta pairing: %w", err)
+	}
+	if pr.Token == "" {
+		return fmt.Errorf("pairing: token vacío en respuesta")
+	}
+
+	// Escribir el token real al env file (reemplaza PAIRING_TOKEN por TOKEN).
+	if err := writePairedToken(opts.EnvFile, pr.Token); err != nil {
+		return fmt.Errorf("escribir token al env file: %w", err)
+	}
+
+	log.Info("[netpulse-agent] pairing OK", "slug", pr.Slug, "env_file", opts.EnvFile)
+	// Salir limpiamente: quien arranque el agente lo relanza y este lee
+	// NETPULSE_TOKEN del env file en modo normal.
+	return nil
+}
+
+// writePairedToken reescribe el env file: quita NETPULSE_PAIRING_TOKEN y
+// añade/actualiza NETPULSE_TOKEN. Conserva el resto de líneas.
+func writePairedToken(path, token string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// Si no existe, crear uno nuevo con el token.
+		return os.WriteFile(path, []byte("NETPULSE_TOKEN="+token+"\n"), 0o600)
+	}
+	var out []string
+	haveToken := false
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			out = append(out, line)
+			continue
+		}
+		k, _, ok := strings.Cut(trimmed, "=")
+		if !ok {
+			out = append(out, line)
+			continue
+		}
+		key := strings.TrimSpace(k)
+		if key == "NETPULSE_PAIRING_TOKEN" {
+			continue // eliminar
+		}
+		if key == "NETPULSE_TOKEN" {
+			out = append(out, "NETPULSE_TOKEN="+token)
+			haveToken = true
+			continue
+		}
+		out = append(out, line)
+	}
+	if !haveToken {
+		out = append(out, "NETPULSE_TOKEN="+token)
+	}
+	return os.WriteFile(path, []byte(strings.Join(out, "\n")+"\n"), 0o600)
+}

--- a/agent/runtime/runtime.go
+++ b/agent/runtime/runtime.go
@@ -1,0 +1,298 @@
+// Package runtime expone el bucle del agente NetPulse como paquete público
+// para que otras aplicaciones (p. ej. NetGrip) lo embeban sin replicar
+// lógica. Run hace todo lo que hacía cmd/netpulse-agent: sondeo local
+// (probe), push con Bearer + backoff + buffer RAM acotado, eventos nl80211
+// en tiempo real, SSE bidireccional (refresh/apply/upgrade) y modo pairing
+// bootstrap. El logger y el estado del agente son observables via Options.
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gnacho/netpulse/agent/executor"
+	"github.com/gnacho/netpulse/agent/internal/heartbeat"
+	"github.com/gnacho/netpulse/agent/internal/iwevents"
+	"github.com/gnacho/netpulse/agent/internal/push"
+	"github.com/gnacho/netpulse/agent/internal/sseclient"
+	"github.com/gnacho/netpulse/agent/internal/tlspin"
+	"github.com/gnacho/netpulse/agent/probe"
+)
+
+const (
+	// DefaultInterval: ciclo completo de sistema + wireless + DHCP + FDB (30s).
+	DefaultInterval = 30 * time.Second
+	// ubusMinGap: tiempo mínimo entre pushes wireless consecutivos disparados
+	// por eventos nl80211 (evita martillear al servidor con ráfagas).
+	ubusMinGap = 3 * time.Second
+)
+
+// Options configura Run. Server/Slug y Token (o PairingToken) son
+// obligatorios; Validate los comprueba antes de arrancar.
+type Options struct {
+	Server        string // URL del servidor ("https://..." o "http://...:3000")
+	Token         string // token del equipo (64 hex)
+	Slug          string // slug del equipo (agent.token.<slug> en el servidor)
+	ServerFP      string // SHA-256 del SPKI del servidor en hex (https obligatorio)
+	PairingToken  string // modo bootstrap: pairing una vez y salir
+	Interval      time.Duration
+	WanTarget     string
+	GwTarget      string
+	HeartbeatFile string
+	EnvFile       string // ruta del env file (para escribir el token tras pairing)
+	Version       string // la reporta cada push
+
+	// OnStatus recibe el estado en cada cambio (arranque, cada push, parada).
+	// Nunca rompe el bucle: un panic dentro del callback se recupera.
+	OnStatus func(Status)
+
+	// Logger opcional; nil usa slog.Default().
+	Logger *slog.Logger
+
+	// ApplyDelegate permite delegar la ejecución de Ops a otro proceso
+	// (NetGrip via HTTP local). nil o (ok=false) ejecuta el executor local.
+	ApplyDelegate func(ops []executor.Op) (executor.ApplyResult, bool)
+
+	// OnUpgrade sustituye el self-upgrade integrado (evento SSE "upgrade").
+	// nil usa el comportamiento estándar: descargar binario + swap + restart.
+	OnUpgrade func(data string)
+}
+
+// Status es una foto del agente para que el embedder pinte estado.
+type Status struct {
+	Running   bool
+	PushOk    bool
+	LastPush  time.Time
+	LastError string
+	Slug      string
+	Server    string
+}
+
+// Run ejecuta el bucle del agente hasta que ctx se cancele. Si
+// Options.PairingToken está puesto, hace el pairing bootstrap y devuelve.
+func Run(ctx context.Context, opts Options) error {
+	if err := opts.Validate(); err != nil {
+		return err
+	}
+	opts.normalize()
+
+	if opts.PairingToken != "" {
+		return pairWithServer(opts)
+	}
+
+	transport, err := tlspin.BuildTransport(opts.Server, opts.ServerFP)
+	if err != nil {
+		return err
+	}
+	client := push.New(opts.Server, opts.Token, &http.Client{Timeout: 10 * time.Second, Transport: transport})
+	log := opts.logger()
+	client.SetLogger(func(format string, args ...any) { log.Debug("[netpulse-agent] " + fmt.Sprintf(format, args)) })
+
+	prober := probe.NewProber(probe.ShellRunner{}, probe.Options{
+		WanPingTarget: opts.WanTarget,
+		GwPingTarget:  opts.GwTarget,
+	})
+
+	a := &agent{opts: opts, log: log, client: client}
+	hbFile := opts.HeartbeatFile
+	if hbFile == "" {
+		hbFile = heartbeat.DefaultFile
+	}
+	a.hbFile = hbFile
+
+	log.Info("[netpulse-agent] agente iniciado", "version", opts.Version, "slug", opts.Slug, "server", opts.Server, "interval", opts.Interval)
+	a.setRunning(true)
+
+	// Eventos nl80211 en tiempo real (new/del station): push inmediato de
+	// wireless sin esperar al ciclo de sondeo.
+	if iwevents.Available() {
+		log.Info("[netpulse-agent] iw detectado: suscribiendo a eventos nl80211")
+		var lastEventPush time.Time
+		var evMu sync.Mutex
+		go func() {
+			if err := iwevents.Listen(ctx, func(ev iwevents.Event) {
+				evMu.Lock()
+				since := time.Since(lastEventPush)
+				if since < ubusMinGap {
+					evMu.Unlock()
+					return
+				}
+				lastEventPush = time.Now()
+				evMu.Unlock()
+				action := "assoc"
+				if !ev.Connected {
+					action = "disassoc"
+				}
+				log.Info("[netpulse-agent] iw evento", "action", action, "mac", ev.MAC, "iface", ev.Iface)
+				payload := prober.BuildWireless(ctx, opts.Slug, opts.Version)
+				a.pushOnce(ctx, payload)
+			}); err != nil {
+				log.Warn("[netpulse-agent] iw event terminó", "err", err)
+			}
+		}()
+	}
+
+	ex := executor.New(opts.GwTarget, opts.WanTarget)
+
+	// SSE bidireccional: el servidor envía comandos al agente. Reutiliza el
+	// mismo transporte (mismo pinning SPKI que el push).
+	refreshCh := make(chan struct{}, 1)
+	go func() {
+		sse := sseclient.New(opts.Server, opts.Slug, opts.Token,
+			&http.Client{Timeout: 0, Transport: transport},
+			func(ev sseclient.Event) {
+				if ev.Name == "refresh" {
+					select {
+					case refreshCh <- struct{}{}:
+					default:
+					}
+				}
+				if ev.Name == "apply" && ev.Data != "" {
+					go a.handleApply(ex, transport, ev.Data)
+				}
+				if ev.Name == "upgrade" {
+					if opts.OnUpgrade != nil {
+						go opts.OnUpgrade(ev.Data)
+					} else {
+						go handleUpgrade(opts, transport, ev.Data)
+					}
+				}
+				log.Debug("[netpulse-agent] SSE evento", "event", ev.Name)
+			})
+		sse.SetLogger(func(format string, args ...any) { log.Debug("[netpulse-agent] " + fmt.Sprintf(format, args)) })
+		sse.Run(ctx)
+	}()
+
+	// Ciclo principal: sondeo completo cada Interval o cuando el servidor
+	// lo pide (refresh).
+	for {
+		payload := prober.Build(ctx, opts.Slug, opts.Version)
+		a.pushOnce(ctx, payload)
+		select {
+		case <-ctx.Done():
+			log.Info("[netpulse-agent] saliendo")
+			a.setRunning(false)
+			return nil
+		case <-refreshCh:
+			// refresh inmediato pedido por el servidor
+		case <-time.After(client.Delay(opts.Interval)):
+		}
+	}
+}
+
+// agent acumula el estado observable del bucle.
+type agent struct {
+	opts   Options
+	log    *slog.Logger
+	client *push.Client
+	hbFile string
+
+	mu     sync.Mutex
+	status Status
+}
+
+// pushOnce envía el payload, toca el heartbeat y actualiza el estado.
+func (a *agent) pushOnce(ctx context.Context, payload *probe.Payload) {
+	if err := a.client.Push(ctx, payload); err != nil {
+		a.log.Warn("[netpulse-agent] push falló", "err", err, "buffered", a.client.Buffered(), "dropped", a.client.Dropped())
+		a.setPush(false, err.Error())
+		return
+	}
+	if err := heartbeat.Touch(a.hbFile, time.Now()); err != nil {
+		a.log.Warn("[netpulse-agent] heartbeat error", "err", err)
+	}
+	a.setPush(true, "")
+}
+
+func (a *agent) setRunning(running bool) {
+	a.mu.Lock()
+	a.status.Running = running
+	a.status.Slug = a.opts.Slug
+	a.status.Server = a.opts.Server
+	a.mu.Unlock()
+	a.emit()
+}
+
+func (a *agent) setPush(ok bool, errMsg string) {
+	a.mu.Lock()
+	a.status.PushOk = ok
+	if ok {
+		a.status.LastPush = time.Now()
+		a.status.LastError = ""
+	} else {
+		a.status.LastError = errMsg
+	}
+	a.mu.Unlock()
+	a.emit()
+}
+
+// emit notifica OnStatus fuera del lock; un panic del callback se recupera
+// para que nunca tumbe el bucle del agente.
+func (a *agent) emit() {
+	if a.opts.OnStatus == nil {
+		return
+	}
+	a.mu.Lock()
+	st := a.status
+	a.mu.Unlock()
+	defer func() { _ = recover() }()
+	a.opts.OnStatus(st)
+}
+
+// handleApply procesa un comando apply del servidor: parsea las Ops, las
+// ejecuta con snapshot+healthcheck+rollback (o delega en NetGrip si
+// ApplyDelegate está puesto) y POSTea el resultado.
+func (a *agent) handleApply(ex *executor.Executor, transport http.RoundTripper, data string) {
+	var payload struct {
+		PlanID string        `json:"plan_id"`
+		Ops    []executor.Op `json:"ops"`
+	}
+	if err := jsonUnmarshal(data, &payload); err != nil {
+		a.log.Warn("[netpulse-agent] apply: parse error", "err", err)
+		return
+	}
+	if len(payload.Ops) == 0 {
+		a.log.Warn("[netpulse-agent] apply: sin ops", "plan_id", payload.PlanID)
+		return
+	}
+
+	a.log.Info("[netpulse-agent] apply iniciado", "plan_id", payload.PlanID, "ops", len(payload.Ops))
+
+	var result executor.ApplyResult
+	delegated := false
+	if a.opts.ApplyDelegate != nil {
+		if r, ok := a.opts.ApplyDelegate(payload.Ops); ok {
+			result = r
+			delegated = true
+			a.log.Info("[netpulse-agent] apply delegado a NetGrip", "plan_id", payload.PlanID, "status", result.Status, "ms", result.DurationMs)
+		}
+	}
+	if !delegated {
+		result = ex.Apply(payload.Ops)
+		a.log.Info("[netpulse-agent] apply ejecutado por agente", "plan_id", payload.PlanID, "status", result.Status, "ms", result.DurationMs)
+	}
+
+	postJSON(a.opts, transport, "/api/agents/"+a.opts.Slug+"/apply-result",
+		map[string]any{"planId": payload.PlanID, "result": result})
+}
+
+func (o Options) logger() *slog.Logger {
+	if o.Logger != nil {
+		return o.Logger
+	}
+	return slog.Default()
+}
+
+// normalize sanea Server (sin / final) y ServerFP (hex normalizado).
+func (o *Options) normalize() {
+	o.Server = strings.TrimRight(o.Server, "/")
+	o.ServerFP = tlspin.Normalize(o.ServerFP)
+	if o.Interval <= 0 {
+		o.Interval = DefaultInterval
+	}
+}

--- a/agent/runtime/runtime.go
+++ b/agent/runtime/runtime.go
@@ -46,6 +46,11 @@ type Options struct {
 	HeartbeatFile string
 	EnvFile       string // ruta del env file (para escribir el token tras pairing)
 	Version       string // la reporta cada push
+	// Kind etiqueta el SABOR del pusher en el payload (#363): "" = agente
+	// standalone netpulse-agent; "netgrip" = agente embebido en el panel
+	// NetGrip. El servidor lo usa para la UI y para NO reinstalar el
+	// binario standalone sobre un NetGrip.
+	Kind string
 
 	// OnStatus recibe el estado en cada cambio (arranque, cada push, parada).
 	// Nunca rompe el bucle: un panic dentro del callback se recupera.
@@ -130,6 +135,7 @@ func Run(ctx context.Context, opts Options) error {
 				}
 				log.Info("[netpulse-agent] iw evento", "action", action, "mac", ev.MAC, "iface", ev.Iface)
 				payload := prober.BuildWireless(ctx, opts.Slug, opts.Version)
+				payload.Kind = opts.Kind
 				a.pushOnce(ctx, payload)
 			}); err != nil {
 				log.Warn("[netpulse-agent] iw event terminó", "err", err)
@@ -172,6 +178,7 @@ func Run(ctx context.Context, opts Options) error {
 	// lo pide (refresh).
 	for {
 		payload := prober.Build(ctx, opts.Slug, opts.Version)
+		payload.Kind = opts.Kind
 		a.pushOnce(ctx, payload)
 		select {
 		case <-ctx.Done():

--- a/agent/runtime/runtime_test.go
+++ b/agent/runtime/runtime_test.go
@@ -1,0 +1,332 @@
+// runtime_test.go: tests del paquete runtime - parsing/validación de config
+// (espejo de los configError del antiguo main), writePairedToken y emisión
+// de Status del bucle contra un servidor de prueba local.
+package runtime
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func TestLoadConfigFromEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, "agent.env")
+	writeFile(t, env, `
+# comentario
+NETPULSE_SERVER=https://example.com:3000/
+NETPULSE_TOKEN=abc123
+NETPULSE_SLUG=patio
+NETPULSE_SERVER_FP=AA-BB-CC
+NETPULSE_INTERVAL=15s
+NETPULSE_WAN_TARGET=1.1.1.1
+NETPULSE_GW_TARGET=192.168.8.1
+NETPULSE_HEARTBEAT_FILE=/tmp/hb
+`)
+	opts, err := LoadConfigFromEnv(env)
+	if err != nil {
+		t.Fatalf("LoadConfigFromEnv: %v", err)
+	}
+	if opts.Server != "https://example.com:3000" {
+		t.Fatalf("Server: %q (quiero sin / final)", opts.Server)
+	}
+	if opts.Token != "abc123" || opts.Slug != "patio" {
+		t.Fatalf("token/slug: %q/%q", opts.Token, opts.Slug)
+	}
+	if opts.ServerFP == "AA-BB-CC" {
+		t.Fatalf("ServerFP sin normalizar: %q", opts.ServerFP)
+	}
+	if opts.Interval != 15*time.Second {
+		t.Fatalf("Interval: %v", opts.Interval)
+	}
+	if opts.WanTarget != "1.1.1.1" || opts.GwTarget != "192.168.8.1" {
+		t.Fatalf("targets: %q/%q", opts.WanTarget, opts.GwTarget)
+	}
+	if opts.HeartbeatFile != "/tmp/hb" || opts.EnvFile != env {
+		t.Fatalf("files: %q/%q", opts.HeartbeatFile, opts.EnvFile)
+	}
+}
+
+func TestLoadConfigIntervalFormats(t *testing.T) {
+	dir := t.TempDir()
+	base := "NETPULSE_SERVER=http://s\nNETPULSE_TOKEN=t\nNETPULSE_SLUG=s\n"
+
+	env := filepath.Join(dir, "secs.env")
+	writeFile(t, env, base+"NETPULSE_INTERVAL=20")
+	opts, err := LoadConfigFromEnv(env)
+	if err != nil || opts.Interval != 20*time.Second {
+		t.Fatalf("NETPULSE_INTERVAL=20: %v %v", opts.Interval, err)
+	}
+
+	env = filepath.Join(dir, "dur.env")
+	writeFile(t, env, base+"NETPULSE_INTERVAL=1m")
+	opts, err = LoadConfigFromEnv(env)
+	if err != nil || opts.Interval != time.Minute {
+		t.Fatalf("NETPULSE_INTERVAL=1m: %v %v", opts.Interval, err)
+	}
+
+	// Valor inválido: default 30s (y no error).
+	env = filepath.Join(dir, "bad.env")
+	writeFile(t, env, base+"NETPULSE_INTERVAL=nada")
+	opts, err = LoadConfigFromEnv(env)
+	if err != nil || opts.Interval != DefaultInterval {
+		t.Fatalf("NETPULSE_INTERVAL inválido: %v %v (quiero default 30s)", opts.Interval, err)
+	}
+}
+
+func TestLoadConfigValidationErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	env := filepath.Join(dir, "no-server.env")
+	writeFile(t, env, "NETPULSE_TOKEN=t\nNETPULSE_SLUG=s\n")
+	if _, err := LoadConfigFromEnv(env); err == nil || !strings.Contains(err.Error(), "NETPULSE_SERVER") {
+		t.Fatalf("sin server: quiero ConfigError NETPULSE_SERVER, got %v", err)
+	}
+
+	env = filepath.Join(dir, "no-slug.env")
+	writeFile(t, env, "NETPULSE_SERVER=http://s\nNETPULSE_TOKEN=t\n")
+	if _, err := LoadConfigFromEnv(env); err == nil || !strings.Contains(err.Error(), "NETPULSE_SLUG") {
+		t.Fatalf("sin slug: quiero ConfigError NETPULSE_SLUG, got %v", err)
+	}
+
+	env = filepath.Join(dir, "no-token.env")
+	writeFile(t, env, "NETPULSE_SERVER=http://s\nNETPULSE_SLUG=s\n")
+	if _, err := LoadConfigFromEnv(env); err == nil || !strings.Contains(err.Error(), "NETPULSE_TOKEN") {
+		t.Fatalf("sin token: quiero ConfigError NETPULSE_TOKEN, got %v", err)
+	}
+
+	// Pairing token sustituye a TOKEN.
+	env = filepath.Join(dir, "pairing.env")
+	writeFile(t, env, "NETPULSE_SERVER=http://s\nNETPULSE_SLUG=s\nNETPULSE_PAIRING_TOKEN=p\n")
+	if _, err := LoadConfigFromEnv(env); err != nil {
+		t.Fatalf("pairing válido: no quiero error, got %v", err)
+	}
+
+	// Options.Validate directo (embedders que no usan LoadConfigFromEnv).
+	if err := (Options{Token: "t"}).Validate(); err == nil {
+		t.Fatal("Validate sin server/slug: quiero error")
+	}
+	if err := (Options{Server: "http://s", Slug: "s"}).Validate(); err == nil {
+		t.Fatal("Validate sin token ni pairing: quiero error")
+	}
+	if err := (Options{Server: "http://s", Slug: "s", Token: "t"}).Validate(); err != nil {
+		t.Fatalf("Validate completo: %v", err)
+	}
+}
+
+func TestLoadConfigProcessEnvWins(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, "agent.env")
+	writeFile(t, env, "NETPULSE_SERVER=http://from-file\nNETPULSE_TOKEN=f\nNETPULSE_SLUG=s\n")
+
+	t.Setenv("NETPULSE_SERVER", "http://from-env")
+	opts, err := LoadConfigFromEnv(env)
+	if err != nil {
+		t.Fatalf("LoadConfigFromEnv: %v", err)
+	}
+	if opts.Server != "http://from-env" {
+		t.Fatalf("el env del proceso debe ganar: %q", opts.Server)
+	}
+}
+
+func TestLoadConfigMissingEnvFileDefaults(t *testing.T) {
+	t.Setenv("NETPULSE_SERVER", "http://s")
+	t.Setenv("NETPULSE_TOKEN", "t")
+	t.Setenv("NETPULSE_SLUG", "s")
+	opts, err := LoadConfigFromEnv(filepath.Join(t.TempDir(), "no-existe.env"))
+	if err != nil {
+		t.Fatalf("env file inexistente no es error: %v", err)
+	}
+	if opts.Interval != DefaultInterval {
+		t.Fatalf("Interval default: %v", opts.Interval)
+	}
+}
+
+func TestWritePairedToken(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, "agent.env")
+	writeFile(t, env, "NETPULSE_SERVER=http://s\nNETPULSE_PAIRING_TOKEN=pt\nNETPULSE_SLUG=s\n")
+
+	if err := writePairedToken(env, "real-token"); err != nil {
+		t.Fatalf("writePairedToken: %v", err)
+	}
+	data, err := os.ReadFile(env)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	content := string(data)
+	if strings.Contains(content, "PAIRING") {
+		t.Fatalf("PAIRING_TOKEN debe desaparecer: %q", content)
+	}
+	if !strings.Contains(content, "NETPULSE_TOKEN=real-token") {
+		t.Fatalf("TOKEN nuevo debe estar: %q", content)
+	}
+	if !strings.Contains(content, "NETPULSE_SERVER=http://s") {
+		t.Fatalf("conserva el resto: %q", content)
+	}
+	st, _ := os.Stat(env)
+	if st.Mode().Perm() != 0o600 {
+		t.Fatalf("permisos: %o", st.Mode().Perm())
+	}
+
+	// Env file inexistente: se crea solo con el token.
+	env2 := filepath.Join(dir, "nuevo.env")
+	if err := writePairedToken(env2, "tk"); err != nil {
+		t.Fatalf("writePairedToken nuevo: %v", err)
+	}
+	data2, _ := os.ReadFile(env2)
+	if string(data2) != "NETPULSE_TOKEN=tk\n" {
+		t.Fatalf("nuevo env: %q", data2)
+	}
+}
+
+// TestRunEmitsStatus: bucle completo contra un servidor de prueba local; el
+// callback OnStatus debe ver Running=true y luego un push confirmado.
+func TestRunEmitsStatus(t *testing.T) {
+	var mu sync.Mutex
+	received := make(chan Status, 16)
+	onStatus := func(st Status) {
+		mu.Lock()
+		defer mu.Unlock()
+		received <- st
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/ingest/agent":
+			w.WriteHeader(http.StatusAccepted)
+		case "/api/agents/patio/stream":
+			// SSE: cuelga hasta que el test cancele el ctx (el cliente cierra).
+			<-r.Context().Done()
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	opts := Options{
+		Server:        srv.URL,
+		Token:         "tok",
+		Slug:          "patio",
+		Interval:      200 * time.Millisecond,
+		HeartbeatFile: filepath.Join(dir, "hb"),
+		Version:       "test",
+		OnStatus:      onStatus,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- Run(ctx, opts) }()
+
+	seenRunning, seenPush := false, false
+	deadline := time.After(15 * time.Second)
+	for !(seenRunning && seenPush) {
+		select {
+		case st := <-received:
+			if st.Running && st.Slug == "patio" && st.Server == srv.URL {
+				seenRunning = true
+			}
+			if st.PushOk && !st.LastPush.IsZero() && st.LastError == "" {
+				seenPush = true
+			}
+		case <-deadline:
+			t.Fatal("no se recibió Running+PushOk via OnStatus")
+		}
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run no terminó tras cancelar ctx")
+	}
+
+	// Parada: último estado con Running=false.
+	var last Status
+	for {
+		select {
+		case last = <-received:
+		default:
+			goto checked
+		}
+	}
+checked:
+	if last.Running {
+		t.Fatalf("tras cancelar, Running debe ser false: %+v", last)
+	}
+}
+
+// TestRunEmitsPushError: servidor de ingest caído → estado PushOk=false con
+// LastError.
+func TestRunEmitsPushError(t *testing.T) {
+	received := make(chan Status, 16)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/ingest/agent" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.URL.Path == "/api/agents/patio/stream" {
+			<-r.Context().Done()
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	opts := Options{
+		Server:   srv.URL,
+		Token:    "tok",
+		Slug:     "patio",
+		Interval: 200 * time.Millisecond,
+		OnStatus: func(st Status) { received <- st },
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- Run(ctx, opts) }()
+
+	deadline := time.After(15 * time.Second)
+	for {
+		select {
+		case st := <-received:
+			if !st.Running {
+				continue
+			}
+			if !st.PushOk && st.LastError != "" {
+				cancel()
+				if err := <-done; err != nil {
+					t.Fatalf("Run: %v", err)
+				}
+				return
+			}
+		case <-deadline:
+			cancel()
+			t.Fatal("no se recibió PushOk=false con LastError")
+		}
+	}
+}
+
+// TestRunInvalidOptions: Run sin config válida falla rápido sin arrancar.
+func TestRunInvalidOptions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := Run(ctx, Options{}); err == nil {
+		t.Fatal("Run sin options: quiero error de validación")
+	}
+}

--- a/agent/runtime/upgrade.go
+++ b/agent/runtime/upgrade.go
@@ -1,12 +1,13 @@
-// upgrade.go — Fase 6.3 (issue #243): self-update del agente.
+// upgrade.go: self-update del agente (Fase 6.3, issue #243).
 //
 // Al recibir el evento SSE "upgrade", el agente descarga el binario embebido
 // del propio servidor (GET /api/agents/{slug}/binary?arch=...), lo verifica,
 // lo intercambia atómicamente por el binario en marcha y reinicia su servicio
 // procd (el proceso actual muere y procd relanza el binario nuevo). El
 // resultado se reporta a POST /api/agents/{slug}/upgrade-result ANTES del
-// reinicio (que mata este proceso).
-package main
+// reinicio (que mata este proceso). Los embedders pueden sustituir todo esto
+// con Options.OnUpgrade.
+package runtime
 
 import (
 	"context"
@@ -22,13 +23,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
-
-	"log/slog"
 )
 
-// Ruta del binario en marcha (instalación estándar) y del init script procd.
-// install-agent.sh los fija así; la variante --tmp usa /tmp/netpulse-agent
-// (se resuelve dinámicamente con os.Executable en currentBinPath).
 const (
 	defaultBinPath  = "/usr/sbin/netpulse-agent"
 	agentInitScript = "/etc/init.d/netpulse-agent"
@@ -90,7 +86,6 @@ func (p *progressReader) Read(buf []byte) (int, error) {
 // vacío. onPct (opcional) recibe el progreso 0-100 de la descarga (#284).
 // Devuelve el valor de la cabecera X-Checksum-Sha256 (vacía si el server no
 // la manda) para que el llamante verifique la integridad.
-// Extraída a función propia para poder testearla con httptest.
 func downloadBinary(ctx context.Context, hc *http.Client, url, token, dest string, onPct func(pct int)) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -192,53 +187,27 @@ func verifySha256(path, want string) error {
 // reportUpgradeProgress POSTea un paso intermedio del upgrade al servidor
 // (#284: progreso en vivo). Fire-and-forget: un fallo se loguea y se sigue
 // (el progreso es best-effort; el resultado final sí es fiable).
-func reportUpgradeProgress(cfg config, transport http.RoundTripper, step string, pct int) {
-	m := map[string]any{"slug": cfg.slug, "step": step}
+func reportUpgradeProgress(opts Options, transport http.RoundTripper, step string, pct int) {
+	m := map[string]any{"slug": opts.Slug, "step": step}
 	if pct > 0 {
 		m["pct"] = pct
 	}
-	body, _ := json.Marshal(m)
-	req, err := http.NewRequest("POST", cfg.server+"/api/agents/"+cfg.slug+"/upgrade-progress", strings.NewReader(string(body)))
-	if err != nil {
-		return
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+cfg.token)
-	hc := &http.Client{Transport: transport, Timeout: 5 * time.Second}
-	resp, err := hc.Do(req)
-	if err != nil {
-		slog.Warn("[netpulse-agent] upgrade: progress POST falló", "step", step, "err", err)
-		return
-	}
-	resp.Body.Close()
+	postJSON(opts, transport, "/api/agents/"+opts.Slug+"/upgrade-progress", m)
 }
 
 // reportUpgradeResult POSTea el resultado del upgrade al servidor.
-func reportUpgradeResult(cfg config, transport http.RoundTripper, ok bool, errMsg string) {
-	m := map[string]any{"slug": cfg.slug, "ok": ok}
+func reportUpgradeResult(opts Options, transport http.RoundTripper, ok bool, errMsg string) {
+	m := map[string]any{"slug": opts.Slug, "ok": ok}
 	if errMsg != "" {
 		m["error"] = errMsg
 	}
-	body, _ := json.Marshal(m)
-	req, err := http.NewRequest("POST", cfg.server+"/api/agents/"+cfg.slug+"/upgrade-result", strings.NewReader(string(body)))
-	if err != nil {
-		return
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+cfg.token)
-	hc := &http.Client{Transport: transport, Timeout: 10 * time.Second}
-	resp, err := hc.Do(req)
-	if err != nil {
-		slog.Warn("[netpulse-agent] upgrade: result POST falló", "err", err)
-		return
-	}
-	resp.Body.Close()
+	postJSON(opts, transport, "/api/agents/"+opts.Slug+"/upgrade-result", m)
 }
 
 // handleUpgrade procesa el evento SSE "upgrade": descarga el binario, lo
 // verifica, hace el swap atómico, reporta el resultado y reinicia el servicio
 // (que mata este proceso; procd relanza el binario nuevo).
-func handleUpgrade(cfg config, transport http.RoundTripper, data string) {
+func handleUpgrade(opts Options, transport http.RoundTripper, data string) {
 	arch := runtime.GOARCH
 	if data != "" {
 		var p struct {
@@ -249,44 +218,45 @@ func handleUpgrade(cfg config, transport http.RoundTripper, data string) {
 		}
 	}
 	arch = netpulseArch(arch)
+	log := opts.logger()
 
-	slog.Info("[netpulse-agent] upgrade iniciado", "slug", cfg.slug, "arch", arch)
-	url := cfg.server + "/api/agents/" + cfg.slug + "/binary?arch=" + arch
+	log.Info("[netpulse-agent] upgrade iniciado", "slug", opts.Slug, "arch", arch)
+	url := opts.Server + "/api/agents/" + opts.Slug + "/binary?arch=" + arch
 	hc := &http.Client{Transport: transport, Timeout: 2 * time.Minute}
 
-	reportUpgradeProgress(cfg, transport, "downloading", 0)
-	digest, err := downloadBinary(context.Background(), hc, url, cfg.token, tmpBinPath, func(pct int) {
-		reportUpgradeProgress(cfg, transport, "downloading", pct)
+	reportUpgradeProgress(opts, transport, "downloading", 0)
+	digest, err := downloadBinary(context.Background(), hc, url, opts.Token, tmpBinPath, func(pct int) {
+		reportUpgradeProgress(opts, transport, "downloading", pct)
 	})
 	if err != nil {
-		slog.Error("[netpulse-agent] upgrade: descarga falló", "err", err)
-		reportUpgradeResult(cfg, transport, false, err.Error())
+		log.Error("[netpulse-agent] upgrade: descarga falló", "err", err)
+		reportUpgradeResult(opts, transport, false, err.Error())
 		return
 	}
 
 	// Integridad (#284): sha256 contra la cabecera del servidor, ANTES del swap.
 	if digest != "" {
-		reportUpgradeProgress(cfg, transport, "verifying", 0)
+		reportUpgradeProgress(opts, transport, "verifying", 0)
 		if err := verifySha256(tmpBinPath, digest); err != nil {
-			slog.Error("[netpulse-agent] upgrade: verificación falló", "err", err)
-			reportUpgradeResult(cfg, transport, false, err.Error())
+			log.Error("[netpulse-agent] upgrade: verificación falló", "err", err)
+			reportUpgradeResult(opts, transport, false, err.Error())
 			return
 		}
 	}
 
 	dst := currentBinPath()
-	reportUpgradeProgress(cfg, transport, "swapping", 0)
+	reportUpgradeProgress(opts, transport, "swapping", 0)
 	if err := swapBinary(tmpBinPath, dst); err != nil {
-		slog.Error("[netpulse-agent] upgrade: swap falló", "err", err, "dst", dst)
-		reportUpgradeResult(cfg, transport, false, err.Error())
+		log.Error("[netpulse-agent] upgrade: swap falló", "err", err, "dst", dst)
+		reportUpgradeResult(opts, transport, false, err.Error())
 		return
 	}
 
-	slog.Info("[netpulse-agent] upgrade: binario intercambiado, reiniciando servicio", "dst", dst)
-	reportUpgradeProgress(cfg, transport, "restarting", 0)
+	log.Info("[netpulse-agent] upgrade: binario intercambiado, reiniciando servicio", "dst", dst)
+	reportUpgradeProgress(opts, transport, "restarting", 0)
 	// Reportar ANTES de reiniciar: el reinicio mata este proceso.
-	reportUpgradeResult(cfg, transport, true, "")
+	reportUpgradeResult(opts, transport, true, "")
 	if err := restartService(); err != nil {
-		slog.Warn("[netpulse-agent] upgrade: reinicio falló", "err", err)
+		log.Warn("[netpulse-agent] upgrade: reinicio falló", "err", err)
 	}
 }

--- a/agent/runtime/upgrade_test.go
+++ b/agent/runtime/upgrade_test.go
@@ -1,7 +1,7 @@
-// upgrade_test.go — Fase 6.3 (issue #243): tests de la lógica de self-update
+// upgrade_test.go - Fase 6.3 (issue #243): tests de la lógica de self-update
 // del agente (mapeo de arquitectura, descarga+verificación y swap atómico).
 // #284: progreso de descarga y pasos reportados al servidor.
-package main
+package runtime
 
 import (
 	"encoding/json"
@@ -196,7 +196,7 @@ func TestReportUpgradeProgressSteps(t *testing.T) {
 	currentBinPath = func() string { return exe }
 	defer func() { currentBinPath = oldPath }()
 
-	cfg := config{server: srv.URL, slug: "patio", token: "tok"}
+	cfg := Options{Server: srv.URL, Slug: "patio", Token: "tok"}
 	handleUpgrade(cfg, nil, "")
 
 	mu.Lock()


### PR DESCRIPTION
Extracts the agent loop (probe cycle, push with buffer, iw events, SSE commands, pairing) into a public `agent/runtime` package with `Run(ctx, Options)`, a `Status` callback for embedders and `LoadConfigFromEnv`. cmd/netpulse-agent becomes a thin wrapper with identical behavior, flags and logs.

Needed by NetGrip to embed the agent in its panel binary (single binary = panel + agent), and by the agent-kind work (`Options.Kind` labels the pusher flavor in the payload).

Closes #362