### PR TITLE
Standalone agent detects NetGrip on the same router and yields

### DIFF
--- a/agent/cmd/netpulse-agent/main.go
+++ b/agent/cmd/netpulse-agent/main.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/gnacho/netpulse/agent/internal/yield"
 	"github.com/gnacho/netpulse/agent/runtime"
 )
 
@@ -64,6 +65,17 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
+
+	// #369: si NetGrip está en este router, su agente embebido (este mismo
+	// runtime dentro del panel) es el que manda: ceder ANTES de arrancar y
+	// luego vigilar por si se instala más tarde. El guard vive SOLO en el
+	// standalone: el runtime queda agnóstico del sabor (ver imports_test).
+	yp := yield.DefaultPaths()
+	if yield.NetgripPresent(yp) {
+		yield.Yield(yp, yield.ReasonStartup, nil)
+		return
+	}
+	go yield.Watch(ctx, yp, yield.Interval, stop)
 
 	if err := runtime.Run(ctx, opts); err != nil {
 		slog.Error("[netpulse-agent] error fatal", "err", err)

--- a/agent/internal/yield/yield.go
+++ b/agent/internal/yield/yield.go
@@ -1,0 +1,196 @@
+// Package yield: ceder el paso a NetGrip (#369). El agente STANDALONE
+// (cmd/netpulse-agent) NO debe convivir con el agente embebido de NetGrip:
+// si ambos corren, pushean dos veces para el mismo slug. NetGrip ya detecta
+// y retira el standalone desde SU lado; este paquete es la protección
+// contraria: el standalone detecta NetGrip y se retira solo.
+//
+// Vive en agent/internal a propósito: el runtime (agent/runtime) lo comparten
+// el standalone y el agente embebido de NetGrip, y el sabor embebido NUNCA
+// debe ceder. Al ser internal, solo el módulo del agente puede importarlo:
+// NetGrip (otro módulo, que consume runtime) no tiene forma de llegar aquí
+// aunque quiera, y runtime no lo referencia (guardado por test de imports).
+package yield
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Interval por defecto del chequeo periódico.
+const Interval = 60 * time.Second
+
+// ReasonStartup / ReasonPeriodic: motivos que quedan anotados en el fichero
+// de estado y en los logs.
+const (
+	ReasonStartup  = "netgrip detected on this router at startup"
+	ReasonPeriodic = "netgrip detected on this router (periodic check)"
+)
+
+// Paths: rutas que usa la detección y la cedida (inyectables en tests).
+type Paths struct {
+	NetgripInit string // /etc/init.d/netgrip
+	NetgripBin  string // /usr/sbin/netgrip
+	SelfInit    string // /etc/init.d/netpulse-agent (propio; puede no existir)
+	StateFile   string // /tmp/netpulse-agent.yielded
+	ProcRoot    string // /proc (escaneo de procesos; "" = sin escanear)
+	CronFile    string // /etc/crontabs/root (línea del watchdog)
+}
+
+// DefaultPaths: rutas de producción en el router.
+func DefaultPaths() Paths {
+	return Paths{
+		NetgripInit: "/etc/init.d/netgrip",
+		NetgripBin:  "/usr/sbin/netgrip",
+		SelfInit:    "/etc/init.d/netpulse-agent",
+		StateFile:   "/tmp/netpulse-agent.yielded",
+		ProcRoot:    "/proc",
+		CronFile:    "/etc/crontabs/root",
+	}
+}
+
+// runCmd inyectable (tests registran los comandos sin ejecutarlos).
+var runCmd = func(name string, args ...string) error {
+	out, err := exec.Command(name, args...).CombinedOutput()
+	if err != nil {
+		slog.Warn("[netpulse-agent] yield cmd falló", "cmd", name, "err", err, "out", strings.TrimSpace(string(out)))
+	}
+	return err
+}
+
+// NetgripPresent: true si hay señales de NetGrip en este router: su init.d,
+// su binario o un proceso netgrip vivo. Barato: dos stat y, solo si ambos
+// fallan, un escaneo de /proc (nombres de proceso, sin tocar cmdline).
+func NetgripPresent(p Paths) bool {
+	if fileExists(p.NetgripInit) || fileExists(p.NetgripBin) {
+		return true
+	}
+	return procHasNetgrip(p.ProcRoot)
+}
+
+// procHasNetgrip escanea <procRoot>/*/comm buscando "netgrip" (comm trunca a
+// 15 chars; "netgrip" entra entero). procRoot vacío desactiva el escaneo.
+func procHasNetgrip(procRoot string) bool {
+	if procRoot == "" {
+		return false
+	}
+	entries, err := os.ReadDir(procRoot)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := strconv.Atoi(e.Name()); err != nil {
+			continue
+		}
+		comm, err := os.ReadFile(filepath.Join(procRoot, e.Name(), "comm"))
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(string(comm)) == "netgrip" {
+			return true
+		}
+	}
+	return false
+}
+
+// Yield ejecuta la cedida (idempotente y mejor esfuerzo):
+//  1. aviso claro en el log (visible en logread),
+//  2. fichero de estado con motivo y ts (para NetGrip o un humano),
+//  3. retira la línea del watchdog del crontab (si no, el cron relanza el
+//     agente cada 2 min y la cedida no termina),
+//  4. disable + stop del propio init.d. El binario NO se autodesinstala:
+//     los ficheros quedan (NetGrip los retira en su siguiente recheck, y un
+//     humano puede re-activar el standalone si algún día se desinstala
+//     NetGrip; el servicio queda disabled hasta entonces).
+//
+// cancel (opcional) se invoca al final para que el bucle principal del
+// agente devuelva el control si el stop de procd no nos mata antes.
+func Yield(p Paths, reason string, cancel func()) {
+	slog.Warn("[netpulse-agent] netgrip detected: embedded netpulse agent takes over, stopping standalone")
+	writeStateFile(p.StateFile, reason)
+	removeCronWatchdog(p.CronFile)
+	if fileExists(p.SelfInit) {
+		_ = runCmd(p.SelfInit, "disable")
+		_ = runCmd(p.SelfInit, "stop")
+	}
+	if cancel != nil {
+		cancel()
+	}
+}
+
+// writeStateFile: motivo + ts en dos líneas KEY=VALUE (tmpfs: muere al
+// reiniciar, que es cuando la detección volvería a evaluarse).
+func writeStateFile(path, reason string) {
+	if path == "" {
+		return
+	}
+	content := "yielded=1\nts=" + time.Now().UTC().Format(time.RFC3339) + "\nreason=" + reason + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		slog.Warn("[netpulse-agent] yield: escribir estado falló", "file", path, "err", err)
+	}
+}
+
+// removeCronWatchdog borra las líneas del watchdog del standalone del
+// crontab conservando el resto (mismo criterio que el cleanup de NetGrip).
+func removeCronWatchdog(path string) {
+	if path == "" {
+		return
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	var kept []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(line, "netpulse-watchdog") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	out := strings.Join(kept, "\n")
+	if out == string(data) {
+		return
+	}
+	mode := os.FileMode(0o600)
+	if st, err := os.Stat(path); err == nil {
+		mode = st.Mode().Perm()
+	}
+	if err := os.WriteFile(path, []byte(out), mode); err != nil {
+		slog.Warn("[netpulse-agent] yield: limpiar cron falló", "file", path, "err", err)
+	}
+}
+
+// Watch: chequeo periódico de NetgripPresent. Al primer hallazgo ejecuta la
+// cedida y termina (no repite: el proceso o muere o su ctx se cancela).
+// Sin NetGrip no hace nada salvo volver a mirar cada every.
+func Watch(ctx context.Context, p Paths, every time.Duration, cancel func()) {
+	if every <= 0 {
+		every = Interval
+	}
+	t := time.NewTicker(every)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if NetgripPresent(p) {
+				Yield(p, ReasonPeriodic, cancel)
+				return
+			}
+		}
+	}
+}
+
+func fileExists(path string) bool {
+	st, err := os.Stat(path)
+	return err == nil && !st.IsDir()
+}

