### PR TITLE
feat: detect active roaming daemon and config anomalies (#428)

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -427,6 +427,12 @@
       "other": "Other"
     },
     "tabsLabel": "Roaming views",
+    "daemon": {
+      "usteer": "usteer active",
+      "dawn": "DAWN active",
+      "both": "DAWN + usteer active",
+      "none": "No roaming daemon"
+    },
     "dawnDeprecated": {
       "title": "DAWN is deprecated",
       "body": "NetPulse has detected DAWN on at least one router. DAWN still works, but it is no longer recommended. Consider migrating to usteer for more stable roaming and lower maintenance.",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -427,6 +427,12 @@
       "other": "Otro"
     },
     "tabsLabel": "Vistas de itinerancia",
+    "daemon": {
+      "usteer": "usteer activo",
+      "dawn": "DAWN activo",
+      "both": "DAWN + usteer activos",
+      "none": "Sin daemon de itinerancia"
+    },
     "dawnDeprecated": {
       "title": "DAWN está en desuso",
       "body": "NetPulse ha detectado DAWN en al menos un router. DAWN sigue funcionando, pero ya no se recomienda. Considera migrar a usteer para un roaming más estable y un mantenimiento menor.",

--- a/app/src/data/DataProvider.tsx
+++ b/app/src/data/DataProvider.tsx
@@ -105,6 +105,8 @@ export interface NetPulseData {
   topology?: TopoSemantics
   /** Disponibilidad de usteer (roaming); ausente = no mostrar /roaming. */
   usteer?: { available: boolean }
+  /** Daemon de roaming detectado: none | dawn | usteer | both (#428). */
+  roamingDaemon?: 'none' | 'dawn' | 'usteer' | 'both'
   /** true si algún router reporta DAWN; la UI avisa de su deprecación (#426). */
   dawnDeprecated?: boolean
   /** Menú de orquestación activado por el admin (#121); ausente = oculto. */
@@ -472,6 +474,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
       vm,
       topology: o.topology,
       usteer: o.usteer,
+      roamingDaemon: o.roamingDaemon,
       dawnDeprecated: o.dawnDeprecated,
       orchestration: o.orchestration,
       ...(o.devices ? { devices: o.devices } : {}),

--- a/app/src/data/types.ts
+++ b/app/src/data/types.ts
@@ -376,6 +376,8 @@ export interface OverviewBundle {
   topology?: TopoSemantics
   /** Disponibilidad de usteer (roaming/band-steering); ausente = no mostrar /roaming. */
   usteer?: { available: boolean }
+  /** Daemon de roaming detectado: none | dawn | usteer | both (#428). */
+  roamingDaemon?: 'none' | 'dawn' | 'usteer' | 'both'
   /** true si algún router reporta DAWN; la UI avisa de su deprecación (#426). */
   dawnDeprecated?: boolean
   /** Menú de orquestación activado por el admin (#121); ausente = oculto. */

--- a/app/src/pages/Roaming.tsx
+++ b/app/src/pages/Roaming.tsx
@@ -83,6 +83,8 @@ interface Dot11rOverview {
   available: boolean
   ssids: Dot11rSSID[]
   routers: Dot11rRouter[]
+  /** Anomalías detectadas en la configuración de roaming (#428). */
+  anomalies?: { kind: string; ssid?: string; message: string; routerId?: string }[]
 }
 
 // ---------------------------------------------------------------------------
@@ -141,10 +143,29 @@ function signalClass(s: number): string {
   return 'bg-danger/15 text-danger ring-danger/30'
 }
 
+/** Badge y estilo para el daemon de roaming activo (#428). */
+function roamingDaemonMeta(
+  daemon: string | undefined,
+  t: (k: string) => string,
+): { label: string; cls: string } | null {
+  switch (daemon) {
+    case 'usteer':
+      return { label: t('roaming.daemon.usteer'), cls: 'bg-accent/15 text-accent ring-accent/30' }
+    case 'dawn':
+      return { label: t('roaming.daemon.dawn'), cls: 'bg-warn/15 text-warn ring-warn/30' }
+    case 'both':
+      return { label: t('roaming.daemon.both'), cls: 'bg-danger/15 text-danger ring-danger/30' }
+    case 'none':
+      return { label: t('roaming.daemon.none'), cls: 'bg-text-muted/15 text-text-muted ring-text-muted/30' }
+    default:
+      return null
+  }
+}
+
 export default function Roaming() {
   const { t } = useTranslation()
   const reduce = useReducedMotion()
-  const { devices, isDemo, dawnDeprecated } = useNetPulse()
+  const { devices, isDemo, dawnDeprecated, roamingDaemon } = useNetPulse()
   const [tab, setTab] = useState<Tab>('matrix')
   const [band, setBand] = useState<Band>('all')
   const [weakOnly, setWeakOnly] = useState(false)
@@ -442,6 +463,21 @@ export default function Roaming() {
           >
             <h1 className="font-display text-h1 text-text-primary">{t('nav.roaming')}</h1>
             <p className="text-caption text-text-muted">{t('roaming.subtitle')}</p>
+            {(() => {
+              const meta = roamingDaemonMeta(roamingDaemon, t)
+              if (!meta) return null
+              return (
+                <span
+                  className={cn(
+                    'mt-2 inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset',
+                    meta.cls,
+                  )}
+                >
+                  <Wifi className="h-3.5 w-3.5" strokeWidth={1.75} />
+                  {meta.label}
+                </span>
+              )
+            })()}
           </motion.div>
           <motion.button
             initial={initial}
@@ -809,6 +845,27 @@ function Dot11rPanel({
           />
         </div>
       </div>
+
+      {/* Anomalías de roaming (#428) */}
+      {(overview.anomalies?.length ?? 0) > 0 && (
+        <div className="space-y-2">
+          {overview.anomalies!.map((a, i) => (
+            <div
+              key={`${a.kind}-${a.ssid ?? ''}-${i}`}
+              className={cn(
+                'flex items-start gap-3 rounded-xl border p-4',
+                a.kind === 'ft_mode_mismatch' || a.kind === 'mobility_domain_mismatch'
+                  ? 'border-danger/30 bg-danger/10 text-text-primary'
+                  : 'border-warn/30 bg-warn/10 text-text-primary',
+              )}
+              role="status"
+            >
+              <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-warn" strokeWidth={1.75} />
+              <p className="text-sm leading-relaxed text-text-secondary">{a.message}</p>
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* ② Tabla por SSID */}
       <div className="rounded-2xl border border-border bg-surface p-5 md:p-6">

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -2211,6 +2211,8 @@ func (l *Live) buildOverview(ctx context.Context) (*Overview, error) {
 	// (SPEC-ALERTAS §3-4): UnreadAlerts = no leídas que pasaron config.
 	alertsCopy := l.engine.List()
 	unread := l.engine.UnreadCount()
+	usteerAvailable := l.usteerAvailableCached()
+	dawnDetected := dawnDeprecatedFromPolled(polled)
 	return &Overview{
 		Health:  computeHealth(routerList, adguard),
 		WAN:     wan,
@@ -2223,11 +2225,27 @@ func (l *Live) buildOverview(ctx context.Context) (*Overview, error) {
 		DistributionNodes: distNodes,
 		Topology:          BuildTopoSemantics(routerList, devices, wgStats, distNodes), // SPEC-65 D65-3
 		Devices:           devices,
-		Usteer:            &UsteerOverview{Available: l.usteerAvailableCached()},
-		DawnDeprecated:    dawnDeprecatedFromPolled(polled),
+		Usteer:            &UsteerOverview{Available: usteerAvailable},
+		DawnDeprecated:    dawnDetected,
+		RoamingDaemon:     classifyRoamingDaemon(usteerAvailable, dawnDetected),
 		VM:                ViewModelVersion, // SPEC-65 D65-4
 		Ts:                time.Now().Unix(),
 	}, nil
+}
+
+// classifyRoamingDaemon decide que daemon de roaming esta activo en la red a
+// partir de los flags recogidos del sondeo (#428).
+func classifyRoamingDaemon(usteerAvailable, dawnDetected bool) RoamingDaemon {
+	switch {
+	case usteerAvailable && dawnDetected:
+		return RoamingDaemonBoth
+	case usteerAvailable:
+		return RoamingDaemonUsteer
+	case dawnDetected:
+		return RoamingDaemonDawn
+	default:
+		return RoamingDaemonNone
+	}
 }
 
 // dawnDeprecatedFromPolled devuelve true si algún router reporta DAWN en
@@ -3025,21 +3043,22 @@ func unquoteUci(s string) string {
 	return s
 }
 
+type dot11rIfaceRef struct {
+	routerID string
+	iface    Dot11rIface
+}
+
 // GetDot11r: estado 802.11r (Fast BSS Transition) por router y SSID. Recorre
 // los routers (saltando agent-only, que son switches sin wifi) y hace SSH
 // `uci show wireless` a cada uno. Devuelve (nil, nil) si ningún router con
-// wifi tiene 802.11r habilitado → el handler responde 503.
+// wifi tiene 802.11r habilitado -> el handler responde 503.
 func (l *Live) GetDot11r(ctx context.Context) (*Dot11rOverview, error) {
 	l.mu.Lock()
 	routers := append([]RouterConfig(nil), l.routers...)
 	l.mu.Unlock()
 
 	out := Dot11rOverview{Routers: []Dot11rRouter{}, SSIDs: []Dot11rSSID{}}
-	type ifaceRef struct {
-		routerID string
-		iface    Dot11rIface
-	}
-	ssidIfaces := map[string][]ifaceRef{}
+	ssidIfaces := map[string][]dot11rIfaceRef{}
 
 	for _, cfg := range routers {
 		name := cfg.Name
@@ -3065,7 +3084,7 @@ func (l *Live) GetDot11r(ctx context.Context) (*Dot11rOverview, error) {
 			if ifc.SSID == "" {
 				continue
 			}
-			ssidIfaces[ifc.SSID] = append(ssidIfaces[ifc.SSID], ifaceRef{routerID: cfg.ID, iface: ifc})
+			ssidIfaces[ifc.SSID] = append(ssidIfaces[ifc.SSID], dot11rIfaceRef{routerID: cfg.ID, iface: ifc})
 		}
 	}
 
@@ -3117,7 +3136,73 @@ func (l *Live) GetDot11r(ctx context.Context) (*Dot11rOverview, error) {
 	if !out.Available {
 		return nil, nil
 	}
+	out.Anomalies = buildRoamingAnomalies(ssidIfaces)
 	return &out, nil
+}
+
+// buildRoamingAnomalies detecta problemas de configuración de roaming a partir
+// de las interfaces wifi-iface agrupadas por SSID (#428).
+func buildRoamingAnomalies(ssidIfaces map[string][]dot11rIfaceRef) []RoamingAnomaly {
+	var anomalies []RoamingAnomaly
+	for ssid, refs := range ssidIfaces {
+		// Solo consideramos interfaces con 802.11r habilitado para las
+		// comprobaciones de consistencia.
+		enabled := make([]dot11rIfaceRef, 0, len(refs))
+		for _, ref := range refs {
+			if ref.iface.Dot11REnabled {
+				enabled = append(enabled, ref)
+			}
+		}
+		if len(enabled) == 0 {
+			continue
+		}
+
+		// 802.11r parcial: algunas interfaces del SSID lo tienen y otras no.
+		if len(enabled) < len(refs) {
+			anomalies = append(anomalies, RoamingAnomaly{
+				Kind:    "partial_11r",
+				SSID:    ssid,
+				Message: fmt.Sprintf("802.11r habilitado solo en %d de %d interfaces del SSID %q", len(enabled), len(refs), ssid),
+			})
+		}
+
+		// Mobility domain inconsistente.
+		md := ""
+		mdOk := true
+		for _, ref := range enabled {
+			if md == "" {
+				md = ref.iface.MobilityDomain
+			} else if ref.iface.MobilityDomain != "" && ref.iface.MobilityDomain != md {
+				mdOk = false
+				break
+			}
+		}
+		if !mdOk {
+			anomalies = append(anomalies, RoamingAnomaly{
+				Kind:    "mobility_domain_mismatch",
+				SSID:    ssid,
+				Message: fmt.Sprintf("Mobility domain distinto entre routers para el SSID %q", ssid),
+			})
+		}
+
+		// FT mode inconsistente.
+		ftOverDS := enabled[0].iface.FTOverDS
+		ftMixed := false
+		for _, ref := range enabled[1:] {
+			if ref.iface.FTOverDS != ftOverDS {
+				ftMixed = true
+				break
+			}
+		}
+		if ftMixed {
+			anomalies = append(anomalies, RoamingAnomaly{
+				Kind:    "ft_mode_mismatch",
+				SSID:    ssid,
+				Message: fmt.Sprintf("Modo FT mixto (over-the-DS / over-the-air) para el SSID %q", ssid),
+			})
+		}
+	}
+	return anomalies
 }
 
 // ---------------------------------------------------------------------------

--- a/server-go/internal/adapters/roaming_anomalies_test.go
+++ b/server-go/internal/adapters/roaming_anomalies_test.go
@@ -1,0 +1,89 @@
+package adapters
+
+import (
+	"testing"
+)
+
+func TestClassifyRoamingDaemon(t *testing.T) {
+	cases := []struct {
+		name     string
+		usteer   bool
+		dawn     bool
+		expected RoamingDaemon
+	}{
+		{"none", false, false, RoamingDaemonNone},
+		{"usteer", true, false, RoamingDaemonUsteer},
+		{"dawn", false, true, RoamingDaemonDawn},
+		{"both", true, true, RoamingDaemonBoth},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyRoamingDaemon(tc.usteer, tc.dawn)
+			if got != tc.expected {
+				t.Errorf("classifyRoamingDaemon(%v, %v) = %q, want %q", tc.usteer, tc.dawn, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestBuildRoamingAnomalies(t *testing.T) {
+	t.Run("sin anomalias", func(t *testing.T) {
+		got := buildRoamingAnomalies(map[string][]dot11rIfaceRef{
+			"temiscira": {
+				{routerID: "r1", iface: Dot11rIface{SSID: "temiscira", Dot11REnabled: true, MobilityDomain: "2025", FTOverDS: false}},
+				{routerID: "r2", iface: Dot11rIface{SSID: "temiscira", Dot11REnabled: true, MobilityDomain: "2025", FTOverDS: false}},
+			},
+		})
+		if len(got) != 0 {
+			t.Fatalf("esperaba 0 anomalias, got %d: %+v", len(got), got)
+		}
+	})
+
+	t.Run("mobility domain distinto", func(t *testing.T) {
+		got := buildRoamingAnomalies(map[string][]dot11rIfaceRef{
+			"temiscira": {
+				{routerID: "r1", iface: Dot11rIface{SSID: "temiscira", Dot11REnabled: true, MobilityDomain: "2025", FTOverDS: false}},
+				{routerID: "r2", iface: Dot11rIface{SSID: "temiscira", Dot11REnabled: true, MobilityDomain: "2026", FTOverDS: false}},
+			},
+		})
+		if len(got) != 1 || got[0].Kind != "mobility_domain_mismatch" {
+			t.Fatalf("esperaba mobility_domain_mismatch, got %+v", got)
+		}
+	})
+
+	t.Run("ft mode mixto", func(t *testing.T) {
+		got := buildRoamingAnomalies(map[string][]dot11rIfaceRef{
+			"temiscira": {
+				{routerID: "r1", iface: Dot11rIface{SSID: "temiscira", Dot11REnabled: true, MobilityDomain: "2025", FTOverDS: true}},
+				{routerID: "r2", iface: Dot11rIface{SSID: "temiscira", Dot11REnabled: true, MobilityDomain: "2025", FTOverDS: false}},
+			},
+		})
+		if len(got) != 1 || got[0].Kind != "ft_mode_mismatch" {
+			t.Fatalf("esperaba ft_mode_mismatch, got %+v", got)
+		}
+	})
+
+	t.Run("802.11r parcial", func(t *testing.T) {
+		got := buildRoamingAnomalies(map[string][]dot11rIfaceRef{
+			"temiscira": {
+				{routerID: "r1", iface: Dot11rIface{SSID: "temiscira", Dot11REnabled: true, MobilityDomain: "2025", FTOverDS: false}},
+				{routerID: "r2", iface: Dot11rIface{SSID: "temiscira", Dot11REnabled: false, MobilityDomain: "", FTOverDS: false}},
+			},
+		})
+		if len(got) != 1 || got[0].Kind != "partial_11r" {
+			t.Fatalf("esperaba partial_11r, got %+v", got)
+		}
+	})
+
+	t.Run("varias anomalias", func(t *testing.T) {
+		got := buildRoamingAnomalies(map[string][]dot11rIfaceRef{
+			"temiscira": {
+				{routerID: "r1", iface: Dot11rIface{SSID: "temiscira", Dot11REnabled: true, MobilityDomain: "2025", FTOverDS: true}},
+				{routerID: "r2", iface: Dot11rIface{SSID: "temiscira", Dot11REnabled: true, MobilityDomain: "2026", FTOverDS: false}},
+			},
+		})
+		if len(got) != 2 {
+			t.Fatalf("esperaba 2 anomalias, got %d: %+v", len(got), got)
+		}
+	})
+}

--- a/server-go/internal/adapters/types.go
+++ b/server-go/internal/adapters/types.go
@@ -333,6 +333,26 @@ type TopoLink struct {
 	Port string `json:"port,omitempty"` // puerto físico si aplica
 }
 
+// RoamingDaemon clasifica el daemon de roaming/band-steering activo en la
+// red según lo que reportan los routers (#428).
+type RoamingDaemon string
+
+const (
+	RoamingDaemonNone   RoamingDaemon = "none"
+	RoamingDaemonDawn   RoamingDaemon = "dawn"
+	RoamingDaemonUsteer RoamingDaemon = "usteer"
+	RoamingDaemonBoth   RoamingDaemon = "both"
+)
+
+// RoamingAnomaly describe un problema detectado en la configuracion de roaming.
+// Se devuelve junto con GET /api/dot11r para pintar avisos en la pestana 802.11r.
+type RoamingAnomaly struct {
+	Kind     string `json:"kind"`
+	SSID     string `json:"ssid,omitempty"`
+	Message  string `json:"message"`
+	RouterID string `json:"routerId,omitempty"`
+}
+
 // Overview es el bundle completo (SPEC §7.8). Ts en SEGUNDOS.
 type Overview struct {
 	Health       HealthScore    `json:"health"`
@@ -365,6 +385,9 @@ type Overview struct {
 	// se mantiene activamente; la UI muestra un aviso recomendando migrar a
 	// usteer (#426).
 	DawnDeprecated bool `json:"dawnDeprecated,omitempty"`
+	// RoamingDaemon: daemon de roaming/band-steering activo detectado en la
+	// red: none, dawn, usteer o both (#428).
+	RoamingDaemon RoamingDaemon `json:"roamingDaemon,omitempty"`
 	// Orchestration: el menú de orquestación (escritura en routers) está
 	// oculto por defecto y solo se muestra si el admin lo activa en Ajustes
 	// (#121). Default false (omitempty).
@@ -600,9 +623,12 @@ type Dot11rSSID struct {
 // Dot11rOverview es la respuesta de GET /api/dot11r. Available=false si ningún
 // router tiene 802.11r (el handler devuelve 503 en ese caso, igual que /usteer).
 type Dot11rOverview struct {
-	Available bool           `json:"available"`
-	SSIDs     []Dot11rSSID   `json:"ssids"`
-	Routers   []Dot11rRouter `json:"routers"`
+	Available  bool           `json:"available"`
+	SSIDs      []Dot11rSSID   `json:"ssids"`
+	Routers    []Dot11rRouter `json:"routers"`
+	// Anomalies: problemas detectados en la configuración de roaming
+	// (mobility domain distinto, FT mode mixto, etc.; #428).
+	Anomalies []RoamingAnomaly `json:"anomalies,omitempty"`
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #428.

- Backend: anade RoamingDaemon a Overview (none/dawn/usteer/both) calculado desde usteerAvailable y dawnDetected.
- Backend: anade anomalies a GET /api/dot11r detectando mobility domain distinto, FT mode mixto y 802.11r parcial por SSID.
- Frontend: muestra badge del daemon activo en /roaming y renderiza las anomalies en la pestana 802.11r.
- i18n ES/EN para etiquetas de daemon.
- Tests para classifyRoamingDaemon y buildRoamingAnomalies.
- Validado con build + go test ./... + npm run build + npm run lint; deploy manual en CT 200 oficina.