### PR TITLE
feat: warn when DAWN roaming is still in use (#426)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ legacy/server-node/.env
 # Binarios compilados
 # (solo el binario local de `go build` en el módulo agent; el patrón `netpulse-agent*`
 # coincidía con el directorio fuente agent/cmd/netpulse-agent/ e ignoraba su código)
+netpulse
 netpulse-agent
 agent/netpulse-agent
 server-go/netpulse

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -426,7 +426,12 @@
       "dawn": "DAWN",
       "other": "Other"
     },
-    "tabsLabel": "Roaming views"
+    "tabsLabel": "Roaming views",
+    "dawnDeprecated": {
+      "title": "DAWN is deprecated",
+      "body": "NetPulse has detected DAWN on at least one router. DAWN still works, but it is no longer recommended. Consider migrating to usteer for more stable roaming and lower maintenance.",
+      "link": "See issue #426 for migration steps"
+    }
   },
   "notFound": {
     "construction": "This page is under construction. The mockup will complete it in the next iteration."

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -426,7 +426,12 @@
       "dawn": "DAWN",
       "other": "Otro"
     },
-    "tabsLabel": "Vistas de itinerancia"
+    "tabsLabel": "Vistas de itinerancia",
+    "dawnDeprecated": {
+      "title": "DAWN está en desuso",
+      "body": "NetPulse ha detectado DAWN en al menos un router. DAWN sigue funcionando, pero ya no se recomienda. Considera migrar a usteer para un roaming más estable y un mantenimiento menor.",
+      "link": "Ver issue #426 con los pasos de migración"
+    }
   },
   "notFound": {
     "construction": "Esta página está en construcción. El mockup la completará en la siguiente iteración."

--- a/app/src/data/DataProvider.tsx
+++ b/app/src/data/DataProvider.tsx
@@ -105,6 +105,8 @@ export interface NetPulseData {
   topology?: TopoSemantics
   /** Disponibilidad de usteer (roaming); ausente = no mostrar /roaming. */
   usteer?: { available: boolean }
+  /** true si algún router reporta DAWN; la UI avisa de su deprecación (#426). */
+  dawnDeprecated?: boolean
   /** Menú de orquestación activado por el admin (#121); ausente = oculto. */
   orchestration?: boolean
 }
@@ -470,6 +472,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
       vm,
       topology: o.topology,
       usteer: o.usteer,
+      dawnDeprecated: o.dawnDeprecated,
       orchestration: o.orchestration,
       ...(o.devices ? { devices: o.devices } : {}),
     }))

--- a/app/src/data/types.ts
+++ b/app/src/data/types.ts
@@ -376,6 +376,8 @@ export interface OverviewBundle {
   topology?: TopoSemantics
   /** Disponibilidad de usteer (roaming/band-steering); ausente = no mostrar /roaming. */
   usteer?: { available: boolean }
+  /** true si algún router reporta DAWN; la UI avisa de su deprecación (#426). */
+  dawnDeprecated?: boolean
   /** Menú de orquestación activado por el admin (#121); ausente = oculto. */
   orchestration?: boolean
   /** Devices from the same polled snapshot as topology.rings. When present,

--- a/app/src/pages/Roaming.tsx
+++ b/app/src/pages/Roaming.tsx
@@ -144,7 +144,7 @@ function signalClass(s: number): string {
 export default function Roaming() {
   const { t } = useTranslation()
   const reduce = useReducedMotion()
-  const { devices, isDemo } = useNetPulse()
+  const { devices, isDemo, dawnDeprecated } = useNetPulse()
   const [tab, setTab] = useState<Tab>('matrix')
   const [band, setBand] = useState<Band>('all')
   const [weakOnly, setWeakOnly] = useState(false)
@@ -467,6 +467,33 @@ export default function Roaming() {
           </motion.button>
         </div>
       </header>
+
+      {/* Banner de deprecación de DAWN (#426). Solo aparece cuando el backend
+          detecta al menos un router con DAWN en uso. */}
+      {dawnDeprecated && (
+        <motion.div
+          initial={initial}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.25, ease: 'easeOut', delay: 0.04 }}
+          className="flex items-start gap-3 rounded-xl border border-warn/30 bg-warn/10 p-4 text-text-primary"
+          role="status"
+          aria-live="polite"
+        >
+          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-warn" strokeWidth={1.75} />
+          <div className="min-w-0 flex-1 space-y-1">
+            <p className="font-medium">{t('roaming.dawnDeprecated.title')}</p>
+            <p className="text-sm leading-relaxed text-text-secondary">{t('roaming.dawnDeprecated.body')}</p>
+            <a
+              href="https://github.com/gnacho/netpulse/issues/426"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-block text-sm font-medium text-warn hover:underline"
+            >
+              {t('roaming.dawnDeprecated.link')}
+            </a>
+          </div>
+        </motion.div>
+      )}
 
       {/* ② Pestañas */}
       <div

--- a/server-go/internal/adapters/agent.go
+++ b/server-go/internal/adapters/agent.go
@@ -560,6 +560,7 @@ func (l *Live) polledFromAgent(cfg RouterConfig, p *probe.Payload) *routerPolled
 	if p.Data.Discovery != nil {
 		out.discovery = p.Data.Discovery
 	}
