### PR TITLE
fix(httpapi): allow empty AdGuard host in glinet mode (#423)

### DIFF
--- a/server-go/internal/httpapi/config.go
+++ b/server-go/internal/httpapi/config.go
@@ -370,24 +370,26 @@ func (s *server) handlePutAdguardConfig(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusBadRequest, "invalid_input", "Required")
 		return
 	}
-	host, portFromHost, msg := validateAdGuardHost(*in.Host)
-	if msg != "" {
-		writeError(w, http.StatusBadRequest, "invalid_input", msg)
-		return
-	}
+	host := strings.TrimSpace(*in.Host)
 	port := 0
 	if mode == "standard" {
+		hostFromVal, portFromHost, msg := validateAdGuardHost(host)
+		if msg != "" {
+			writeError(w, http.StatusBadRequest, "invalid_input", msg)
+			return
+		}
+		host = hostFromVal
 		if in.Port < 1 || in.Port > 65535 {
 			writeError(w, http.StatusBadRequest, "invalid_input", "port must be between 1 and 65535")
 			return
 		}
 		port = in.Port
-	}
-	if mode == "standard" && port == 0 {
-		port = portFromHost
-	}
-	if mode == "standard" && port == 0 {
-		port = 3000
+		if port == 0 {
+			port = portFromHost
+		}
+		if port == 0 {
+			port = 3000
+		}
 	}
 	user := strings.TrimSpace(in.User)
 	if user == "" {

--- a/server-go/internal/httpapi/config_test.go
+++ b/server-go/internal/httpapi/config_test.go
@@ -365,6 +365,19 @@ func TestAdGuardConfigPort(t *testing.T) {
 	if res.StatusCode != 400 {
 		t.Fatalf("port fuera de rango: esperado 400, got %d", res.StatusCode)
 	}
+
+	// Modo glinet con host vacío debe seguir permitiéndose (no regresión)
+	res = doReq(t, "PUT", srv.URL+"/api/config/adguard", cookie,
+		`{"mode":"glinet","host":"","port":0,"user":"root","password":"secret"}`)
+	if res.StatusCode != 204 {
+		body := readJSON(t, res)
+		t.Fatalf("PUT glinet host vacío: %d %v", res.StatusCode, body)
+	}
+	res = doReq(t, "GET", srv.URL+"/api/config/adguard", cookie, "")
+	body = readJSON(t, res)
+	if body["mode"] != "glinet" || body["host"] != "" || body["port"] != float64(0) {
+		t.Fatalf("glinet host vacío no se guardó: %+v", body)
+	}
 }
 
 func TestConfigRoutersSNMP(t *testing.T) {


### PR DESCRIPTION
Closes #423.\n\nTras el fix de #421 para persistir el puerto en modo standard, el PUT /api/config/adguard rechazaba host vacio en modo glinet. Este PR corrige la validacion para que glinet siga aceptando host vacio y anade test de regresion.