### PR TITLE
fix(ui): make alert feed text selectable and copyable (#393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 ## [Unreleased]
 
+### Fixed
+
+- **Texto seleccionable en el feed de alertas (#393)**: las filas del feed de `/alerts` renderizaban todo su contenido dentro de un `<button>`, y los navegadores desactivan la selección de texto dentro de los botones. La fila pasa a ser un `div role="button"` (Enter/Espacio siguen funcionando) con un guard por movimiento de puntero: arrastrar para seleccionar no despliega la alerta, un click normal sí. Corrige además el anidado inválido de botones (silenciar dentro de la fila).
+
 ### Added
 
 - **Delegación de planes a NetGrip (#339)**: si un router tiene un executor token de NetGrip (enviado con el snapshot en #340), `POST /api/plans/{id}/apply` delega la ejecución de las ops a NetGrip vía `POST /api/executor/apply`. Si NetGrip no responde, se mantiene el fallback al agente embebido por SSE.

--- a/app/src/pages/Alerts.tsx
+++ b/app/src/pages/Alerts.tsx
@@ -252,6 +252,9 @@ function FeedRow({ ev, index, read, expanded, onToggle, reduce, onSilence }: Fee
   const sev = SEVERITY[ev.severity]
   const Icon = ev.icon ?? sev.icon
   const [showSilence, setShowSilence] = useState(false)
+  // #393: posición del pointerdown para distinguir click (sin movimiento →
+  // togglear) de arrastre de selección de texto (movimiento → no togglear).
+  const downAt = useRef<{ x: number; y: number } | null>(null)
   return (
     <motion.li
       initial={reduce ? false : { opacity: 0, y: 14 }}
@@ -271,13 +274,16 @@ function FeedRow({ ev, index, read, expanded, onToggle, reduce, onSilence }: Fee
 
       {/* #393: div role=button (no <button>) para permitir seleccionar/copiar
           el texto de la alerta; los navegadores desactivan la selección dentro
-          de los <button>. Guard en click: no togglear si acaba de seleccionarse
-          texto. Teclado: Enter/Espacio como un botón real. */}
+          de los <button>. Guard por movimiento: un click (≤4 px entre
+          pointerdown y click) togglear; un arrastre de selección no. Teclado:
+          Enter/Espacio como un botón real. */}
       <div
         role="button"
         tabIndex={0}
-        onClick={() => {
-          if (window.getSelection()?.toString()) return
+        onPointerDown={(e) => { downAt.current = { x: e.clientX, y: e.clientY } }}
+        onClick={(e) => {
+          const d = downAt.current
+          if (d && Math.hypot(e.clientX - d.x, e.clientY - d.y) > 4) return
           onToggle()
         }}
         onKeyDown={(e) => {

--- a/app/src/pages/Alerts.tsx
+++ b/app/src/pages/Alerts.tsx
@@ -269,12 +269,26 @@ function FeedRow({ ev, index, read, expanded, onToggle, reduce, onSilence }: Fee
         <Icon className="h-5 w-5" strokeWidth={1.75} />
       </span>
 
-      <button
-        type="button"
-        onClick={onToggle}
+      {/* #393: div role=button (no <button>) para permitir seleccionar/copiar
+          el texto de la alerta; los navegadores desactivan la selección dentro
+          de los <button>. Guard en click: no togglear si acaba de seleccionarse
+          texto. Teclado: Enter/Espacio como un botón real. */}
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => {
+          if (window.getSelection()?.toString()) return
+          onToggle()
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            onToggle()
+          }
+        }}
         aria-expanded={expanded}
         className={cn(
-          'group flex w-full items-center gap-3 rounded-xl border-l-[3px] px-3 py-3 text-left transition-colors duration-150 hover:bg-hover',
+          'group flex w-full cursor-pointer select-text items-center gap-3 rounded-xl border-l-[3px] px-3 py-3 text-left transition-colors duration-150 hover:bg-hover focus-visible:outline-2 focus-visible:outline-accent',
           sev.stripe,
           !read && 'bg-elevated',
         )}
@@ -328,7 +342,7 @@ function FeedRow({ ev, index, read, expanded, onToggle, reduce, onSilence }: Fee
           className={cn('h-4 w-4 shrink-0 text-text-muted transition-transform duration-200', expanded && 'rotate-90')}
           strokeWidth={1.75}
         />
-      </button>
+      </div>
 
       {/* Silence options popup */}
       {showSilence && onSilence && (


### PR DESCRIPTION
The whole feed row (title, description, hint) rendered inside a `<button>`, and browsers disable text selection inside buttons by design.

- Replace the outer button with a `div role=button`: select-text + cursor-pointer, Enter/Space still toggle it (keyboard parity with a real button).
- Pointer-movement guard: a drag beyond 4px (text selection) does not toggle the row; a plain click does. A first attempt used selection-presence, but Chromium can deliver the click while the old selection is still observable, swallowing legitimate clicks.
- Also fixes invalid nested buttons (the silence button inside the row button).

Verified with Playwright in demo mode (5/5): drag selects text, row does not toggle after selection, plain click expands, copy works. Deployed and validated on the live CT.

Closes #393