### PR TITLE
fix(#404): muestra changelog del release en el asistente de actualización

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1282,6 +1282,8 @@
       "hideHint": "You can close this window: the update continues on the server",
       "progressLabel": "Update progress",
       "changelogTitle": "What's new",
+      "changelogFallback": "Could not load changelog.",
+      "changelogLink": "View release notes on GitHub",
       "downNotice": "The service will be down while it restarts"
     }
   },

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1282,6 +1282,8 @@
       "hideHint": "Puedes cerrar esta ventana: la actualización continúa en el servidor",
       "progressLabel": "Progreso de la actualización",
       "changelogTitle": "Novedades",
+      "changelogFallback": "No se ha podido cargar el changelog.",
+      "changelogLink": "Ver notas del release en GitHub",
       "downNotice": "El servicio estará caído mientras se reinicia"
     }
   },

--- a/app/src/components/UpdateDialog.tsx
+++ b/app/src/components/UpdateDialog.tsx
@@ -277,6 +277,15 @@ export function UpdateDialog({ open, onOpenChange, initialStatus }: UpdateDialog
     [status?.latestBody],
   )
 
+  // Issue #404: enlace de fallback cuando no hay changelog cargado.
+  const releaseUrl = useMemo(() => {
+    const repo = status?.repo || 'gnacho/netpulse'
+    const latest = status?.latest
+    if (!latest) return `https://github.com/${repo}/releases`
+    if (latest.startsWith('v')) return `https://github.com/${repo}/releases/tag/${latest}`
+    return `https://github.com/${repo}/releases`
+  }, [status?.repo, status?.latest])
+
   return (
     <Dialog open={open} onOpenChange={(o) => !busy && onOpenChange(o)}>
       <DialogContent className="max-w-md">
@@ -319,6 +328,20 @@ export function UpdateDialog({ open, onOpenChange, initialStatus }: UpdateDialog
                   </ul>
                 </div>
               </div>
+            )}
+            {/* Issue #404: fallback con enlace si no hay changelog. */}
+            {changelogLines.length === 0 && status?.latest && (
+              <p className="text-caption text-text-muted">
+                {t('update.dialog.changelogFallback')}{' '}
+                <a
+                  href={releaseUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-accent hover:underline"
+                >
+                  {t('update.dialog.changelogLink')}
+                </a>
+              </p>
             )}
             {status?.readiness && <ReadinessPanel readiness={status.readiness} compact />}
             <label className="flex cursor-pointer items-start gap-2.5 rounded-xl bg-warn/10 px-3.5 py-2.5 text-caption leading-snug text-warn">

--- a/server-go/internal/updater/updater.go
+++ b/server-go/internal/updater/updater.go
@@ -179,12 +179,13 @@ func gitShort(repoRoot string) string {
 
 // fetchLatestCommit consulta el último commit de main (modo rolling).
 // Errores → {error: ...}. El body (líneas tras el subject) se devuelve como
-// changelog del asistente.
-func (u *Updater) fetchLatestCommit(ctx context.Context) (sha, msg, body, errCode string) {
+// changelog del asistente. También devuelve el SHA completo para poder buscar
+// las notas del release asociado (#404).
+func (u *Updater) fetchLatestCommit(ctx context.Context) (sha, fullSHA, msg, body, errCode string) {
 	req, err := http.NewRequestWithContext(ctx, "GET",
 		fmt.Sprintf("%s/repos/%s/commits/main", APIBase, u.repo), nil)
 	if err != nil {
-		return "", "", "", "network"
+		return "", "", "", "", "network"
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", "netpulse-updater")
@@ -196,19 +197,19 @@ func (u *Updater) fetchLatestCommit(ctx context.Context) (sha, msg, body, errCod
 	res, err := client.Do(req)
 	if err != nil {
 		if ctx.Err() != nil {
-			return "", "", "", "timeout"
+			return "", "", "", "", "timeout"
 		}
-		return "", "", "", "network"
+		return "", "", "", "", "network"
 	}
 	defer res.Body.Close()
 	if res.StatusCode == 401 || res.StatusCode == 403 || res.StatusCode == 404 {
 		if u.token != "" {
-			return "", "", "", fmt.Sprintf("github_%d", res.StatusCode)
+			return "", "", "", "", fmt.Sprintf("github_%d", res.StatusCode)
 		}
-		return "", "", "", "no_token"
+		return "", "", "", "", "no_token"
 	}
 	if res.StatusCode != 200 {
-		return "", "", "", fmt.Sprintf("github_%d", res.StatusCode)
+		return "", "", "", "", fmt.Sprintf("github_%d", res.StatusCode)
 	}
 	var data struct {
 		SHA    string `json:"sha"`
@@ -217,9 +218,10 @@ func (u *Updater) fetchLatestCommit(ctx context.Context) (sha, msg, body, errCod
 		} `json:"commit"`
 	}
 	if err := json.NewDecoder(io.LimitReader(res.Body, 1<<20)).Decode(&data); err != nil {
-		return "", "", "", "network"
+		return "", "", "", "", "network"
 	}
-	sha = data.SHA
+	fullSHA = data.SHA
+	sha = fullSHA
 	if len(sha) > 7 {
 		sha = sha[:7]
 	}
@@ -240,7 +242,7 @@ func (u *Updater) fetchLatestCommit(ctx context.Context) (sha, msg, body, errCod
 		units += w
 	}
 	msg = msg[:cut]
-	return sha, msg, body, ""
+	return sha, fullSHA, msg, body, ""
 }
 
 // fetchLatestRelease consulta el último release tag (modo stable). Devuelve
@@ -292,6 +294,48 @@ func (u *Updater) fetchLatestRelease(ctx context.Context) (tag, name, body, errC
 	return tag, name, strings.TrimSpace(data.Body), ""
 }
 
+// fetchReleaseBody busca las notas del release asociado al commit dado. Si no
+// encuentra coincidencia o falla la red, devuelve cadena vacía (el asistente
+// usará el body del commit o el fallback a enlace).
+func (u *Updater) fetchReleaseBody(ctx context.Context, sha string) string {
+	if sha == "" {
+		return ""
+	}
+	req, err := http.NewRequestWithContext(ctx, "GET",
+		fmt.Sprintf("%s/repos/%s/releases?per_page=10", APIBase, u.repo), nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "netpulse-updater")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if u.token != "" {
+		req.Header.Set("Authorization", "Bearer "+u.token)
+	}
+	client := &http.Client{Timeout: httpTimeout}
+	res, err := client.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		return ""
+	}
+	var releases []struct {
+		Body            string `json:"body"`
+		TargetCommitish string `json:"target_commitish"`
+	}
+	if err := json.NewDecoder(io.LimitReader(res.Body, 1<<20)).Decode(&releases); err != nil {
+		return ""
+	}
+	for _, r := range releases {
+		if strings.EqualFold(r.TargetCommitish, sha) || strings.HasPrefix(strings.ToLower(r.TargetCommitish), strings.ToLower(sha)) {
+			return strings.TrimSpace(r.Body)
+		}
+	}
+	return ""
+}
+
 // compareSemver compara dos strings semver (con o sin prefijo "v").
 // Devuelve >0 si a > b, 0 si iguales, <0 si a < b. No-parseable → 0.
 func compareSemver(a, b string) int {
@@ -326,6 +370,7 @@ func parseSemver(s string) [3]int {
 // el último release tag (semver).
 func (u *Updater) Check(ctx context.Context) Status {
 	var current, latest, latestMsg, latestBody, errCode string
+	var latestSHA string
 
 	if u.mode == "stable" {
 		current = u.version
@@ -338,7 +383,14 @@ func (u *Updater) Check(ctx context.Context) Status {
 		if current == "" {
 			current = "desconocido"
 		}
-		latest, latestMsg, latestBody, errCode = u.fetchLatestCommit(ctx)
+		latest, latestSHA, latestMsg, latestBody, errCode = u.fetchLatestCommit(ctx)
+		// Issue #404: si el body del commit está vacío, intentar usar las
+		// notas del release asociado a ese commit (rolling en CTs reales).
+		if errCode == "" && latestBody == "" && latestSHA != "" {
+			if releaseBody := u.fetchReleaseBody(ctx, latestSHA); releaseBody != "" {
+				latestBody = releaseBody
+			}
+		}
 	}
 
 	now := time.Now().UnixMilli()

--- a/server-go/internal/updater/updater_test.go
+++ b/server-go/internal/updater/updater_test.go
@@ -28,11 +28,16 @@ func withAPI(t *testing.T, h http.HandlerFunc) {
 
 func TestCheckUpdateAvailable(t *testing.T) {
 	withAPI(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/repos/owner/netpulse/commits/main" {
+		switch r.URL.Path {
+		case "/repos/owner/netpulse/commits/main":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"sha":"abc1234deadbeef","commit":{"message":"feat: algo\n\nbody"}}`)
+		case "/repos/owner/netpulse/releases":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `[]`)
+		default:
 			t.Errorf("path: %s", r.URL.Path)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"sha":"abc1234deadbeef","commit":{"message":"feat: algo\n\nbody"}}`)
 	})
 	// repoRoot con git válido (commit distinto) para updateAvailable.
 	// deploy/update.sh → modo rolling (compara contra main HEAD).
@@ -65,6 +70,34 @@ func TestCheckUpdateAvailable(t *testing.T) {
 	}
 	if st.LastCheck == nil {
 		t.Fatal("lastCheck nil")
+	}
+}
+
+// Issue #404: si el body del commit está vacío, el backend debe buscar las
+// notas del release asociado al commit y devolverlas como changelog.
+func TestCheckUsesReleaseBodyWhenCommitBodyEmpty(t *testing.T) {
+	withAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/netpulse/commits/main":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"sha":"deadbeefabc1234","commit":{"message":"chore(release): v2.5.0"}}`)
+		case "/repos/owner/netpulse/releases":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `[{"body":"Release notes line 1\nRelease notes line 2","target_commitish":"deadbeefabc1234"}]`)
+		default:
+			t.Errorf("path: %s", r.URL.Path)
+		}
+	})
+	root := t.TempDir()
+	writeDeployScript(t, root)
+	writeGitHead(t, root)
+	u := New(root, "owner/netpulse", "", "2.0.0", nil)
+	st := u.Check(context.Background())
+	if st.Error != nil {
+		t.Fatalf("error: %v", *st.Error)
+	}
+	if st.LatestBody == nil || *st.LatestBody != "Release notes line 1\nRelease notes line 2" {
+		t.Fatalf("latestBody: %v", st.LatestBody)
 	}
 }
 


### PR DESCRIPTION
Closes #404.\n\n- En modo rolling se busca el body del release asociado al commit cuando el body del commit está vacío.\n- Se añade un fallback con enlace a las notas del release si no se puede cargar el changelog.\n\n## Verificación\n\n- go test ./... verde (incluye nuevo ).\n- npm run build y npm run lint verdes.