### PR TITLE
feat(orchestr): delegate plan rollback to the NetGrip executor (#397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 ## [Unreleased]
 
+### Added
+
+- **Rollback de planes delegado a NetGrip (#397)**: `POST /api/plans/{id}/rollback` ahora delega las ops inversas al executor de NetGrip cuando el router tiene executor token (mismo criterio que el apply), asentando el plan como `rolled_back` vía la máquina de estados existente. El fallback al agente embebido por SSE se mantiene.
+
 ## [2.20.0] - 2026-08-30
 
 ### Added

--- a/server-go/internal/httpapi/orchestr.go
+++ b/server-go/internal/httpapi/orchestr.go
@@ -128,9 +128,11 @@ func (s *server) registerOrchestrRoutes(mux *http.ServeMux, mgr *orchestr.Manage
 	//
 	// Calcula el "desired inverso" del módulo (p. ej. AdGuard: si el plan era
 	// enabled=true, el inverso es enabled=false), vuelve a sondear el router
-	// (para detectar el escenario actual) y envía las Ops inversas al agente
-	// vía SSE. El agente las ejecuta con su snapshot+healthcheck+rollback
-	// automático. El resultado llega por POST /api/agents/{slug}/apply-result.
+	// (para detectar el escenario actual) y envía las Ops inversas. #397: si el
+	// router tiene executor token de NetGrip, se delegan las Ops inversas a su
+	// API local (snapshot+healthcheck+rollback probados); si NetGrip no está
+	// configurado o no responde, se envían al agente vía SSE como antes. El
+	// resultado SSE llega por POST /api/agents/{slug}/apply-result.
 	mux.Handle("POST /api/plans/{id}/rollback", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("id")
 		plan, err := mgr.GetPlan(id)
@@ -154,6 +156,28 @@ func (s *server) registerOrchestrRoutes(mux *http.ServeMux, mgr *orchestr.Manage
 			s.writeModuleErr(w, err)
 			return
 		}
+		user := auth.UserFromContext(r.Context())
+		actor := ""
+		if user != nil {
+			actor = user.Username
+		}
+		// #397: delegar el rollback al executor de NetGrip si está configurado
+		// (mismo criterio que el apply). Éxito → SetRollingBack + SetResult;
+		// la máquina de estados traduce el resultado applied a rolled_back
+		// cuando el estado previo es rolling_back.
+		if ok, ngErr := s.applyViaNetGrip(plan.RouterID, plan.ID, diff); ngErr != nil {
+			writeError(w, http.StatusBadGateway, "netgrip_error", ngErr.Error())
+			return
+		} else if ok {
+			if err := mgr.SetRollingBack(id, actor); err != nil {
+				log.Printf("[netpulse] error marcando plan rolling_back vía NetGrip: %v", err)
+			}
+			if err := mgr.SetResult(id, netgripApplyResult()); err != nil {
+				log.Printf("[netpulse] error asentando rollback vía NetGrip: %v", err)
+			}
+			writeJSON(w, http.StatusAccepted, map[string]string{"status": "rolling_back", "planId": id})
+			return
+		}
 		if s.agentHub == nil {
 			writeError(w, http.StatusServiceUnavailable, "no_agent_hub")
 			return
@@ -164,11 +188,6 @@ func (s *server) registerOrchestrRoutes(mux *http.ServeMux, mgr *orchestr.Manage
 			writeError(w, http.StatusServiceUnavailable, "agent_not_connected",
 				"El agente no está conectado vía SSE")
 			return
-		}
-		user := auth.UserFromContext(r.Context())
-		actor := ""
-		if user != nil {
-			actor = user.Username
 		}
 		mgr.SetRollingBack(id, actor)
 		writeJSON(w, http.StatusAccepted, map[string]string{"status": "rolling_back", "planId": id})

--- a/server-go/internal/httpapi/orchestr_netgrip_rollback_test.go
+++ b/server-go/internal/httpapi/orchestr_netgrip_rollback_test.go
@@ -1,0 +1,158 @@
+// orchestr_netgrip_rollback_test.go — regresión #397: el rollback delega al
+// executor de NetGrip cuando el router tiene executor token, y el plan queda
+// rolled_back (SetRollingBack + SetResult).
+package httpapi_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/agent/executor"
+	"github.com/gnacho/netpulse/server-go/internal/adapters"
+	"github.com/gnacho/netpulse/server-go/internal/apitoken"
+	"github.com/gnacho/netpulse/server-go/internal/auth"
+	"github.com/gnacho/netpulse/server-go/internal/config"
+	"github.com/gnacho/netpulse/server-go/internal/configbackup"
+	"github.com/gnacho/netpulse/server-go/internal/db"
+	"github.com/gnacho/netpulse/server-go/internal/httpapi"
+	"github.com/gnacho/netpulse/server-go/internal/orchestr"
+	"github.com/gnacho/netpulse/server-go/internal/routerstore"
+	"github.com/gnacho/netpulse/server-go/internal/sse"
+)
+
+// fakeProbeSSH responde al probe de guestwifi con secciones vacías (sin guest
+// configurado) y registra las llamadas.
+type fakeProbeSSH struct{}
+
+func (fakeProbeSSH) Run(host, cmd string, _ time.Duration) (string, error) {
+	if strings.Contains(cmd, "===WIRELESS===") {
+		return "===WIRELESS===\n===NETWORK===\n===FIREWALL===\n===END===", nil
+	}
+	return "", nil
+}
+
+func TestRollbackDelegatesToNetGrip(t *testing.T) {
+	// Server a medida: igual que makeTestServer pero con Pool (fakeProbeSSH)
+	// para que computeModuleDiff pueda sondear el escenario sin SSH real.
+	dataDir := t.TempDir()
+	cfg, err := config.Load(map[string]string{
+		"AUTH_USER": "admin", "AUTH_PASS": "test123456",
+		"DEMO_MODE": "0", "DATA_DIR": dataDir, "NODE_ENV": "test",
+	}, dataDir)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	d, err := db.Open(dataDir)
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	secret, err := auth.EnsureSessionSecret(d, cfg)
+	if err != nil {
+		t.Fatalf("secret: %v", err)
+	}
+	if err := auth.EnsureUsers(d, cfg); err != nil {
+		t.Fatalf("users: %v", err)
+	}
+	if err := apitoken.EnsureSchema(d); err != nil {
+		t.Fatalf("api_tokens schema: %v", err)
+	}
+	configBackup, err := configbackup.NewStore(d)
+	if err != nil {
+		t.Fatalf("config backup store: %v", err)
+	}
+	reg := adapters.NewAgentRegistry(90 * time.Second)
+	hub := sse.NewHub(d, cfg.MaxSSEClients, func() any { return nil })
+	handler := httpapi.NewHandler(httpapi.Deps{
+		Config: cfg, DB: d, Adapter: adapters.NewDemo(), Hub: hub, Secret: secret,
+		Agents: reg, Pool: fakeProbeSSH{}, Started: time.Now(),
+		TokenStore:   apitoken.NewStore(d, secret),
+		ConfigBackup: configBackup,
+		Orchestr:     orchestr.New(d),
+	})
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	// Mock de NetGrip: registra las ops recibidas.
+	var receivedOps []executor.Op
+	netgripMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/executor/apply" {
+			http.NotFound(w, r)
+			return
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer netgrip-secret" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		var body struct {
+			Ops []executor.Op `json:"ops"`
+		}
+		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		receivedOps = body.Ops
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+	}))
+	defer netgripMock.Close()
+
+	// Router gateway apuntando al mock + executor token en kv.
+	host := netgripMock.Listener.Addr().String()
+	if _, err := routerstore.AddRouter(d.DB, routerstore.AddInput{
+		Name: "Flint 2", Host: host, Type: "openwrt", IsGateway: true,
+	}); err != nil {
+		t.Fatalf("add router: %v", err)
+	}
+	if _, err := d.Exec("UPDATE routers SET id = ? WHERE host = ?", "flint2", host); err != nil {
+		t.Fatalf("update router id: %v", err)
+	}
+	if _, err := d.Exec(
+		"INSERT INTO kv (key, value) VALUES (?, ?)",
+		"netgrip.executor_token.flint2", "netgrip-secret"); err != nil {
+		t.Fatalf("insert executor token: %v", err)
+	}
+
+	_, cookie, _ := loginCookie(t, srv.URL, "admin", "test123456")
+
+	// Plan guestwifi YA APLICADO con enabled=true (el rollback lo invierte).
+	planID := "plan-roll-01"
+	opsJSON, _ := json.Marshal([]executor.Op{{Kind: "uci_set", Args: map[string]string{"key": "guestwifi.guest.enabled"}, Desc: "enable guest"}})
+	if _, err := d.Exec(
+		`INSERT INTO orchestr_plans (id, router_id, resource, desired, diff, status, created_by, created_at, applied_at, result)
+		 VALUES (?, ?, 'guestwifi', ?, ?, 'applied', 'admin', ?, ?, '{"status":"applied"}')`,
+		planID, "flint2", `{"enabled":true,"allowNonGateway":false}`, string(opsJSON),
+		time.Now().UnixMilli(), time.Now().UnixMilli()); err != nil {
+		t.Fatalf("insert plan: %v", err)
+	}
+
+	// Rollback.
+	req, _ := http.NewRequest("POST", srv.URL+"/api/plans/"+planID+"/rollback", nil)
+	req.Header.Set("Cookie", "session="+cookie)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusAccepted {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("rollback: esperaba 202, got %d: %s", res.StatusCode, string(b))
+	}
+
+	if len(receivedOps) == 0 {
+		t.Fatal("NetGrip no recibió las ops inversas del rollback")
+	}
+	var status string
+	if err := d.QueryRow("SELECT status FROM orchestr_plans WHERE id = ?", planID).Scan(&status); err != nil {
+		t.Fatalf("select plan status: %v", err)
+	}
+	if status != "rolled_back" {
+		t.Fatalf("plan status: esperaba rolled_back, got %s", status)
+	}
+}


### PR DESCRIPTION
Mirrors the apply path from #339: when the router has a NetGrip executor token, the rollback sends the inverse ops to NetGrip and settles the plan through SetRollingBack + SetResult (which translates applied to rolled_back). SSE fallback unchanged. Regression test uses a fake SSH pool for the module probe.

Closes #397