### PR TITLE
fix(agent/probe): omit NetIf when /proc/net/dev sample is stale (#408)

### DIFF
--- a/agent/probe/local.go
+++ b/agent/probe/local.go
@@ -67,6 +67,10 @@ type Prober struct {
 	// para derivar la sección NetIf (contadores por iface, #305) sin un
 	// segundo cat.
 	lastNetRaw string
+	// netIfUpdated indica si el último ciclo de probeSystem consiguió
+	// refrescar /proc/net/dev. Build solo incluye NetIf cuando es true,
+	// evitando enviar contadores repetidos si CmdNetDev falla o tarda.
+	netIfUpdated bool
 
 	// radiosCache (#368): el resumen de radios (canal/htmode/txpower) cambia
 	// tan poco que no merece iwinfo en cada ciclo NI en el path de eventos:
@@ -110,10 +114,12 @@ func (p *Prober) Build(ctx context.Context, router, version string) *Payload {
 	// Discovery (#338): mDNS services + randomized MAC detection.
 	pl.Data.Discovery = p.probeDiscovery(ctx, pl.Data.Wireless)
 	// NetIf (#305): contadores por iface desde el MISMO /proc/net/dev que
-	// leyó probeSystem (sin segundo cat). Los rates los computa el server
-	// con el delta entre payloads.
-	if p.lastNetRaw != "" {
+	// leyó probeSystem (sin segundo cat). Solo se incluyen si el ciclo actual
+	// refrescó la muestra; si no, el payload se envía sin NetIf para que el
+	// servidor no inserte deltas 0 con contadores repetidos (#408).
+	if p.netIfUpdated {
 		pl.Data.NetIf = ParseNetDevIfaces(p.lastNetRaw)
+		p.netIfUpdated = false
 	}
 	return pl
 }
@@ -176,6 +182,7 @@ func (p *Prober) probeSystem(ctx context.Context) *SystemData {
 		}
 		p.lastNetRx, p.lastNetTx, p.lastNetAt, p.hasLastNet = rx, tx, now, true
 		p.lastNetRaw = out
+		p.netIfUpdated = true
 		any = true
 	}
 

--- a/agent/probe/probe_test.go
+++ b/agent/probe/probe_test.go
@@ -373,6 +373,39 @@ func TestProberBuild(t *testing.T) {
 	}
 }
 
+func TestProberNetIfOmittedWhenCmdNetDevFails(t *testing.T) {
+	// Issue #408: si /proc/net/dev no se refresca en un ciclo, NetIf no debe
+	// enviarse para que el servidor no calcule deltas 0 con contadores viejos.
+	run := fakeRunner{outs: map[string]string{
+		CmdUbusSystemInfo:  `{"uptime":90061,"load":[0.1,0.2,0.3],"memory":{"total":256000000,"free":100000000,"buffered":0,"available":128000000}}`,
+		CmdUbusSystemBoard: `{"model":"TP-Link EAP225","hostname":"patio","release":{"version":"23.05","description":"OpenWrt 23.05"}}`,
+		CmdProcStat:        "cpu  4705 356 584 3699 23 0 23 0 0 0\n",
+		CmdTemp:            "43500\n",
+		CmdNetDev:          "  eth0: 1000000 0 0 0 0 0 0 0 500000 0\n",
+		CmdBridgeMAC:       "94:83:c4:00:00:09\n",
+	}}
+	p := NewProber(run, Options{})
+
+	pl := p.Build(context.Background(), "patio", "0.1.0")
+	if pl.Data.NetIf == nil || pl.Data.NetIf["eth0"].Rx != 1000000 {
+		t.Fatalf("primera muestra debería incluir NetIf: %+v", pl.Data.NetIf)
+	}
+
+	// Segundo ciclo: /proc/net/dev falla; NetIf debe omitirse.
+	delete(run.outs, CmdNetDev)
+	pl2 := p.Build(context.Background(), "patio", "0.1.0")
+	if pl2.Data.NetIf != nil {
+		t.Fatalf("CmdNetDev falló: NetIf debería ser nil, got %+v", pl2.Data.NetIf)
+	}
+
+	// Tercer ciclo: /proc/net/dev vuelve; NetIf se reanuda.
+	run.outs[CmdNetDev] = "  eth0: 2000000 0 0 0 0 0 0 0 1000000 0\n"
+	pl3 := p.Build(context.Background(), "patio", "0.1.0")
+	if pl3.Data.NetIf == nil || pl3.Data.NetIf["eth0"].Rx != 2000000 {
+		t.Fatalf("tercera muestra debería incluir NetIf refrescado: %+v", pl3.Data.NetIf)
+	}
+}
+
 func TestProberSondasFallidasSeccionAusente(t *testing.T) {
 	// Equipo sin ubus/iwinfo/brctl (todo falla salvo /proc): las secciones
 	// wireless/dhcp/fdb quedan ausentes (nil) → el servidor conserva lo último.


### PR DESCRIPTION
Closes #408.

When `CmdNetDev` fails or times out in a cycle, the prober was still sending the previous `/proc/net/dev` snapshot as `NetIf`. Because the payload carried a fresh timestamp, the server computed zero-bps deltas and fired a Ghost port alert on the only active LAN port.

This change only includes `NetIf` in the payload when the current cycle successfully refreshed the counters. If the read fails, the agent omits the section and the server keeps using its last good sample.

## Changes

- `agent/probe/local.go`: track `netIfUpdated` and only serialize `NetIf` when the sample was refreshed.
- `agent/probe/probe_test.go`: add `TestProberNetIfOmittedWhenCmdNetDevFails` covering the regression.

## Verification

- `go test ./...` green in `agent/` and `server-go/`.
- `npm run build` and `npm run lint` green (5 pre-existing warnings).
- Deployed the patched `netpulse-agent` to `rt2` (redmi-ax6) for a smoke test; the agent stays fresh and LAN1 keeps reporting real counters.
