### PR TITLE
UDP discovery responder and autoenroll token for zero-touch agents

### DIFF
--- a/doc/DISCOVERY.md
+++ b/doc/DISCOVERY.md
@@ -1,0 +1,75 @@
+# Discovery zero-touch v1 - servidor y autoenroll (#367)
+
+Mecanismo por el que un NetGrip recién instalado (agente NetPulse embebido,
+sin config) encuentra un servidor NetPulse en la LAN y se da de alta solo.
+Reutiliza el mismo socket UDP del listener de beacons (`:5140` en el server,
+ver BEACON.md), así que no abre puertos nuevos.
+
+## 1. Probe (broadcast, desde NetGrip)
+
+NetGrip emite este datagrama en broadcast (por interfaz, `.255` de cada
+subred + `255.255.255.255`) cuando su agente NO está conectado (sin config
+válida, o server caído y sin pushes aceptados en 10 min). Cadencia 30 s.
+
+```json
+{"v":1,"type":"netgrip-probe"}
+```
+
+- Puerto destino: el del listener de beacons del server (5140 por defecto).
+- El lado NetGrip puede overridearlo con `NETPULSE_DISCOVERY_PORT` en
+  `/etc/netgrip/netpulse.env` (deployes con el beacon en otro puerto).
+- Servers viejos sin discovery ignoran el probe en silencio (su parser de
+  beacons no conoce el campo `type`).
+
+## 2. Respuesta (unicast, desde el server)
+
+El server contesta UNICAST a la IP del prober con su URL HTTP real. La IP
+sale de un socket UDP conectado hacia el prober (en hosts multi-homed es la
+IP de la interfaz correcta); el puerto es el HTTP de la config (3000).
+
+```json
+{"v":1,"type":"netpulse-server","url":"http://192.168.1.226:3000",
+ "autoenroll":true,"pairing_token":"<uuid>"}
+```
+
+- `autoenroll`: refleja el flag `AGENT_AUTOENROLL` del server (default off).
+- `pairing_token`: SOLO presente con `autoenroll:true`. Es el token de alta
+  de red, distinto del pairing token de admin.
+- Rate limit por IP origen, igual que la ingesta.
+
+## 3. Autoenroll (alta sin intervención)
+
+Con el token de alta de red, NetGrip llama al pairing existente:
+
+```
+POST /api/agents/pair   {"pairing_token":"<uuid>","slug":"<hostname>"}
+```
+
+- Slug: hostname del router saneado (`^[a-z0-9][a-z0-9-]{0,63}$`, fallback
+  `netgrip`). Si el slug existe (409 slug_taken) reintenta con sufijos
+  `-2`..`-5` antes de rendirse hasta el siguiente ciclo.
+- El token de red SOLO puede crear agentes NUEVOS: nunca rota ni suplanta
+  el token de un slug existente (409 si está ocupado).
+- Respuesta 201: `{slug, token, server_fp}`; NetGrip persiste la config en
+  `/etc/netgrip/netpulse.env` y el agente empieza a pushear.
+- NetGrip NO se re-enrolla si ya está conectado al mismo server que
+  descubre; contra un server DISTINTO solo migra si el configurado lleva
+  10 min sin aceptar pushes (caso IP cambiada).
+
+## 4. Flags de config (server)
+
+| Variable | Default | Efecto |
+|---|---|---|
+| `AGENT_AUTOENROLL` | `0` | `1` = el responder incluye token de alta y `/api/agents/pair` lo acepta para slugs nuevos. |
+| `NETPULSE_BEACON_LISTEN` | `:5140` | Socket UDP compartido beacons + discovery. |
+
+El token de alta rota solo a las 24 h (rotación perezosa en lectura: el
+token previo muere en el instante del cambio).
+
+## 5. Modelo de seguridad
+
+LAN de confianza (misma decisión consciente que el beacon #291): el token
+viaja en claro, solo hacia la IP del prober, y únicamente autoriza crear
+agentes nuevos. Un atacante de la LAN puede auto-dar de alta routers, no
+suplantar los existentes; la rotación de 24 h acota la ventana de un token
+filtrado.

--- a/server-go/internal/config/config.go
+++ b/server-go/internal/config/config.go
@@ -65,7 +65,7 @@ type Config struct {
 	AutoRearm       bool   // NETPULSE_AUTO_REARM=1: supervisor rearma agentes caídos
 	BeaconListen    string // NETPULSE_BEACON_LISTEN: socket UDP de beacons embebidos (#291); "" = off, p. ej. ":5140"
 	AgentAutoenroll bool   // AGENT_AUTOENROLL=1: el responder UDP entrega token de alta y /pair lo acepta (#367)
-	Onbox           bool   // NETPULSE_ONBOX=1: modo on-box (Fase 9 — config UCI, bootstrap AUTH_PASS)
+	Onbox           bool   // NETPULSE_ONBOX=1: modo on-box (Fase 9: config UCI, bootstrap AUTH_PASS)
 }
 
 // LoadDotEnv parsea un .env: KEY=VALUE por línea, '#' comentarios (línea

--- a/server-go/internal/config/config.go
+++ b/server-go/internal/config/config.go
@@ -42,29 +42,30 @@ type Webhook struct {
 
 // Config es la config normalizada (equivalente al objeto de loadConfig).
 type Config struct {
-	Port          int
-	NodeEnv       string
-	StaticDir     string // resuelta (absoluta)
-	DataDir       string // resuelta (absoluta)
-	SessionSecret string // "" si falta (autogenerado en kv)
-	AuthUser      string
-	AuthPass      string
-	DemoMode      bool
-	MaxSSEClients int
-	Routers       []RouterSeed
-	SSHKeyPath    string
-	Adguard       *AdGuard
-	Webhook       *Webhook
-	WGInterface   string
-	CookieSecure  string // "auto" | "always" | "never"
-	TrustProxy    bool   // confiar en X-Forwarded-For/-Proto (detrás de proxy)
-	MaxTsDriftSec int    // ventana frescura ts agente en s (0 → default 5 min)
-	GithubRepo    string
-	GithubToken   string
-	ServerRoot    string
-	AutoRearm     bool   // NETPULSE_AUTO_REARM=1: supervisor rearma agentes caídos
-	BeaconListen  string // NETPULSE_BEACON_LISTEN: socket UDP de beacons embebidos (#291); "" = off, p. ej. ":5140"
-	Onbox         bool // NETPULSE_ONBOX=1: modo on-box (Fase 9 — config UCI, bootstrap AUTH_PASS)
+	Port            int
+	NodeEnv         string
+	StaticDir       string // resuelta (absoluta)
+	DataDir         string // resuelta (absoluta)
+	SessionSecret   string // "" si falta (autogenerado en kv)
+	AuthUser        string
+	AuthPass        string
+	DemoMode        bool
+	MaxSSEClients   int
+	Routers         []RouterSeed
+	SSHKeyPath      string
+	Adguard         *AdGuard
+	Webhook         *Webhook
+	WGInterface     string
+	CookieSecure    string // "auto" | "always" | "never"
+	TrustProxy      bool   // confiar en X-Forwarded-For/-Proto (detrás de proxy)
+	MaxTsDriftSec   int    // ventana frescura ts agente en s (0 → default 5 min)
+	GithubRepo      string
+	GithubToken     string
+	ServerRoot      string
+	AutoRearm       bool   // NETPULSE_AUTO_REARM=1: supervisor rearma agentes caídos
+	BeaconListen    string // NETPULSE_BEACON_LISTEN: socket UDP de beacons embebidos (#291); "" = off, p. ej. ":5140"
+	AgentAutoenroll bool   // AGENT_AUTOENROLL=1: el responder UDP entrega token de alta y /pair lo acepta (#367)
+	Onbox           bool   // NETPULSE_ONBOX=1: modo on-box (Fase 9 — config UCI, bootstrap AUTH_PASS)
 }
 
 // LoadDotEnv parsea un .env: KEY=VALUE por línea, '#' comentarios (línea
@@ -291,6 +292,21 @@ func Load(env map[string]string, serverRoot string) (*Config, error) {
 		beaconListen = ""
 	}
 
+	// AGENT_AUTOENROLL: '0'|'1', opcional (#367). Con '1' el responder de
+	// descubrimiento UDP entrega un token de alta de red y /api/agents/pair
+	// lo acepta (solo para slugs NUEVOS). Opt-in explícito: sin él, el
+	// responder anuncia el server sin token.
+	agentAutoenroll := false
+	if v, ok := env["AGENT_AUTOENROLL"]; ok && v != "" {
+		switch v {
+		case "0":
+		case "1":
+			agentAutoenroll = true
+		default:
+			errs.issues = append(errs.issues, issue{"AGENT_AUTOENROLL", "Invalid enum value. Expected '0' | '1'"})
+		}
+	}
+
 	// ADGUARD_*: cliente estándar solo si hay URL válida
 	var adguard *AdGuard
 	if v, ok := env["ADGUARD_URL"]; ok && v != "" {
@@ -384,29 +400,30 @@ func Load(env map[string]string, serverRoot string) (*Config, error) {
 	}
 
 	return &Config{
-		Port:          port,
-		NodeEnv:       nodeEnv,
-		StaticDir:     resolve(staticDir),
-		DataDir:       resolve(dataDir),
-		SessionSecret: sessionSecret,
-		AuthUser:      authUser,
-		AuthPass:      authPass,
-		DemoMode:      demoMode,
-		MaxSSEClients: maxSSE,
-		Routers:       routers,
-		SSHKeyPath:    sshKeyPath,
-		Adguard:       adguard,
-		Webhook:       webhook,
-		WGInterface:   wgInterface,
-		CookieSecure:  cookieSecure,
-		TrustProxy:    trustProxy,
-		MaxTsDriftSec: maxTsDriftSec,
-		GithubRepo:    githubRepo,
-		GithubToken:   githubToken,
-		ServerRoot:    serverRoot,
-		AutoRearm:     autoRearm,
-		BeaconListen:  beaconListen,
-		Onbox:         onbox,
+		Port:            port,
+		NodeEnv:         nodeEnv,
+		StaticDir:       resolve(staticDir),
+		DataDir:         resolve(dataDir),
+		SessionSecret:   sessionSecret,
+		AuthUser:        authUser,
+		AuthPass:        authPass,
+		DemoMode:        demoMode,
+		MaxSSEClients:   maxSSE,
+		Routers:         routers,
+		SSHKeyPath:      sshKeyPath,
+		Adguard:         adguard,
+		Webhook:         webhook,
+		WGInterface:     wgInterface,
+		CookieSecure:    cookieSecure,
+		TrustProxy:      trustProxy,
+		MaxTsDriftSec:   maxTsDriftSec,
+		GithubRepo:      githubRepo,
+		GithubToken:     githubToken,
+		ServerRoot:      serverRoot,
+		AutoRearm:       autoRearm,
+		BeaconListen:    beaconListen,
+		AgentAutoenroll: agentAutoenroll,
+		Onbox:           onbox,
 	}, nil
 }
 

--- a/server-go/internal/httpapi/beacon.go
+++ b/server-go/internal/httpapi/beacon.go
@@ -329,14 +329,14 @@ func (s *server) emitPortLinkChange(slug, label string, up bool) {
 	var ev alerts.AlertEvent
 	if up {
 		ev = alerts.AlertEvent{
-			ID: fmt.Sprintf("beacon-port-up-%s-%d", slug, time.Now().UnixMilli()),
+			ID:       fmt.Sprintf("beacon-port-up-%s-%d", slug, time.Now().UnixMilli()),
 			Category: alerts.CatSystem, Severity: "ok", Time: "ahora mismo",
 			RouterID: slug, Title: "Link restablecido en " + name,
 			Description: "Detectado por el cambio entre beacons",
 		}
 	} else {
 		ev = alerts.AlertEvent{
-			ID: fmt.Sprintf("beacon-port-down-%s-%d", slug, time.Now().UnixMilli()),
+			ID:       fmt.Sprintf("beacon-port-down-%s-%d", slug, time.Now().UnixMilli()),
 			Category: alerts.CatSystem, Severity: "warn", Time: "ahora mismo",
 			RouterID: slug, Title: "Link caído en " + name,
 			Description: "Detectado por el cambio entre beacons",
@@ -366,19 +366,19 @@ func (s *server) emitSFPAlerts(slug string, labels map[string]string, sfpByPort 
 		}
 		if sfp.RxPower < sfpAlertRxLow {
 			eng.Emit(alerts.AlertEvent{
-				ID: fmt.Sprintf("sfp-rx-%s-%d", slug, portNum),
+				ID:       fmt.Sprintf("sfp-rx-%s-%d", slug, portNum),
 				Category: alerts.CatSystem, Urgent: false,
 				Severity: "warn", Time: "ahora mismo", RouterID: slug,
-				Title: fmt.Sprintf("SFP RX bajo en %s", portName),
+				Title:       fmt.Sprintf("SFP RX bajo en %s", portName),
 				Description: fmt.Sprintf("Potencia RX %.1f dBm (umbral %.0f dBm)", sfp.RxPower, sfpAlertRxLow),
 			})
 		}
 		if sfp.Temperature > sfpAlertTempHigh {
 			eng.Emit(alerts.AlertEvent{
-				ID: fmt.Sprintf("sfp-temp-%s-%d", slug, portNum),
+				ID:       fmt.Sprintf("sfp-temp-%s-%d", slug, portNum),
 				Category: alerts.CatSystem, Urgent: false,
 				Severity: "warn", Time: "ahora mismo", RouterID: slug,
-				Title: fmt.Sprintf("SFP caliente en %s", portName),
+				Title:       fmt.Sprintf("SFP caliente en %s", portName),
 				Description: fmt.Sprintf("Temperatura %.1f °C (umbral %.0f °C)", sfp.Temperature, sfpAlertTempHigh),
 			})
 		}
@@ -476,9 +476,9 @@ func (s *server) beaconSeqNote(slug string, seq uint32) {
 	if had && seq <= 1 && old > 1 {
 		if eng := s.alertsEngine(); eng != nil {
 			eng.Emit(alerts.AlertEvent{
-				ID:         fmt.Sprintf("beacon-reboot-%s-%d", slug, time.Now().UnixMilli()),
-				Category:   alerts.CatSystem, Severity: "info", Time: "ahora mismo",
-				RouterID:   slug, Title: "Switch reiniciado",
+				ID:       fmt.Sprintf("beacon-reboot-%s-%d", slug, time.Now().UnixMilli()),
+				Category: alerts.CatSystem, Severity: "info", Time: "ahora mismo",
+				RouterID: slug, Title: "Switch reiniciado",
 				Description: fmt.Sprintf("El contador de beacons de %s volvió a empezar (seq %d tras %d): el switch ha arrancado de nuevo", slug, seq, old),
 			})
 		}
@@ -505,6 +505,12 @@ func (s *server) startBeaconListener(addr string) (net.Addr, error) {
 				return // socket cerrado
 			}
 			if src == nil {
+				continue
+			}
+			// #367: probe de descubrimiento zero-touch (NetGrip). Se
+			// contesta unicast y no entra en la vía del beacon.
+			if isDiscoveryProbe(buf[:n]) {
+				s.answerDiscovery(pc, src)
 				continue
 			}
 			host, _, splitErr := net.SplitHostPort(src.String())

--- a/server-go/internal/httpapi/discovery.go
+++ b/server-go/internal/httpapi/discovery.go
@@ -1,0 +1,180 @@
+// discovery.go — responder UDP de descubrimiento zero-touch (#367).
+//
+// NetGrip (panel on-router con el agente embebido) no tiene config inicial:
+// para encontrarnos emite un probe UDP en broadcast al puerto del listener
+// de beacons. Este responder contesta UNICAST con la URL HTTP real del
+// server (derivada de un socket conectado hacia el prober: en hosts
+// multi-homed es la IP de la interfaz correcta) y, si AGENT_AUTOENROLL=1,
+// con un token de alta de red que /api/agents/pair acepta SOLO para slugs
+// nuevos.
+//
+// Contrato v1:
+//
+//	probe    → {"v":1,"type":"netgrip-probe"}
+//	respuesta→ {"v":1,"type":"netpulse-server","url":"http://IP:PORT",
+//	            "autoenroll":true|false,"pairing_token":"<uuid>"}
+//
+// Seguridad (modelo LAN de confianza, misma decisión consciente que el
+// beacon #291): el token de alta viaja en claro, solo hacia la IP del
+// prober, y únicamente autoriza crear agentes NUEVOS (nunca rotar ni
+// suplantar uno existente: slug ocupado → 409). Rotación automática a las
+// 24 h para acotar la ventana de validez. Rate limit por IP origen igual
+// que la ingesta. Servidores viejos ignoran el probe en silencio (sin
+// campo "type" en su parser de beacons), y este server ignora datagramas
+// que no sean probes.
+package httpapi
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// discoveryProbeV es la única versión de probe aceptada.
+const discoveryProbeV = 1
+
+// discoveryProbe es el datagrama que envía NetGrip en broadcast.
+type discoveryProbe struct {
+	V    int    `json:"v"`
+	Type string `json:"type"`
+}
+
+// isDiscoveryProbe dice si un datagrama crudo es un probe (parse barato;
+// los beacons reales no llevan "type" y devuelven false).
+func isDiscoveryProbe(raw []byte) bool {
+	var p discoveryProbe
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return false
+	}
+	return p.Type == "netgrip-probe" && p.V == discoveryProbeV
+}
+
+// discoveryResponse es la respuesta unicast al prober.
+type discoveryResponse struct {
+	V            int    `json:"v"`
+	Type         string `json:"type"`
+	URL          string `json:"url"`
+	Autoenroll   bool   `json:"autoenroll"`
+	PairingToken string `json:"pairing_token,omitempty"`
+}
+
+// autoenrollTokenTTL: el token de red rota cuando su ts de generación
+// supera esta edad. Ventana acotada: un token filtrado deja de valer solo.
+const autoenrollTokenTTL = 24 * time.Hour
+
+const (
+	autoenrollTokenKey = "autoenroll.token"
+	autoenrollTSKey    = "autoenroll.token.ts"
+)
+
+var autoenrollMu sync.Mutex
+
+// getAutoenrollToken devuelve el token de alta de red vigente, creándolo o
+// rotándolo si no existe o si superó el TTL. La rotación es perezosa (en
+// lectura): no hay timer, y el token previo muere en el mismo instante.
+func (s *server) getAutoenrollToken() (string, error) {
+	autoenrollMu.Lock()
+	defer autoenrollMu.Unlock()
+	var stored string
+	_ = s.db.QueryRow("SELECT COALESCE(value,'') FROM kv WHERE key = ?", autoenrollTokenKey).Scan(&stored)
+	var tsRaw string
+	_ = s.db.QueryRow("SELECT COALESCE(value,'') FROM kv WHERE key = ?", autoenrollTSKey).Scan(&tsRaw)
+	ts := int64(0)
+	if tsRaw != "" {
+		if v, perr := strconv.ParseInt(tsRaw, 10, 64); perr == nil {
+			ts = v
+		}
+	}
+	if stored != "" && ts > 0 &&
+		time.Since(time.Unix(ts, 0)) < autoenrollTokenTTL {
+		return stored, nil
+	}
+	tok, err := newPairingToken()
+	if err != nil {
+		return "", err
+	}
+	now := strconv.FormatInt(time.Now().Unix(), 10)
+	if _, err := s.db.Exec(
+		"INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+		autoenrollTokenKey, tok); err != nil {
+		return "", err
+	}
+	if _, err := s.db.Exec(
+		"INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+		autoenrollTSKey, now); err != nil {
+		return "", err
+	}
+	return tok, nil
+}
+
+// checkAutoenrollToken valida un token contra el vigente (tiempo constante).
+func (s *server) checkAutoenrollToken(token string) bool {
+	if token == "" || !s.autoenrollEnabled() {
+		return false
+	}
+	stored, err := s.getAutoenrollToken()
+	if err != nil || stored == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(token), []byte(stored)) == 1
+}
+
+// autoenrollEnabled: flag de config (nil-safe para tests).
+func (s *server) autoenrollEnabled() bool {
+	return s.cfg != nil && s.cfg.AgentAutoenroll
+}
+
+// answerDiscovery responde unicast al prober con la URL del server y, si
+// procede, el token de alta. La IP de la URL sale de un socket UDP
+// conectado hacia el origen (la ruta elegida dice qué interfaz usar) y el
+// puerto es el HTTP de la config (default 3000 si no hay cfg).
+func (s *server) answerDiscovery(pc net.PacketConn, src net.Addr) {
+	host, _, err := net.SplitHostPort(src.String())
+	if err != nil {
+		host = src.String()
+	}
+	if ok, _ := s.ingestLimit.allow(host); !ok {
+		return
+	}
+	port := 3000
+	if s.cfg != nil && s.cfg.Port > 0 {
+		port = s.cfg.Port
+	}
+	// Socket conectado hacia el prober: LocalAddr lleva la IP de la
+	// interfaz por la que el kernel enrutaría la respuesta.
+	conn, err := net.Dial("udp", src.String())
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	local, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok || local.IP == nil || local.IP.IsUnspecified() {
+		return
+	}
+	resp := discoveryResponse{
+		V:          discoveryProbeV,
+		Type:       "netpulse-server",
+		URL:        fmt.Sprintf("http://%s:%d", local.IP.String(), port),
+		Autoenroll: s.autoenrollEnabled(),
+	}
+	if resp.Autoenroll {
+		tok, err := s.getAutoenrollToken()
+		if err != nil {
+			log.Printf("[netpulse:discovery] token de alta no disponible: %v", err)
+			return
+		}
+		resp.PairingToken = tok
+	}
+	payload, err := json.Marshal(resp)
+	if err != nil {
+		return
+	}
+	if _, err := conn.Write(payload); err != nil {
+		log.Printf("[netpulse:discovery] respuesta a %s: %v", host, err)
+	}
+}

--- a/server-go/internal/httpapi/discovery.go
+++ b/server-go/internal/httpapi/discovery.go
@@ -1,4 +1,4 @@
-// discovery.go — responder UDP de descubrimiento zero-touch (#367).
+// discovery.go: responder UDP de descubrimiento zero-touch (#367).
 //
 // NetGrip (panel on-router con el agente embebido) no tiene config inicial:
 // para encontrarnos emite un probe UDP en broadcast al puerto del listener

--- a/server-go/internal/httpapi/discovery_test.go
+++ b/server-go/internal/httpapi/discovery_test.go
@@ -1,0 +1,184 @@
+// discovery_test.go — #367: responder UDP de descubrimiento y token de alta
+// de red (autoenroll). Tests internos para ejercitar el listener UDP y el
+// handler de pair directamente.
+package httpapi
+
+import (
+	"encoding/json"
+	"net"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/adapters"
+	"github.com/gnacho/netpulse/server-go/internal/config"
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+// newDiscoveryTestServer: server mínimo con cfg configurable (autoenroll y
+// PORT) para el responder UDP.
+func newDiscoveryTestServer(t *testing.T, autoenroll bool) *server {
+	t.Helper()
+	dataDir := t.TempDir()
+	env := map[string]string{
+		"AUTH_USER": "admin", "AUTH_PASS": "test123456",
+		"DEMO_MODE": "0", "DATA_DIR": dataDir, "NODE_ENV": "test",
+		"PORT": "3457",
+	}
+	if autoenroll {
+		env["AGENT_AUTOENROLL"] = "1"
+	}
+	cfg, err := config.Load(env, dataDir)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	d, err := db.Open(dataDir)
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	return &server{
+		cfg:         cfg,
+		db:          d,
+		agents:      adapters.NewAgentRegistry(90 * time.Second),
+		ingestLimit: newIPRateLimit(ingestRateLimit, ingestRateWindow),
+	}
+}
+
+// probeAndWait: envía un probe desde un socket propio y devuelve la
+// respuesta del responder (o falla por timeout).
+func probeAndWait(t *testing.T, addr net.Addr) discoveryResponse {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer pc.Close()
+	if _, err := pc.WriteTo([]byte(`{"v":1,"type":"netgrip-probe"}`), addr); err != nil {
+		t.Fatalf("write probe: %v", err)
+	}
+	buf := make([]byte, 1024)
+	_ = pc.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, _, err := pc.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	var resp discoveryResponse
+	if err := json.Unmarshal(buf[:n], &resp); err != nil {
+		t.Fatalf("unmarshal: %v (%s)", err, buf[:n])
+	}
+	return resp
+}
+
+// pairViaHandler llama a handleAgentPair con un recorder.
+func pairViaHandler(t *testing.T, s *server, pairingToken, slug string) (int, string) {
+	t.Helper()
+	body := `{"pairing_token":` + strconv.Quote(pairingToken) + `,"slug":` + strconv.Quote(slug) + `}`
+	req := httptest.NewRequest("POST", "/api/agents/pair", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.handleAgentPair(rec, req)
+	return rec.Code, rec.Body.String()
+}
+
+func TestDiscoveryProbeDetection(t *testing.T) {
+	if !isDiscoveryProbe([]byte(`{"v":1,"type":"netgrip-probe"}`)) {
+		t.Fatal("probe válido no detectado")
+	}
+	for _, raw := range []string{
+		`{"v":1,"seq":7,"slug":"switch16","token":"x","ports":[]}`,
+		`{"v":1,"type":"otra-cosa"}`,
+		`{"v":2,"type":"netgrip-probe"}`,
+		`no json`,
+	} {
+		if isDiscoveryProbe([]byte(raw)) {
+			t.Fatalf("datagrama no-probe detectado como probe: %s", raw)
+		}
+	}
+}
+
+func TestDiscoveryAnswerWithoutAutoenroll(t *testing.T) {
+	s := newDiscoveryTestServer(t, false)
+	addr, err := s.startBeaconListener("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listener: %v", err)
+	}
+	defer s.beaconConn.Close()
+
+	resp := probeAndWait(t, addr)
+	if resp.Type != "netpulse-server" || resp.V != 1 {
+		t.Fatalf("respuesta: %+v", resp)
+	}
+	if resp.Autoenroll || resp.PairingToken != "" {
+		t.Fatalf("sin AGENT_AUTOENROLL no debe ir token: %+v", resp)
+	}
+	if resp.URL != "http://127.0.0.1:3457" {
+		t.Fatalf("url: %q (esperaba el PORT de la config)", resp.URL)
+	}
+}
+
+func TestDiscoveryAnswerWithAutoenroll(t *testing.T) {
+	s := newDiscoveryTestServer(t, true)
+	addr, err := s.startBeaconListener("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listener: %v", err)
+	}
+	defer s.beaconConn.Close()
+
+	resp := probeAndWait(t, addr)
+	if !resp.Autoenroll || resp.PairingToken == "" {
+		t.Fatalf("con AGENT_AUTOENROLL debe ir token: %+v", resp)
+	}
+
+	// El token de red crea un slug nuevo...
+	status, body := pairViaHandler(t, s, resp.PairingToken, "router-nuevo")
+	if status != 201 || !strings.Contains(body, `"token"`) {
+		t.Fatalf("pair con token de red: %d %s", status, body)
+	}
+	// ...pero NO puede tocar un slug existente.
+	status, body = pairViaHandler(t, s, resp.PairingToken, "router-nuevo")
+	if status != 409 || !strings.Contains(body, "slug_taken") {
+		t.Fatalf("pair repetido con token de red: %d %s", status, body)
+	}
+	// Token desconocido: 401.
+	status, _ = pairViaHandler(t, s, "token-falso", "otro")
+	if status != 401 {
+		t.Fatalf("token falso: %d", status)
+	}
+	// El pairing token de admin sigue rotando slugs existentes.
+	adminTok, err := s.getPairingToken()
+	if err != nil {
+		t.Fatalf("admin token: %v", err)
+	}
+	status, _ = pairViaHandler(t, s, adminTok, "router-nuevo")
+	if status != 201 {
+		t.Fatalf("admin pair sobre slug existente: %d", status)
+	}
+}
+
+func TestAutoenrollTokenStableAndRotatable(t *testing.T) {
+	s := newDiscoveryTestServer(t, true)
+	t1, err := s.getAutoenrollToken()
+	if err != nil || t1 == "" {
+		t.Fatalf("token 1: %v %q", err, t1)
+	}
+	t2, err := s.getAutoenrollToken()
+	if err != nil || t2 != t1 {
+		t.Fatalf("el token debe ser estable dentro del TTL: %q vs %q", t1, t2)
+	}
+	// Simular expiración: borrar el ts → rota en la siguiente lectura.
+	if _, err := s.db.Exec("DELETE FROM kv WHERE key = ?", autoenrollTSKey); err != nil {
+		t.Fatalf("delete ts: %v", err)
+	}
+	t3, err := s.getAutoenrollToken()
+	if err != nil || t3 == "" || t3 == t1 {
+		t.Fatalf("tras expirar debe rotar: %q", t3)
+	}
+	// Con el flag apagado, checkAutoenrollToken nunca acepta.
+	s.cfg.AgentAutoenroll = false
+	if s.checkAutoenrollToken(t3) {
+		t.Fatal("checkAutoenrollToken debe rechazar con el flag apagado")
+	}
+}

--- a/server-go/internal/httpapi/discovery_test.go
+++ b/server-go/internal/httpapi/discovery_test.go
@@ -1,4 +1,4 @@
-// discovery_test.go — #367: responder UDP de descubrimiento y token de alta
+// discovery_test.go: #367 responder UDP de descubrimiento y token de alta
 // de red (autoenroll). Tests internos para ejercitar el listener UDP y el
 // handler de pair directamente.
 package httpapi

--- a/server-go/internal/httpapi/pairing.go
+++ b/server-go/internal/httpapi/pairing.go
@@ -101,6 +101,12 @@ type pairResponse struct {
 
 // handleAgentPair (POST /api/agents/pair): valida el pairing token y crea un
 // agente nuevo. No requiere sesión (el pairing token es la auth). Rate limited.
+//
+// #367: además del pairing token de admin (crea o ROTA el agente del slug),
+// acepta el token de alta de red del autoenroll cuando AGENT_AUTOENROLL=1.
+// El token de red SOLO puede crear agentes para slugs que no existan: si el
+// slug ya tiene token, responde 409 slug_taken (un router descubierto nunca
+// puede suplantar ni rotar el agente de otro).
 func (s *server) handleAgentPair(w http.ResponseWriter, r *http.Request) {
 	ip := auth.ClientIP(r)
 	if ok, _ := s.ingestLimit.allow(ip); !ok {
@@ -120,15 +126,28 @@ func (s *server) handleAgentPair(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validar pairing token contra el almacenado.
+	// Validar el token: primero el pairing token de admin (semántica
+	// completa: crear o rotar), después el token de red del autoenroll
+	// (solo creación de slugs nuevos).
 	stored, err := s.getPairingToken()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "pairing_error")
 		return
 	}
-	if stored == "" || subtle.ConstantTimeCompare([]byte(body.PairingToken), []byte(stored)) != 1 {
-		writeError(w, http.StatusUnauthorized, "invalid_pairing_token")
-		return
+	adminToken := stored != "" && subtle.ConstantTimeCompare([]byte(body.PairingToken), []byte(stored)) == 1
+	if !adminToken {
+		if !s.checkAutoenrollToken(body.PairingToken) {
+			writeError(w, http.StatusUnauthorized, "invalid_pairing_token")
+			return
+		}
+		var existing string
+		_ = s.db.QueryRow(
+			"SELECT COALESCE(value,'') FROM kv WHERE key = ?", agentTokenKey(body.Slug)).Scan(&existing)
+		if existing != "" {
+			writeError(w, http.StatusConflict, "slug_taken",
+				"el slug ya tiene un agente; el autoenroll no puede rotarlo (renombra el equipo o usa el pairing token de admin)")
+			return
+		}
 	}
 
 	// Crear el agente (mismo flujo que POST /api/agents).


### PR DESCRIPTION
Standalone agents answer a UDP discovery probe and can autoenroll with a server token, removing manual slug/token setup on new routers. Includes the contract documentation.

Closes #367