### PR TITLE
fix(#413,#415,#416): mejora detección de puertos y descubrimiento por hostname

### DIFF
--- a/agent/probe/probe.go
+++ b/agent/probe/probe.go
@@ -670,6 +670,10 @@ func BuildEthPorts(layout []PortLayout, states []PortState, brMembers map[string
 	for _, p := range states {
 		byName[p.Name] = p
 	}
+
+	used := map[string]bool{}
+	ports := make([]EthPort, 0, len(states))
+
 	if len(layout) > 0 {
 		lanCount := 0
 		for _, p := range layout {
@@ -677,7 +681,6 @@ func BuildEthPorts(layout []PortLayout, states []PortState, brMembers map[string
 				lanCount++
 			}
 		}
-		ports := make([]EthPort, 0, len(layout))
 		for _, p := range layout {
 			st, ok := byName[p.Name]
 			up := ok && st.Up
@@ -691,44 +694,82 @@ func BuildEthPorts(layout []PortLayout, states []PortState, brMembers map[string
 			}
 			applyStats(&ep, p.Name)
 			ports = append(ports, ep)
+			used[p.Name] = true
 		}
-		return ports
-	}
-	// Fallback sin config
-	lanRe := regexp.MustCompile(`^lan\d+$`)
-	lans := []PortState{}
-	for _, p := range states {
-		if lanRe.MatchString(p.Name) {
-			lans = append(lans, p)
+	} else {
+		// Fallback sin config
+		lanRe := regexp.MustCompile(`^lan\d+$`)
+		lans := []PortState{}
+		for _, p := range states {
+			if lanRe.MatchString(p.Name) {
+				lans = append(lans, p)
+			}
+		}
+		sort.Slice(lans, func(i, j int) bool { return NaturalLess(lans[i].Name, lans[j].Name) })
+		for _, p := range lans {
+			ep := EthPort{ID: p.Name, Label: strings.Replace(p.Name, "lan", "LAN ", 1), Up: p.Up}
+			if p.Up {
+				ep.Speed = p.Speed
+			}
+			applyStats(&ep, p.Name)
+			ports = append(ports, ep)
+			used[p.Name] = true
+		}
+		wanName := ""
+		if _, ok := byName["wan"]; ok {
+			wanName = "wan"
+		} else if _, ok := byName["pppoe-wan"]; ok {
+			wanName = "eth1"
+		} else if _, ok := byName["eth1"]; ok {
+			wanName = "eth1"
+		}
+		if wanName != "" {
+			st := byName[wanName]
+			ep := EthPort{ID: "wan", Label: "WAN", Up: st.Up}
+			if st.Up {
+				ep.Speed = st.Speed
+			}
+			applyStats(&ep, wanName)
+			ports = append([]EthPort{ep}, ports...)
+			used[wanName] = true
 		}
 	}
-	sort.Slice(lans, func(i, j int) bool { return NaturalLess(lans[i].Name, lans[j].Name) })
-	ports := make([]EthPort, 0, len(lans)+1)
-	for _, p := range lans {
-		ep := EthPort{ID: p.Name, Label: strings.Replace(p.Name, "lan", "LAN ", 1), Up: p.Up}
-		if p.Up {
-			ep.Speed = p.Speed
+
+	// Mejora #413/#416: añadir interfaces físicas que no estén ya cubiertas
+	// por el layout/fallback (p. ej. eth0, sfp+ en BPI-R4/UniFi).
+	phyRe := regexp.MustCompile(`^(eth|sfp|en|swp)[0-9a-zA-Z_\-]*$|^(lan|wan)[0-9]+$`)
+	skipRe := regexp.MustCompile(`^(lo|br[-_]?|br-lan|br0|docker|veth|wg|tun|tap|ifb|pppoe|wlan|wpan|phy|gre|gretap|erspan|ip6tnl|sit|teql|bond|dummy|nat64|rmnet|usb|wwan)`)
+	extras := make([]EthPort, 0)
+	for _, st := range states {
+		if used[st.Name] {
+			continue
 		}
-		applyStats(&ep, p.Name)
-		ports = append(ports, ep)
-	}
-	wanName := ""
-	if _, ok := byName["wan"]; ok {
-		wanName = "wan"
-	} else if _, ok := byName["pppoe-wan"]; ok {
-		wanName = "eth1"
-	} else if _, ok := byName["eth1"]; ok {
-		wanName = "eth1"
-	}
-	if wanName != "" {
-		st := byName[wanName]
-		ep := EthPort{ID: "wan", Label: "WAN", Up: st.Up}
+		if skipRe.MatchString(st.Name) {
+			continue
+		}
+		if !phyRe.MatchString(st.Name) {
+			continue
+		}
+		label := st.Name
+		if strings.HasPrefix(st.Name, "eth") {
+			label = "ETH " + strings.TrimPrefix(st.Name, "eth")
+		} else if strings.HasPrefix(st.Name, "sfp") {
+			label = "SFP " + strings.TrimPrefix(st.Name, "sfp")
+		}
+		ep := EthPort{ID: st.Name, Label: label, Up: st.Up}
 		if st.Up {
 			ep.Speed = st.Speed
 		}
-		applyStats(&ep, wanName)
-		ports = append([]EthPort{ep}, ports...)
+		applyStats(&ep, st.Name)
+		extras = append(extras, ep)
+		used[st.Name] = true
 	}
+	if len(extras) > 0 {
+		sort.Slice(extras, func(i, j int) bool { return NaturalLess(extras[i].ID, extras[j].ID) })
+		// Mantener WAN primero, luego LANs, luego extras.
+		ports = append(ports, extras...)
+	}
+
 	return ports
 }
 

--- a/agent/probe/probe_test.go
+++ b/agent/probe/probe_test.go
@@ -248,13 +248,55 @@ func TestParsePortsYLayout(t *testing.T) {
 	}
 	// AP en bridge: wan en br-lan → se re-etiqueta LAN 5
 	ports := BuildEthPorts(layout, states, map[string]bool{"wan": true}, nil)
-	if len(ports) != 5 || ports[0].Label != "LAN 5" {
+	if len(ports) != 6 || ports[0].Label != "LAN 5" {
 		t.Fatalf("ethports bridge: %+v", ports)
 	}
-	// Sin layout: fallback heurístico
-	ports = BuildEthPorts(nil, ParsePortStates("lan2 up 1000\nlan10 up 100\nwan down -1\n"), nil, nil)
-	if len(ports) != 3 || ports[0].ID != "wan" || ports[1].ID != "lan2" || ports[2].ID != "lan10" {
-		t.Fatalf("ethports fallback: %+v", ports)
+	foundBridge := map[string]bool{}
+	for _, p := range ports {
+		foundBridge[p.ID] = true
+	}
+	if !foundBridge["eth0"] {
+		t.Fatalf("ethports bridge sin eth0 extra: %+v", ports)
+	}
+	// Sin layout: fallback heurístico + interfaces físicas no cubiertas (#413/#416)
+	ports = BuildEthPorts(nil, ParsePortStates("lan2 up 1000\nlan10 up 100\nwan down -1\neth0 up 2500\n"), nil, nil)
+	fallbackIDs := map[string]int{}
+	for i, p := range ports {
+		fallbackIDs[p.ID] = i
+	}
+	if len(fallbackIDs) != 4 {
+		t.Fatalf("ethports fallback count: %+v", ports)
+	}
+	for _, id := range []string{"wan", "lan2", "lan10", "eth0"} {
+		if _, ok := fallbackIDs[id]; !ok {
+			t.Fatalf("falta puerto %s: %+v", id, ports)
+		}
+	}
+	if fallbackIDs["wan"] != 0 {
+		t.Fatalf("wan no es el primero: %+v", ports)
+	}
+
+	// Con layout: eth0 no está en board.json pero sí en /sys → se añade al final.
+	ports = BuildEthPorts(layout, []PortState{
+		{Name: "wan", Up: true, Speed: "1 Gbps"},
+		{Name: "lan1", Up: true, Speed: "1 Gbps"},
+		{Name: "lan2", Up: true, Speed: "1 Gbps"},
+		{Name: "lan3", Up: true, Speed: "1 Gbps"},
+		{Name: "lan4", Up: true, Speed: "1 Gbps"},
+		{Name: "eth0", Up: true, Speed: "2.5 Gbps"},
+		{Name: "sfp0", Up: true, Speed: "10 Gbps"},
+	}, nil, nil)
+	if len(ports) != 7 {
+		t.Fatalf("layout + extras: %d ports, %+v", len(ports), ports)
+	}
+	found := map[string]bool{}
+	for _, p := range ports {
+		found[p.ID] = true
+	}
+	for _, id := range []string{"wan", "lan1", "lan2", "lan3", "lan4", "eth0", "sfp0"} {
+		if !found[id] {
+			t.Fatalf("falta puerto %s: %+v", id, ports)
+		}
 	}
 }
 

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1282,6 +1282,8 @@
       "hideHint": "You can close this window: the update continues on the server",
       "progressLabel": "Update progress",
       "changelogTitle": "What's new",
+      "changelogFallback": "Could not load changelog.",
+      "changelogLink": "View release notes on GitHub",
       "downNotice": "The service will be down while it restarts"
     }
   },

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1282,6 +1282,8 @@
       "hideHint": "Puedes cerrar esta ventana: la actualización continúa en el servidor",
       "progressLabel": "Progreso de la actualización",
       "changelogTitle": "Novedades",
+      "changelogFallback": "No se ha podido cargar el changelog.",
+      "changelogLink": "Ver notas del release en GitHub",
       "downNotice": "El servicio estará caído mientras se reinicia"
     }
   },

--- a/app/src/components/UpdateDialog.tsx
+++ b/app/src/components/UpdateDialog.tsx
@@ -277,6 +277,15 @@ export function UpdateDialog({ open, onOpenChange, initialStatus }: UpdateDialog
     [status?.latestBody],
   )
 
+  // Issue #404: enlace de fallback cuando no hay changelog cargado.
+  const releaseUrl = useMemo(() => {
+    const repo = status?.repo || 'gnacho/netpulse'
+    const latest = status?.latest
+    if (!latest) return `https://github.com/${repo}/releases`
+    if (latest.startsWith('v')) return `https://github.com/${repo}/releases/tag/${latest}`
+    return `https://github.com/${repo}/releases`
+  }, [status?.repo, status?.latest])
+
   return (
     <Dialog open={open} onOpenChange={(o) => !busy && onOpenChange(o)}>
       <DialogContent className="max-w-md">
@@ -319,6 +328,20 @@ export function UpdateDialog({ open, onOpenChange, initialStatus }: UpdateDialog
                   </ul>
                 </div>
               </div>
+            )}
+            {/* Issue #404: fallback con enlace si no hay changelog. */}
+            {changelogLines.length === 0 && status?.latest && (
+              <p className="text-caption text-text-muted">
+                {t('update.dialog.changelogFallback')}{' '}
+                <a
+                  href={releaseUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-accent hover:underline"
+                >
+                  {t('update.dialog.changelogLink')}
+                </a>
+              </p>
             )}
             {status?.readiness && <ReadinessPanel readiness={status.readiness} compact />}
             <label className="flex cursor-pointer items-start gap-2.5 rounded-xl bg-warn/10 px-3.5 py-2.5 text-caption leading-snug text-warn">

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -282,6 +282,7 @@ interface ConfigRouter {
 
 interface DiscoverCandidate {
   host: string
+  hostname?: string
   isGateway: boolean
   authorized: boolean
   model: string | null
@@ -432,18 +433,21 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
 
   const addCandidate = async (cand: DiscoverCandidate) => {
     try {
+      const host = cand.hostname?.trim() || cand.host
       const res = await fetch('/api/config/routers', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          host: cand.host,
+          host,
           name: cand.model || undefined,
           type: /GL[.-]?iNet|GL-[A-Z]/i.test(cand.model || '') ? 'glinet' : 'openwrt',
           gateway: cand.isGateway,
         }),
       })
       if (!res.ok && res.status !== 409) throw new Error(`HTTP ${res.status}`)
-      setCandidates((prev) => prev?.map((x) => (x.host === cand.host ? { ...x, configured: true } : x)) ?? prev)
+      setCandidates((prev) =>
+        prev?.map((x) => (x.host === cand.host ? { ...x, configured: true } : x)) ?? prev,
+      )
       await load()
       refresh()
       onSaved()
@@ -674,7 +678,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
                     <span className="truncate text-sm font-medium text-text-primary">
-                      {cand.model || cand.host}
+                      {cand.model || cand.hostname || cand.host}
                     </span>
                     {cand.isGateway && (
                       <span className="rounded-full bg-accent-soft px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-accent">
@@ -682,7 +686,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
                       </span>
                     )}
                   </div>
-                  <div className="font-mono text-caption text-text-muted">{cand.host}</div>
+                  <div className="font-mono text-caption text-text-muted">{cand.hostname ? `${cand.host} (${cand.hostname})` : cand.host}</div>
                 </div>
                 {cand.configured ? (
                   <span className="shrink-0 text-caption text-text-muted">{t('settings.routers.alreadyAdded')}</span>

--- a/server-go/internal/discover/discover.go
+++ b/server-go/internal/discover/discover.go
@@ -41,6 +41,7 @@ const (
 // Result es un candidato a router.
 type Result struct {
 	Host       string  `json:"host"`
+	Hostname   string  `json:"hostname,omitempty"`
 	IsGateway  bool    `json:"isGateway"`
 	Authorized bool    `json:"authorized"`
 	Model      *string `json:"model"`
@@ -254,6 +255,29 @@ func probeSsh(ctx context.Context, host, keyPath string) (bool, *string) {
 	}
 }
 
+// reverseHostname intenta obtener el FQDN de una IP y validarlo con DNS
+// directo. Devuelve el hostname (sin punto final) o cadena vacía.
+func reverseHostname(ip string) string {
+	names, err := net.LookupAddr(ip)
+	if err != nil || len(names) == 0 {
+		return ""
+	}
+	for _, n := range names {
+		// Solo devolver nombres que resuelven de vuelta a la IP (evita
+		// fallback genéricos de PTR mal configurados).
+		ips, lerr := net.LookupIP(n)
+		if lerr != nil {
+			continue
+		}
+		for _, resolved := range ips {
+			if resolved.String() == ip {
+				return strings.TrimSuffix(n, ".")
+			}
+		}
+	}
+	return ""
+}
+
 // selfIPs: IPs propias del servidor (para excluirlas del barrido).
 func selfIPs() map[string]bool {
 	out, err := exec.Command("sh", "-c", `ip -o -4 addr show | grep -oP "inet \K[0-9.]+"`).Output()
@@ -339,8 +363,13 @@ func Routers(ctx context.Context, db *sql.DB, keyPath string, force bool) Respon
 			return Response{Subnet: &subnet, Results: []Result{}, Cached: false, Error: "cancelled"}
 		}
 		authorized, model := probeSsh(ctx, c.h, keyPath)
+		hostname := ""
+		if authorized {
+			hostname = reverseHostname(c.h)
+		}
 		results = append(results, Result{
 			Host:       c.h,
+			Hostname:   hostname,
 			IsGateway:  c.h == gwIP,
 			Authorized: authorized,
 			Model:      model,

--- a/server-go/internal/updater/updater.go
+++ b/server-go/internal/updater/updater.go
@@ -179,12 +179,13 @@ func gitShort(repoRoot string) string {
 
 // fetchLatestCommit consulta el último commit de main (modo rolling).
 // Errores → {error: ...}. El body (líneas tras el subject) se devuelve como
-// changelog del asistente.
-func (u *Updater) fetchLatestCommit(ctx context.Context) (sha, msg, body, errCode string) {
+// changelog del asistente. También devuelve el SHA completo para poder buscar
+// las notas del release asociado (#404).
+func (u *Updater) fetchLatestCommit(ctx context.Context) (sha, fullSHA, msg, body, errCode string) {
 	req, err := http.NewRequestWithContext(ctx, "GET",
 		fmt.Sprintf("%s/repos/%s/commits/main", APIBase, u.repo), nil)
 	if err != nil {
-		return "", "", "", "network"
+		return "", "", "", "", "network"
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", "netpulse-updater")
@@ -196,19 +197,19 @@ func (u *Updater) fetchLatestCommit(ctx context.Context) (sha, msg, body, errCod
 	res, err := client.Do(req)
 	if err != nil {
 		if ctx.Err() != nil {
-			return "", "", "", "timeout"
+			return "", "", "", "", "timeout"
 		}
-		return "", "", "", "network"
+		return "", "", "", "", "network"
 	}
 	defer res.Body.Close()
 	if res.StatusCode == 401 || res.StatusCode == 403 || res.StatusCode == 404 {
 		if u.token != "" {
-			return "", "", "", fmt.Sprintf("github_%d", res.StatusCode)
+			return "", "", "", "", fmt.Sprintf("github_%d", res.StatusCode)
 		}
-		return "", "", "", "no_token"
+		return "", "", "", "", "no_token"
 	}
 	if res.StatusCode != 200 {
-		return "", "", "", fmt.Sprintf("github_%d", res.StatusCode)
+		return "", "", "", "", fmt.Sprintf("github_%d", res.StatusCode)
 	}
 	var data struct {
 		SHA    string `json:"sha"`
@@ -217,9 +218,10 @@ func (u *Updater) fetchLatestCommit(ctx context.Context) (sha, msg, body, errCod
 		} `json:"commit"`
 	}
 	if err := json.NewDecoder(io.LimitReader(res.Body, 1<<20)).Decode(&data); err != nil {
-		return "", "", "", "network"
+		return "", "", "", "", "network"
 	}
-	sha = data.SHA
+	fullSHA = data.SHA
+	sha = fullSHA
 	if len(sha) > 7 {
 		sha = sha[:7]
 	}
@@ -240,7 +242,7 @@ func (u *Updater) fetchLatestCommit(ctx context.Context) (sha, msg, body, errCod
 		units += w
 	}
 	msg = msg[:cut]
-	return sha, msg, body, ""
+	return sha, fullSHA, msg, body, ""
 }
 
 // fetchLatestRelease consulta el último release tag (modo stable). Devuelve
@@ -292,6 +294,48 @@ func (u *Updater) fetchLatestRelease(ctx context.Context) (tag, name, body, errC
 	return tag, name, strings.TrimSpace(data.Body), ""
 }
 
+// fetchReleaseBody busca las notas del release asociado al commit dado. Si no
+// encuentra coincidencia o falla la red, devuelve cadena vacía (el asistente
+// usará el body del commit o el fallback a enlace).
+func (u *Updater) fetchReleaseBody(ctx context.Context, sha string) string {
+	if sha == "" {
+		return ""
+	}
+	req, err := http.NewRequestWithContext(ctx, "GET",
+		fmt.Sprintf("%s/repos/%s/releases?per_page=10", APIBase, u.repo), nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "netpulse-updater")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if u.token != "" {
+		req.Header.Set("Authorization", "Bearer "+u.token)
+	}
+	client := &http.Client{Timeout: httpTimeout}
+	res, err := client.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		return ""
+	}
+	var releases []struct {
+		Body            string `json:"body"`
+		TargetCommitish string `json:"target_commitish"`
+	}
+	if err := json.NewDecoder(io.LimitReader(res.Body, 1<<20)).Decode(&releases); err != nil {
+		return ""
+	}
+	for _, r := range releases {
+		if strings.EqualFold(r.TargetCommitish, sha) || strings.HasPrefix(strings.ToLower(r.TargetCommitish), strings.ToLower(sha)) {
+			return strings.TrimSpace(r.Body)
+		}
+	}
+	return ""
+}
+
 // compareSemver compara dos strings semver (con o sin prefijo "v").
 // Devuelve >0 si a > b, 0 si iguales, <0 si a < b. No-parseable → 0.
 func compareSemver(a, b string) int {
@@ -326,6 +370,7 @@ func parseSemver(s string) [3]int {
 // el último release tag (semver).
 func (u *Updater) Check(ctx context.Context) Status {
 	var current, latest, latestMsg, latestBody, errCode string
+	var latestSHA string
 
 	if u.mode == "stable" {
 		current = u.version
@@ -338,7 +383,14 @@ func (u *Updater) Check(ctx context.Context) Status {
 		if current == "" {
 			current = "desconocido"
 		}
-		latest, latestMsg, latestBody, errCode = u.fetchLatestCommit(ctx)
+		latest, latestSHA, latestMsg, latestBody, errCode = u.fetchLatestCommit(ctx)
+		// Issue #404: si el body del commit está vacío, intentar usar las
+		// notas del release asociado a ese commit (rolling en CTs reales).
+		if errCode == "" && latestBody == "" && latestSHA != "" {
+			if releaseBody := u.fetchReleaseBody(ctx, latestSHA); releaseBody != "" {
+				latestBody = releaseBody
+			}
+		}
 	}
 
 	now := time.Now().UnixMilli()

--- a/server-go/internal/updater/updater_test.go
+++ b/server-go/internal/updater/updater_test.go
@@ -28,11 +28,16 @@ func withAPI(t *testing.T, h http.HandlerFunc) {
 
 func TestCheckUpdateAvailable(t *testing.T) {
 	withAPI(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/repos/owner/netpulse/commits/main" {
+		switch r.URL.Path {
+		case "/repos/owner/netpulse/commits/main":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"sha":"abc1234deadbeef","commit":{"message":"feat: algo\n\nbody"}}`)
+		case "/repos/owner/netpulse/releases":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `[]`)
+		default:
 			t.Errorf("path: %s", r.URL.Path)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"sha":"abc1234deadbeef","commit":{"message":"feat: algo\n\nbody"}}`)
 	})
 	// repoRoot con git válido (commit distinto) para updateAvailable.
 	// deploy/update.sh → modo rolling (compara contra main HEAD).
@@ -65,6 +70,34 @@ func TestCheckUpdateAvailable(t *testing.T) {
 	}
 	if st.LastCheck == nil {
 		t.Fatal("lastCheck nil")
+	}
+}
+
+// Issue #404: si el body del commit está vacío, el backend debe buscar las
+// notas del release asociado al commit y devolverlas como changelog.
+func TestCheckUsesReleaseBodyWhenCommitBodyEmpty(t *testing.T) {
+	withAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/netpulse/commits/main":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"sha":"deadbeefabc1234","commit":{"message":"chore(release): v2.5.0"}}`)
+		case "/repos/owner/netpulse/releases":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `[{"body":"Release notes line 1\nRelease notes line 2","target_commitish":"deadbeefabc1234"}]`)
+		default:
+			t.Errorf("path: %s", r.URL.Path)
+		}
+	})
+	root := t.TempDir()
+	writeDeployScript(t, root)
+	writeGitHead(t, root)
+	u := New(root, "owner/netpulse", "", "2.0.0", nil)
+	st := u.Check(context.Background())
+	if st.Error != nil {
+		t.Fatalf("error: %v", *st.Error)
+	}
+	if st.LatestBody == nil || *st.LatestBody != "Release notes line 1\nRelease notes line 2" {
+		t.Fatalf("latestBody: %v", st.LatestBody)
 	}
 }
 


### PR DESCRIPTION
Closes #413, closes #415, closes #416.\n\n-  añade interfaces físicas no listadas en board.json (eth0, sfp+, etc.) para dispositivos como BPI-R4 y UniFi 6 Plus.\n- El descubrimiento de routers resuelve hostname por PTR y lo usa al añadir, evitando problemas con IP y known_hosts.\n\n## Verificación\n\n- FAIL	./... [setup failed]
FAIL verde en  y .\n-  y  verdes.