### PR TITLE
fix: sync update banner with Settings manual check

### DIFF
--- a/app/src/components/UpdateBanner.tsx
+++ b/app/src/components/UpdateBanner.tsx
@@ -30,9 +30,9 @@ interface UpdateStatus {
   readiness?: UpdateReadiness | null
 }
 
+import { CHECK_INTERVAL, CHECK_KEY, onBannerSignal } from '@/lib/update-check'
+
 const POLL_MS = 60 * 60 * 1000
-const WEEK_MS = 7 * 24 * 60 * 60 * 1000
-const CHECK_KEY = 'netpulse-last-update-check'
 
 export function UpdateBanner() {
   const { t } = useTranslation()
@@ -62,7 +62,7 @@ export function UpdateBanner() {
     const shouldCheck = () => {
       try {
         const last = Number(localStorage.getItem(CHECK_KEY) || 0)
-        return !last || Date.now() - last > WEEK_MS
+        return !last || Date.now() - last > CHECK_INTERVAL
       } catch {
         return true
       }
@@ -78,7 +78,8 @@ export function UpdateBanner() {
     }
     run()
     const id = window.setInterval(run, POLL_MS)
-    return () => window.clearInterval(id)
+    const off = onBannerSignal(() => void fetchStatus())
+    return () => { window.clearInterval(id); off() }
   }, [auth?.role, fetchStatus])
 
   // Al cerrar el asistente: refrescar (si la actualización sigue en curso,

--- a/app/src/lib/update-check.ts
+++ b/app/src/lib/update-check.ts
@@ -1,0 +1,23 @@
+const CHECK_KEY = 'netpulse-last-update-check'
+const CHECK_INTERVAL = 4 * 60 * 60 * 1000
+const EVENT_NAME = 'netpulse-update-available'
+
+export { CHECK_KEY, CHECK_INTERVAL }
+
+export function invalidateThrottle(): void {
+  try { localStorage.removeItem(CHECK_KEY) } catch { /* no storage */ }
+}
+
+export function notifyBanner(latest: string): void {
+  invalidateThrottle()
+  window.dispatchEvent(new CustomEvent(EVENT_NAME, { detail: { latest } }))
+}
+
+export function onBannerSignal(cb: (latest: string) => void): () => void {
+  const handler = (e: Event) => {
+    const detail = (e as CustomEvent<{ latest: string }>).detail
+    if (detail?.latest) cb(detail.latest)
+  }
+  window.addEventListener(EVENT_NAME, handler)
+  return () => window.removeEventListener(EVENT_NAME, handler)
+}

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -60,6 +60,7 @@ import { useServicesVisibility } from '@/hooks/useServicesVisibility'
 import type { ServicesVisibility } from '@/hooks/useServicesVisibility'
 import { relTimeFromTs } from '@/i18n'
 import { cn, exitDemo } from '@/lib/utils'
+import { notifyBanner } from '@/lib/update-check'
 import { ACCENTS, PALETTES, type AccentId, type PaletteId, type ThemeMode } from '@/lib/theme-boot'
 import TelegramCard from '@/components/TelegramCard'
 import pkg from '../../package.json'
@@ -2219,7 +2220,9 @@ function UpdateCheckInline() {
     try {
       const res = await fetch('/api/update/status')
       if (!res.ok) throw new Error('status')
-      setStatus((await res.json()) as NetPulseUpdateStatus)
+      const data = (await res.json()) as NetPulseUpdateStatus
+      setStatus(data)
+      if (data.updateAvailable && data.latest) notifyBanner(data.latest)
     } catch {
       setError(true)
     } finally {


### PR DESCRIPTION
Closes #392

**Problem**: The global UpdateBanner has a 7-day localStorage throttle that is never invalidated by the Settings manual check.

**Fix**:
- Shared module `app/src/lib/update-check.ts` with constants, throttle invalidation, and CustomEvent bus
- Settings UpdateCheckInline calls `notifyBanner()` on `updateAvailable: true`
- UpdateBanner listens for the signal and re-fetches status immediately
- Throttle reduced from 7 days to 4 hours