--- a/agent/internal/yield/yield_test.go
+++ b/agent/internal/yield/yield_test.go
@@ -1,0 +1,230 @@
+// yield_test.go: detección, cedida, idempotencia y garantía de que el sabor
+// embebido (runtime) nunca depende de este paquete (#369).
+package yield
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeProc monta un /proc falso con un proceso por nombre.
+func fakeProc(t *testing.T, names map[int]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for pid, name := range names {
+		dir := filepath.Join(root, strconv.Itoa(pid))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "comm"), []byte(name+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func touch(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestNetgripPresentFiles: init.d o binario de netgrip cuentan como presencia.
+func TestNetgripPresentFiles(t *testing.T) {
+	dir := t.TempDir()
+	p := Paths{
+		NetgripInit: filepath.Join(dir, "init.d", "netgrip"),
+		NetgripBin:  filepath.Join(dir, "sbin", "netgrip"),
+		ProcRoot:    "", // sin /proc: aislado del host de CI
+	}
+	if NetgripPresent(p) {
+		t.Fatal("sin ficheros ni /proc no debería detectar")
+	}
+	touch(t, p.NetgripBin)
+	if !NetgripPresent(p) {
+		t.Fatal("el binario de netgrip debería detectarse")
+	}
+	os.Remove(p.NetgripBin)
+	touch(t, p.NetgripInit)
+	if !NetgripPresent(p) {
+		t.Fatal("el init.d de netgrip debería detectarse")
+	}
+}
+
+// TestNetgripPresentProc: proceso vivo por comm (ficheros ausentes).
+func TestNetgripPresentProc(t *testing.T) {
+	proc := fakeProc(t, map[int]string{1: "procd", 42: "netgrip", 99: "netpulse-agent"})
+	p := Paths{ProcRoot: proc}
+	if !NetgripPresent(p) {
+		t.Fatal("el proceso netgrip debería detectarse por comm")
+	}
+	p.ProcRoot = fakeProc(t, map[int]string{1: "procd", 99: "netpulse-agent"})
+	if NetgripPresent(p) {
+		t.Fatal("sin netgrip en /proc no debería detectar")
+	}
+}
+
+// TestYieldFull: fichero de estado, orden disable->stop del init propio y
+// limpieza de la línea del watchdog del cron.
+func TestYieldFull(t *testing.T) {
+	dir := t.TempDir()
+	selfInit := filepath.Join(dir, "init.d", "netpulse-agent")
+	touch(t, selfInit)
+	cron := filepath.Join(dir, "crontabs", "root")
+	touch(t, cron)
+	if err := os.WriteFile(cron, []byte("*/5 * * * * /usr/sbin/algo\n*/2 * * * * /usr/sbin/netpulse-watchdog\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p := Paths{
+		SelfInit:  selfInit,
+		StateFile: filepath.Join(dir, "netpulse-agent.yielded"),
+		ProcRoot:  "",
+		CronFile:  cron,
+	}
+
+	var cmds [][]string
+	origRun := runCmd
+	runCmd = func(name string, args ...string) error {
+		cmds = append(cmds, append([]string{name}, args...))
+		return nil
+	}
+	cancelled := false
+	defer func() { runCmd = origRun }()
+
+	Yield(p, "prueba", func() { cancelled = true })
+
+	if !cancelled {
+		t.Fatal("cancel debería invocarse al final de la cedida")
+	}
+	data, err := os.ReadFile(p.StateFile)
+	if err != nil {
+		t.Fatal("el fichero de estado debería existir tras la cedida")
+	}
+	if !strings.HasPrefix(string(data), "yielded=1\n") || !strings.Contains(string(data), "reason=prueba") {
+		t.Fatalf("contenido inesperado del estado: %q", data)
+	}
+	// orden exacto: disable antes que stop (si stop mata el proceso, el
+	// disable ya quedó aplicado)
+	if len(cmds) != 2 || cmds[0][1] != "disable" || cmds[1][1] != "stop" {
+		t.Fatalf("comandos inesperados: %v", cmds)
+	}
+	cronData, _ := os.ReadFile(cron)
+	if strings.Contains(string(cronData), "netpulse-watchdog") {
+		t.Fatalf("la línea del watchdog debería desaparecer del cron: %q", cronData)
+	}
+	if !strings.Contains(string(cronData), "/usr/sbin/algo") {
+		t.Fatal("el resto del cron debería conservarse")
+	}
+}
+
+// TestYieldIdempotente: una segunda cedida no rompe nada (estado se
+// reescribe, comandos se repiten pero todo es mejor esfuerzo).
+func TestYieldIdempotente(t *testing.T) {
+	dir := t.TempDir()
+	selfInit := filepath.Join(dir, "init.d", "netpulse-agent")
+	touch(t, selfInit)
+	p := Paths{SelfInit: selfInit, StateFile: filepath.Join(dir, "y"), ProcRoot: "", CronFile: ""}
+	var n int
+	origRun := runCmd
+	runCmd = func(name string, args ...string) error { n++; return nil }
+	defer func() { runCmd = origRun }()
+
+	Yield(p, "uno", nil)
+	Yield(p, "dos", nil)
+	if n != 4 {
+		t.Fatalf("dos cedidas = 4 comandos, hubo %d", n)
+	}
+	data, _ := os.ReadFile(p.StateFile)
+	if !strings.Contains(string(data), "reason=dos") {
+		t.Fatal("la segunda cedida debería reescribir el motivo")
+	}
+}
+
+// TestYieldSinInit: agente manual (sin init.d propio): no ejecuta comandos,
+// pero sí escribe estado y cancela.
+func TestYieldSinInit(t *testing.T) {
+	dir := t.TempDir()
+	p := Paths{SelfInit: filepath.Join(dir, "no-existe"), StateFile: filepath.Join(dir, "y"), ProcRoot: "", CronFile: ""}
+	var n int
+	origRun := runCmd
+	runCmd = func(name string, args ...string) error { n++; return nil }
+	defer func() { runCmd = origRun }()
+	cancelled := false
+	Yield(p, "manual", func() { cancelled = true })
+	if n != 0 {
+		t.Fatal("sin init.d propio no debería lanzar comandos")
+	}
+	if !cancelled || !fileExists(p.StateFile) {
+		t.Fatal("debería escribir estado y cancelar igualmente")
+	}
+}
+
+// TestWatchSinNetgripNuncaCede: sin señales de netgrip, Watch termina solo
+// por ctx y NO ejecuta la cedida.
+func TestWatchSinNetgripNuncaCede(t *testing.T) {
+	dir := t.TempDir()
+	p := Paths{
+		NetgripInit: filepath.Join(dir, "ninguna"),
+		NetgripBin:  filepath.Join(dir, "ninguno"),
+		StateFile:   filepath.Join(dir, "y"),
+		ProcRoot:    "",
+		CronFile:    "",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { time.Sleep(150 * time.Millisecond); cancel() }()
+	start := time.Now()
+	Watch(ctx, p, 30*time.Millisecond, func() { t.Error("cancel no debería invocarse sin netgrip") })
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("Watch debería terminar con el ctx, tardó %s", elapsed)
+	}
+	if fileExists(p.StateFile) {
+		t.Fatal("sin netgrip no debería escribirse el estado de cedida")
+	}
+}
+
+// TestWatchCedeAlDetectar: netgrip aparece a mitad de ejecución -> cedida.
+func TestWatchCedeAlDetectar(t *testing.T) {
+	dir := t.TempDir()
+	netgripBin := filepath.Join(dir, "sbin", "netgrip")
+	p := Paths{
+		NetgripInit: filepath.Join(dir, "init.d", "netgrip"),
+		NetgripBin:  netgripBin,
+		StateFile:   filepath.Join(dir, "y"),
+		ProcRoot:    "",
+		CronFile:    "",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { Watch(ctx, p, 30*time.Millisecond, cancel); close(done) }()
+
+	time.Sleep(60 * time.Millisecond) // un par de ticks sin netgrip
+	if fileExists(p.StateFile) {
+		t.Fatal("aún no hay netgrip: no debería haber cedido")
+	}
+	touch(t, netgripBin) // netgrip se instala en caliente
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Watch debería ceder tras detectar netgrip")
+	}
+	data, err := os.ReadFile(p.StateFile)
+	if err != nil {
+		t.Fatal("el estado de cedida debería existir")
+	}
+	if !strings.Contains(string(data), ReasonPeriodic) {
+		t.Fatalf("motivo inesperado: %q", data)
+	}
+	if ctx.Err() == nil {
+		t.Fatal("el ctx del agente debería quedar cancelado tras la cedida")
+	}
+}

--- a/agent/runtime/imports_test.go
+++ b/agent/runtime/imports_test.go
@@ -1,0 +1,23 @@
+// imports_test.go (#369): garantía arquitectural de que el runtime compartido
+// NUNCA depende del paquete de cedida. El runtime lo consumen el standalone
+// y el agente embebido de NetGrip; si llegara a importar internal/yield, el
+// sabor embebido podría ceder el paso a sí mismo. Además, al ser internal,
+// NetGrip (otro módulo) no puede importarlo: esta prueba cierra la puerta
+// que quedaría dentro de nuestro propio módulo.
+package runtime_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestRuntimeDoesNotImportYield(t *testing.T) {
+	out, err := exec.Command("go", "list", "-deps", ".").CombinedOutput()
+	if err != nil {
+		t.Skipf("go list no disponible: %v (%s)", err, strings.TrimSpace(string(out)))
+	}
+	if strings.Contains(string(out), "internal/yield") {
+		t.Fatal("agent/runtime no debe depender de internal/yield: el agente embebido de NetGrip usa este runtime y NUNCA debe ceder")
+	}
+}


### PR DESCRIPTION
The standalone agent checks for a local NetGrip install and stops itself instead of double-pushing alongside the embedded agent (mirrors the installer/apk handoff on the NetGrip side).

Closes #369