+	out.dawnDetected = p.Data.Dawn != nil
 
 	if cached == nil {
 		cached = &extrasSnapshot{ports: []EthPort{}, radios: []Radio{},

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -134,6 +134,9 @@ type routerPolled struct {
 	// discovery: mDNS services + randomized MACs (#338). nil = sin datos
 	// (umdns no instalado o sonda fallida).
 	discovery *probe.DiscoveryData
+	// dawnDetected: el agente reportó una sección DAWN en el payload. Se
+	// usa para mostrar el aviso de deprecación (#426).
+	dawnDetected bool
 }
 
 // extrasSnapshot es la caché anti-parpadeo por router.
@@ -2208,6 +2211,13 @@ func (l *Live) buildOverview(ctx context.Context) (*Overview, error) {
 	// (SPEC-ALERTAS §3-4): UnreadAlerts = no leídas que pasaron config.
 	alertsCopy := l.engine.List()
 	unread := l.engine.UnreadCount()
+	dawnDeprecated := false
+	for _, p := range polled {
+		if p.dawnDetected {
+			dawnDeprecated = true
+			break
+		}
+	}
 	return &Overview{
 		Health:  computeHealth(routerList, adguard),
 		WAN:     wan,
@@ -2221,6 +2231,7 @@ func (l *Live) buildOverview(ctx context.Context) (*Overview, error) {
 		Topology:          BuildTopoSemantics(routerList, devices, wgStats, distNodes), // SPEC-65 D65-3
 		Devices:           devices,
 		Usteer:            &UsteerOverview{Available: l.usteerAvailableCached()},
+		DawnDeprecated:    dawnDeprecated,
 		VM:                ViewModelVersion, // SPEC-65 D65-4
 		Ts:                time.Now().Unix(),
 	}, nil

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -2211,13 +2211,6 @@ func (l *Live) buildOverview(ctx context.Context) (*Overview, error) {
 	// (SPEC-ALERTAS §3-4): UnreadAlerts = no leídas que pasaron config.
 	alertsCopy := l.engine.List()
 	unread := l.engine.UnreadCount()
-	dawnDeprecated := false
-	for _, p := range polled {
-		if p.dawnDetected {
-			dawnDeprecated = true
-			break
-		}
-	}
 	return &Overview{
 		Health:  computeHealth(routerList, adguard),
 		WAN:     wan,
@@ -2231,10 +2224,21 @@ func (l *Live) buildOverview(ctx context.Context) (*Overview, error) {
 		Topology:          BuildTopoSemantics(routerList, devices, wgStats, distNodes), // SPEC-65 D65-3
 		Devices:           devices,
 		Usteer:            &UsteerOverview{Available: l.usteerAvailableCached()},
-		DawnDeprecated:    dawnDeprecated,
+		DawnDeprecated:    dawnDeprecatedFromPolled(polled),
 		VM:                ViewModelVersion, // SPEC-65 D65-4
 		Ts:                time.Now().Unix(),
 	}, nil
+}
+
+// dawnDeprecatedFromPolled devuelve true si algún router reporta DAWN en
+// el payload del agente. Extraído para poder testearlo sin levantar SSH.
+func dawnDeprecatedFromPolled(polled map[string]*routerPolled) bool {
+	for _, p := range polled {
+		if p.dawnDetected {
+			return true
+		}
+	}
+	return false
 }
 
 // usteerAvailableCached devuelve si hay usteer en la red (cacheado). Lanza un

--- a/server-go/internal/adapters/live_dawn_test.go
+++ b/server-go/internal/adapters/live_dawn_test.go
@@ -1,0 +1,36 @@
+package adapters
+
+import (
+	"testing"
+)
+
+// TestDawnDeprecatedFromPolled verifica que la detección de DAWN se active
+// cuando al menos un router reporta el dato en su payload (#426).
+func TestDawnDeprecatedFromPolled(t *testing.T) {
+	t.Run("sin DAWN", func(t *testing.T) {
+		got := dawnDeprecatedFromPolled(map[string]*routerPolled{
+			"r1": {dawnDetected: false},
+			"r2": {dawnDetected: false},
+		})
+		if got {
+			t.Errorf("dawnDeprecatedFromPolled = true, want false")
+		}
+	})
+
+	t.Run("con DAWN en al menos un router", func(t *testing.T) {
+		got := dawnDeprecatedFromPolled(map[string]*routerPolled{
+			"r1": {dawnDetected: false},
+			"r2": {dawnDetected: true},
+		})
+		if !got {
+			t.Errorf("dawnDeprecatedFromPolled = false, want true")
+		}
+	})
+
+	t.Run("mapa vacío", func(t *testing.T) {
+		got := dawnDeprecatedFromPolled(map[string]*routerPolled{})
+		if got {
+			t.Errorf("dawnDeprecatedFromPolled = true, want false")
+		}
+	})
+}

--- a/server-go/internal/adapters/types.go
+++ b/server-go/internal/adapters/types.go
@@ -361,6 +361,10 @@ type Overview struct {
 	// la app muestra la entrada /roaming. Puntero: ausente en snapshots viejos y
 	// cuando ningún router tiene usteer → nil = no mostrar la página.
 	Usteer *UsteerOverview `json:"usteer,omitempty"`
+	// DawnDeprecated: true si algún router sigue reportando DAWN. DAWN ya no
+	// se mantiene activamente; la UI muestra un aviso recomendando migrar a
+	// usteer (#426).
+	DawnDeprecated bool `json:"dawnDeprecated,omitempty"`
 	// Orchestration: el menú de orquestación (escritura en routers) está
 	// oculto por defecto y solo se muestra si el admin lo activa en Ajustes
 	// (#121). Default false (omitempty).


### PR DESCRIPTION
Implementa el aviso de deprecacion de DAWN pedido en #426:

- Mantiene el soporte de DAWN; solo se anade una advertencia en la UI.
- El backend detecta DAWN si el payload del agente incluye Data.Dawn y expone dawnDeprecated en GET /api/overview.
- El frontend consume ese flag en DataProvider y muestra un banner en /roaming con enlace al issue #426.
- Anade claves i18n en ES y EN.
- Incluye tests unitarios para la deteccion.

Closes #426