### PR TITLE
chore(release): v2.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 ## [Unreleased]
 
+## [2.21.0] - 2026-08-30
+
 ### Added
 
 - **Rollback de planes delegado a NetGrip (#397)**: `POST /api/plans/{id}/rollback` ahora delega las ops inversas al executor de NetGrip cuando el router tiene executor token (mismo criterio que el apply), asentando el plan como `rolled_back` vía la máquina de estados existente. El fallback al agente embebido por SSE se mantiene.

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.20.0",
+  "version": "2.21.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -49,7 +49,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.20.0"
+var Version = "2.21.0"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Version bump to 2.21.0.

- CHANGELOG: 2.21.0 section with #397 (plan rollback delegated to the NetGrip executor).
- app/package.json and httpapi.Version bumped to 2.21.0.