### PR TITLE
fix(landing): add Umami analytics tracker

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -843,5 +843,6 @@
 
   <script src="i18n.js?v=20260828a"></script>
   <script src="app.js?v=20260828a"></script>
+<script defer src="https://stat.domatix.com/script.js" data-website-id="b9a57c48-cfbb-59fb-af00-e21b868371d9"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds the stat.domatix.com tracker to the landing page so visits are recorded in Umami.\n\nCloses #384