### PR TITLE
fix(snmp): intervalo de polling SNMP configurable y histeresis ghost-port (#414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
-<<<<<<< HEAD
+## [2.23.6] - 2026-09-01
+
+### Added
+
+- **Intervalo de polling SNMP configurable por switch (#414)**: los routers con SNMP activado ahora usan un `snmp_poll_interval` configurable (10-3600 s, default 60) en lugar de sondear en cada tick de 5 s. Se expone en el formulario de edicion del router (Ajustes > Routers) y en `PUT /api/config/routers/:id`.
+
+### Fixed
+
+- **Falsos positivos ghost-port en switches SNMP (#414)**: el `PortMonitor` aplica una histeresis temporal de 5 minutos de silencio real antes de declarar ghost-port en puertos procedentes de SNMP. Ademas, cuando un router SNMP se cachea entre polls, no se re-observa el mismo snapshot, evitando que el contador de polls sin trafico crezca artificialmente.
+- **Métricas duplicadas para routers SNMP (#414)**: el poller ya no inserta filas repetidas en `metrics` cuando reutiliza el snapshot cacheado de un switch SNMP.
+
 ## [2.23.5] - 2026-09-01
 
 ### Fixed

--- a/agent/probe/probe.go
+++ b/agent/probe/probe.go
@@ -670,6 +670,10 @@ func BuildEthPorts(layout []PortLayout, states []PortState, brMembers map[string
 	for _, p := range states {
 		byName[p.Name] = p
 	}
+
+	used := map[string]bool{}
+	ports := make([]EthPort, 0, len(states))
+
 	if len(layout) > 0 {
 		lanCount := 0
 		for _, p := range layout {
@@ -677,7 +681,6 @@ func BuildEthPorts(layout []PortLayout, states []PortState, brMembers map[string
 				lanCount++
 			}
 		}
-		ports := make([]EthPort, 0, len(layout))
 		for _, p := range layout {
 			st, ok := byName[p.Name]
 			up := ok && st.Up
@@ -691,44 +694,82 @@ func BuildEthPorts(layout []PortLayout, states []PortState, brMembers map[string
 			}
 			applyStats(&ep, p.Name)
 			ports = append(ports, ep)
+			used[p.Name] = true
 		}
-		return ports
-	}
-	// Fallback sin config
-	lanRe := regexp.MustCompile(`^lan\d+$`)
-	lans := []PortState{}
-	for _, p := range states {
-		if lanRe.MatchString(p.Name) {
-			lans = append(lans, p)
+	} else {
+		// Fallback sin config
+		lanRe := regexp.MustCompile(`^lan\d+$`)
+		lans := []PortState{}
+		for _, p := range states {
+			if lanRe.MatchString(p.Name) {
+				lans = append(lans, p)
+			}
+		}
+		sort.Slice(lans, func(i, j int) bool { return NaturalLess(lans[i].Name, lans[j].Name) })
+		for _, p := range lans {
+			ep := EthPort{ID: p.Name, Label: strings.Replace(p.Name, "lan", "LAN ", 1), Up: p.Up}
+			if p.Up {
+				ep.Speed = p.Speed
+			}
+			applyStats(&ep, p.Name)
+			ports = append(ports, ep)
+			used[p.Name] = true
+		}
+		wanName := ""
+		if _, ok := byName["wan"]; ok {
+			wanName = "wan"
+		} else if _, ok := byName["pppoe-wan"]; ok {
+			wanName = "eth1"
+		} else if _, ok := byName["eth1"]; ok {
+			wanName = "eth1"
+		}
+		if wanName != "" {
+			st := byName[wanName]
+			ep := EthPort{ID: "wan", Label: "WAN", Up: st.Up}
+			if st.Up {
+				ep.Speed = st.Speed
+			}
+			applyStats(&ep, wanName)
+			ports = append([]EthPort{ep}, ports...)
+			used[wanName] = true
 		}
 	}
-	sort.Slice(lans, func(i, j int) bool { return NaturalLess(lans[i].Name, lans[j].Name) })
-	ports := make([]EthPort, 0, len(lans)+1)
-	for _, p := range lans {
-		ep := EthPort{ID: p.Name, Label: strings.Replace(p.Name, "lan", "LAN ", 1), Up: p.Up}
-		if p.Up {
-			ep.Speed = p.Speed
+
+	// Mejora #413/#416: añadir interfaces físicas que no estén ya cubiertas
+	// por el layout/fallback (p. ej. eth0, sfp+ en BPI-R4/UniFi).
+	phyRe := regexp.MustCompile(`^(eth|sfp|en|swp)[0-9a-zA-Z_\-]*$|^(lan|wan)[0-9]+$`)
+	skipRe := regexp.MustCompile(`^(lo|br[-_]?|br-lan|br0|docker|veth|wg|tun|tap|ifb|pppoe|wlan|wpan|phy|gre|gretap|erspan|ip6tnl|sit|teql|bond|dummy|nat64|rmnet|usb|wwan)`)
+	extras := make([]EthPort, 0)
+	for _, st := range states {
+		if used[st.Name] {
+			continue
 		}
-		applyStats(&ep, p.Name)
-		ports = append(ports, ep)
-	}
-	wanName := ""
-	if _, ok := byName["wan"]; ok {
-		wanName = "wan"
-	} else if _, ok := byName["pppoe-wan"]; ok {
-		wanName = "eth1"
-	} else if _, ok := byName["eth1"]; ok {
-		wanName = "eth1"
-	}
-	if wanName != "" {
-		st := byName[wanName]
-		ep := EthPort{ID: "wan", Label: "WAN", Up: st.Up}
+		if skipRe.MatchString(st.Name) {
+			continue
+		}
+		if !phyRe.MatchString(st.Name) {
+			continue
+		}
+		label := st.Name
+		if strings.HasPrefix(st.Name, "eth") {
+			label = "ETH " + strings.TrimPrefix(st.Name, "eth")
+		} else if strings.HasPrefix(st.Name, "sfp") {
+			label = "SFP " + strings.TrimPrefix(st.Name, "sfp")
+		}
+		ep := EthPort{ID: st.Name, Label: label, Up: st.Up}
 		if st.Up {
 			ep.Speed = st.Speed
 		}
-		applyStats(&ep, wanName)
-		ports = append([]EthPort{ep}, ports...)
+		applyStats(&ep, st.Name)
+		extras = append(extras, ep)
+		used[st.Name] = true
 	}
+	if len(extras) > 0 {
+		sort.Slice(extras, func(i, j int) bool { return NaturalLess(extras[i].ID, extras[j].ID) })
+		// Mantener WAN primero, luego LANs, luego extras.
+		ports = append(ports, extras...)
+	}
+
 	return ports
 }
 

--- a/agent/probe/probe_test.go
+++ b/agent/probe/probe_test.go
@@ -248,13 +248,55 @@ func TestParsePortsYLayout(t *testing.T) {
 	}
 	// AP en bridge: wan en br-lan → se re-etiqueta LAN 5
 	ports := BuildEthPorts(layout, states, map[string]bool{"wan": true}, nil)
-	if len(ports) != 5 || ports[0].Label != "LAN 5" {
+	if len(ports) != 6 || ports[0].Label != "LAN 5" {
 		t.Fatalf("ethports bridge: %+v", ports)
 	}
-	// Sin layout: fallback heurístico
-	ports = BuildEthPorts(nil, ParsePortStates("lan2 up 1000\nlan10 up 100\nwan down -1\n"), nil, nil)
-	if len(ports) != 3 || ports[0].ID != "wan" || ports[1].ID != "lan2" || ports[2].ID != "lan10" {
-		t.Fatalf("ethports fallback: %+v", ports)
+	foundBridge := map[string]bool{}
+	for _, p := range ports {
+		foundBridge[p.ID] = true
+	}
+	if !foundBridge["eth0"] {
+		t.Fatalf("ethports bridge sin eth0 extra: %+v", ports)
+	}
+	// Sin layout: fallback heurístico + interfaces físicas no cubiertas (#413/#416)
+	ports = BuildEthPorts(nil, ParsePortStates("lan2 up 1000\nlan10 up 100\nwan down -1\neth0 up 2500\n"), nil, nil)
+	fallbackIDs := map[string]int{}
+	for i, p := range ports {
+		fallbackIDs[p.ID] = i
+	}
+	if len(fallbackIDs) != 4 {
+		t.Fatalf("ethports fallback count: %+v", ports)
+	}
+	for _, id := range []string{"wan", "lan2", "lan10", "eth0"} {
+		if _, ok := fallbackIDs[id]; !ok {
+			t.Fatalf("falta puerto %s: %+v", id, ports)
+		}
+	}
+	if fallbackIDs["wan"] != 0 {
+		t.Fatalf("wan no es el primero: %+v", ports)
+	}
+
+	// Con layout: eth0 no está en board.json pero sí en /sys → se añade al final.
+	ports = BuildEthPorts(layout, []PortState{
+		{Name: "wan", Up: true, Speed: "1 Gbps"},
+		{Name: "lan1", Up: true, Speed: "1 Gbps"},
+		{Name: "lan2", Up: true, Speed: "1 Gbps"},
+		{Name: "lan3", Up: true, Speed: "1 Gbps"},
+		{Name: "lan4", Up: true, Speed: "1 Gbps"},
+		{Name: "eth0", Up: true, Speed: "2.5 Gbps"},
+		{Name: "sfp0", Up: true, Speed: "10 Gbps"},
+	}, nil, nil)
+	if len(ports) != 7 {
+		t.Fatalf("layout + extras: %d ports, %+v", len(ports), ports)
+	}
+	found := map[string]bool{}
+	for _, p := range ports {
+		found[p.ID] = true
+	}
+	for _, id := range []string{"wan", "lan1", "lan2", "lan3", "lan4", "eth0", "sfp0"} {
+		if !found[id] {
+			t.Fatalf("falta puerto %s: %+v", id, ports)
+		}
 	}
 }
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.23.5",
+  "version": "2.23.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.23.5",
+      "version": "2.23.6",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.23.5",
+  "version": "2.23.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1282,6 +1282,8 @@
       "hideHint": "You can close this window: the update continues on the server",
       "progressLabel": "Update progress",
       "changelogTitle": "What's new",
+      "changelogFallback": "Could not load changelog.",
+      "changelogLink": "View release notes on GitHub",
       "downNotice": "The service will be down while it restarts"
     }
   },

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1065,7 +1065,8 @@
       "firmwareTargetHint": "Optional. If the installed firmware doesn't match this version, NetPulse alerts.",
       "snmpEnabled": "SNMP polling",
       "snmpCommunity": "Community (SNMPv2c)",
-      "snmpPort": "Port"
+      "snmpPort": "Port",
+      "snmpPollInterval": "Interval (s)"
     },
     "overrides": {
       "title": "Topology — manual tagging",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1282,6 +1282,8 @@
       "hideHint": "Puedes cerrar esta ventana: la actualización continúa en el servidor",
       "progressLabel": "Progreso de la actualización",
       "changelogTitle": "Novedades",
+      "changelogFallback": "No se ha podido cargar el changelog.",
+      "changelogLink": "Ver notas del release en GitHub",
       "downNotice": "El servicio estará caído mientras se reinicia"
     }
   },

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1065,7 +1065,8 @@
       "firmwareTargetHint": "Opcional. Si el firmware instalado no coincide con esta versión, NetPulse lo avisa.",
       "snmpEnabled": "Sondeo SNMP",
       "snmpCommunity": "Comunidad (SNMPv2c)",
-      "snmpPort": "Puerto"
+      "snmpPort": "Puerto",
+      "snmpPollInterval": "Intervalo (s)"
     },
     "overrides": {
       "title": "Topología — etiquetado manual",

--- a/app/src/components/UpdateDialog.tsx
+++ b/app/src/components/UpdateDialog.tsx
@@ -277,6 +277,15 @@ export function UpdateDialog({ open, onOpenChange, initialStatus }: UpdateDialog
     [status?.latestBody],
   )
 
+  // Issue #404: enlace de fallback cuando no hay changelog cargado.
+  const releaseUrl = useMemo(() => {
+    const repo = status?.repo || 'gnacho/netpulse'
+    const latest = status?.latest
+    if (!latest) return `https://github.com/${repo}/releases`
+    if (latest.startsWith('v')) return `https://github.com/${repo}/releases/tag/${latest}`
+    return `https://github.com/${repo}/releases`
+  }, [status?.repo, status?.latest])
+
   return (
     <Dialog open={open} onOpenChange={(o) => !busy && onOpenChange(o)}>
       <DialogContent className="max-w-md">
@@ -319,6 +328,20 @@ export function UpdateDialog({ open, onOpenChange, initialStatus }: UpdateDialog
                   </ul>
                 </div>
               </div>
+            )}
+            {/* Issue #404: fallback con enlace si no hay changelog. */}
+            {changelogLines.length === 0 && status?.latest && (
+              <p className="text-caption text-text-muted">
+                {t('update.dialog.changelogFallback')}{' '}
+                <a
+                  href={releaseUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-accent hover:underline"
+                >
+                  {t('update.dialog.changelogLink')}
+                </a>
+              </p>
             )}
             {status?.readiness && <ReadinessPanel readiness={status.readiness} compact />}
             <label className="flex cursor-pointer items-start gap-2.5 rounded-xl bg-warn/10 px-3.5 py-2.5 text-caption leading-snug text-warn">

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -278,6 +278,7 @@ interface ConfigRouter {
   snmp_enabled: boolean
   snmp_community: string
   snmp_port: number
+  snmp_poll_interval: number
 }
 
 interface DiscoverCandidate {
@@ -312,6 +313,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
   const [editSnmpEnabled, setEditSnmpEnabled] = useState(false)
   const [editSnmpCommunity, setEditSnmpCommunity] = useState('')
   const [editSnmpPort, setEditSnmpPort] = useState(161)
+  const [editSnmpPollInterval, setEditSnmpPollInterval] = useState(60)
   const [editSubmitting, setEditSubmitting] = useState(false)
   const [pubkey, setPubkey] = useState<{ publicKey: string; fingerprint: string } | null>(null)
   const [copied, setCopied] = useState(false)
@@ -505,6 +507,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
     setEditSnmpEnabled(r.snmp_enabled ?? false)
     setEditSnmpCommunity(r.snmp_community ?? '')
     setEditSnmpPort(r.snmp_port ?? 161)
+    setEditSnmpPollInterval(r.snmp_poll_interval ?? 60)
     setError(null)
   }
 
@@ -527,6 +530,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
           snmp_enabled: editSnmpEnabled,
           snmp_community: editSnmpCommunity.trim() || undefined,
           snmp_port: editSnmpPort,
+          snmp_poll_interval: editSnmpPollInterval,
         }),
       })
       if (res.status === 409) {
@@ -856,21 +860,36 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
                           className="w-full rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
                         />
                       </div>
-                      <div>
-                        <label htmlFor="snmp-port" className="mb-1 block text-caption font-medium uppercase tracking-[0.06em] text-text-muted">
-                          {t('settings.routers.snmpPort')}
-                        </label>
-                        <input
-                          id="snmp-port"
-                          type="number"
-                          min={1}
-                          max={65535}
-                          value={editSnmpPort}
-                          onChange={(e) => setEditSnmpPort(Number(e.target.value))}
-                          aria-label={t('settings.routers.snmpPort')}
-                          className="w-full rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
-                        />
-                      </div>
+                        <div>
+                          <label htmlFor="snmp-port" className="mb-1 block text-caption font-medium uppercase tracking-[0.06em] text-text-muted">
+                            {t('settings.routers.snmpPort')}
+                          </label>
+                          <input
+                            id="snmp-port"
+                            type="number"
+                            min={1}
+                            max={65535}
+                            value={editSnmpPort}
+                            onChange={(e) => setEditSnmpPort(Number(e.target.value))}
+                            aria-label={t('settings.routers.snmpPort')}
+                            className="w-full rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+                          />
+                        </div>
+                        <div>
+                          <label htmlFor="snmp-poll-interval" className="mb-1 block text-caption font-medium uppercase tracking-[0.06em] text-text-muted">
+                            {t('settings.routers.snmpPollInterval')}
+                          </label>
+                          <input
+                            id="snmp-poll-interval"
+                            type="number"
+                            min={10}
+                            max={3600}
+                            value={editSnmpPollInterval}
+                            onChange={(e) => setEditSnmpPollInterval(Number(e.target.value))}
+                            aria-label={t('settings.routers.snmpPollInterval')}
+                            className="w-full rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+                          />
+                        </div>
                     </div>
                   )}
                 </div>

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -282,6 +282,7 @@ interface ConfigRouter {
 
 interface DiscoverCandidate {
   host: string
+  hostname?: string
   isGateway: boolean
   authorized: boolean
   model: string | null
@@ -432,18 +433,21 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
 
   const addCandidate = async (cand: DiscoverCandidate) => {
     try {
+      const host = cand.hostname?.trim() || cand.host
       const res = await fetch('/api/config/routers', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          host: cand.host,
+          host,
           name: cand.model || undefined,
           type: /GL[.-]?iNet|GL-[A-Z]/i.test(cand.model || '') ? 'glinet' : 'openwrt',
           gateway: cand.isGateway,
         }),
       })
       if (!res.ok && res.status !== 409) throw new Error(`HTTP ${res.status}`)
-      setCandidates((prev) => prev?.map((x) => (x.host === cand.host ? { ...x, configured: true } : x)) ?? prev)
+      setCandidates((prev) =>
+        prev?.map((x) => (x.host === cand.host ? { ...x, configured: true } : x)) ?? prev,
+      )
       await load()
       refresh()
       onSaved()
@@ -674,7 +678,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
                     <span className="truncate text-sm font-medium text-text-primary">
-                      {cand.model || cand.host}
+                      {cand.model || cand.hostname || cand.host}
                     </span>
                     {cand.isGateway && (
                       <span className="rounded-full bg-accent-soft px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-accent">
@@ -682,7 +686,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
                       </span>
                     )}
                   </div>
-                  <div className="font-mono text-caption text-text-muted">{cand.host}</div>
+                  <div className="font-mono text-caption text-text-muted">{cand.hostname ? `${cand.host} (${cand.hostname})` : cand.host}</div>
                 </div>
                 {cand.configured ? (
                   <span className="shrink-0 text-caption text-text-muted">{t('settings.routers.alreadyAdded')}</span>

--- a/server-go/internal/adapters/agent.go
+++ b/server-go/internal/adapters/agent.go
@@ -469,7 +469,7 @@ func (l *Live) polledFromAgent(cfg RouterConfig, p *probe.Payload) *routerPolled
 	cached := l.extrasCache[cfg.ID]
 	l.mu.Unlock()
 
-	out := &routerPolled{cfg: cfg, client: l.clients[cfg.ID], net: &NetDevBps{}}
+	out := &routerPolled{cfg: cfg, client: l.clients[cfg.ID], net: &NetDevBps{}, polledAt: time.Now().UnixMilli()}
 	sysInfo := &SysInfo{}
 	ramPct := 0
 

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -137,6 +137,9 @@ type routerPolled struct {
 	// dawnDetected: el agente reportó una sección DAWN en el payload. Se
 	// usa para mostrar el aviso de deprecación (#426).
 	dawnDetected bool
+	// polledAt (issue #414): epoch ms en que se realizó el sondeo real. Se
+	// usa para deduplicar filas de métricas cuando SNMP se cachea.
+	polledAt int64
 }
 
 // extrasSnapshot es la caché anti-parpadeo por router.
@@ -207,6 +210,12 @@ type Live struct {
 	// snmpPorts (issue #309): contadores del último poll SNMP por router y
 	// puerto. Se usa para calcular rxBps/txBps entre polls sucesivos.
 	snmpPorts map[string]map[string]snmpPortSample
+	// snmpLastPoll (issue #414): timestamp del último poll SNMP real por router.
+	snmpLastPoll map[string]time.Time
+	// snmpLastMetricsTick (issue #414): polledAt del último tick que se persistió
+	// en la tabla metrics, para evitar filas duplicadas cuando se reutiliza el
+	// snapshot cacheado de un router SNMP.
+	snmpLastMetricsTick map[string]int64
 	lastPolled  map[string]*routerPolled
 	failCount   map[string]int
 	lastErr     map[string]error // último error del sondeo (issue #257: distinguir sin-acceso de caído)
@@ -303,6 +312,8 @@ func NewLive(cfg *config.Config, d *db.DB, initial []RouterConfig, pool *SSHPool
 		lastAgentIf:          map[string]*agentIfSample{},
 		lastObsTs:            map[string]int64{},
 		snmpPorts:            map[string]map[string]snmpPortSample{},
+		snmpLastPoll:         map[string]time.Time{},
+		snmpLastMetricsTick:  map[string]int64{},
 		lastPolled:           map[string]*routerPolled{},
 		failCount:            map[string]int{},
 		lastErr:              map[string]error{},
@@ -437,6 +448,16 @@ func (l *Live) SetRouters(list []RouterConfig) {
 	for id := range l.snmpPorts {
 		if !ids[id] {
 			delete(l.snmpPorts, id)
+		}
+	}
+	for id := range l.snmpLastPoll {
+		if !ids[id] {
+			delete(l.snmpLastPoll, id)
+		}
+	}
+	for id := range l.snmpLastMetricsTick {
+		if !ids[id] {
+			delete(l.snmpLastMetricsTick, id)
 		}
 	}
 	for id := range l.lastPolled {
@@ -943,6 +964,7 @@ func (l *Live) pollRouter(ctx context.Context, cfg RouterConfig) (*routerPolled,
 		fdb: fdbGood, brMac: brMac, latencyMs: latencyMs, lossPct: lossPct,
 		backhaul: backhaul, lldp: lldp, lldpUnavailable: lldpUnavailable,
 		luci: luciGood, wanInfo: wanInfo, vlans: vlansGood,
+		polledAt: l.now().UnixMilli(),
 	}, nil
 }
 
@@ -2688,9 +2710,13 @@ func (l *Live) AlertsEngine() *alerts.Engine { return l.engine }
 func (l *Live) GetMetricsRows(context.Context) []MetricsRow {
 	l.mu.Lock()
 	polled := l.lastPolled
-	l.mu.Unlock()
 	rows := []MetricsRow{}
 	for id, p := range polled {
+		// issue #414: los routers SNMP cacheados repiten el mismo snapshot
+		// entre polls reales; no se vuelve a persistir la misma fila.
+		if p.cfg.SnmpEnabled && p.polledAt != 0 && p.polledAt <= l.snmpLastMetricsTick[id] {
+			continue
+		}
 		row := MetricsRow{
 			RouterID:  id,
 			CPU:       fptr(float64(p.cpu)),
@@ -2703,7 +2729,11 @@ func (l *Live) GetMetricsRows(context.Context) []MetricsRow {
 			row.TxBps = p.net.TxBps
 		}
 		rows = append(rows, row)
+		if p.cfg.SnmpEnabled {
+			l.snmpLastMetricsTick[id] = p.polledAt
+		}
 	}
+	l.mu.Unlock()
 	return rows
 }
 

--- a/server-go/internal/adapters/portmonitor.go
+++ b/server-go/internal/adapters/portmonitor.go
@@ -9,12 +9,13 @@ import (
 )
 
 const (
-	flapWindow         = 10 * time.Minute
-	flapThreshold      = 5
-	ghostConsecutive   = 3
-	ghostMinHistory   = 12
-	degradedConsec     = 3
-	degradedMinHistory = 12
+	flapWindow             = 10 * time.Minute
+	flapThreshold          = 5
+	ghostConsecutive       = 3
+	ghostMinHistory        = 12
+	snmpGhostMinDuration   = 5 * time.Minute
+	degradedConsec         = 3
+	degradedMinHistory     = 12
 )
 
 type portKey struct {
@@ -23,13 +24,14 @@ type portKey struct {
 }
 
 type portState struct {
-	up           bool
-	transitions  []time.Time
-	speedMbps    int
-	speedHistory []int
-	trafficTotal uint64
-	zeroStreak   int
-	hadTraffic   bool
+	up             bool
+	transitions    []time.Time
+	speedMbps      int
+	speedHistory   []int
+	trafficTotal   uint64
+	zeroStreak     int
+	hadTraffic     bool
+	lastTrafficAt  time.Time
 	// Incidentes abiertos (issue #366): mientras la condición persiste hay
 	// UNA sola alerta viva por puerto (EmitOrUpdate la refresca in situ);
 	// la flag dispara la alerta de recuperación exactamente una vez.
@@ -148,6 +150,7 @@ func (pm *PortMonitor) checkGhost(key portKey, st *portState, p EthPort, now tim
 		st.zeroStreak = 0
 		st.hadTraffic = false
 		st.trafficTotal = 0
+		st.lastTrafficAt = time.Time{}
 		st.ghostActive = false
 		return
 	}
@@ -158,12 +161,14 @@ func (pm *PortMonitor) checkGhost(key portKey, st *portState, p EthPort, now tim
 		st.trafficTotal = total
 		st.hadTraffic = false
 		st.zeroStreak = 0
+		st.lastTrafficAt = time.Time{}
 		st.ghostActive = false
 		return
 	}
 	if total > st.trafficTotal {
 		st.hadTraffic = true
 		st.zeroStreak = 0
+		st.lastTrafficAt = now
 	} else if st.hadTraffic {
 		st.zeroStreak++
 	}
@@ -172,6 +177,11 @@ func (pm *PortMonitor) checkGhost(key portKey, st *portState, p EthPort, now tim
 		return
 	}
 	if st.zeroStreak >= ghostConsecutive {
+		// issue #414: los puertos SNMP se sondean con menos frecuencia; exigir
+		// también un tiempo mínimo de silencio para reducir falsos positivos.
+		if p.Snmp && now.Sub(st.lastTrafficAt) < snmpGhostMinDuration {
+			return
+		}
 		st.ghostActive = true
 		engine.EmitOrUpdate(alerts.AlertEvent{
 			ID:          fmt.Sprintf("alert-ghost-%s-%s", key.routerID, key.portID),

--- a/server-go/internal/adapters/snmp_live.go
+++ b/server-go/internal/adapters/snmp_live.go
@@ -10,6 +10,21 @@ import (
 )
 
 func (l *Live) pollRouterSNMP(cfg RouterConfig) (*routerPolled, error) {
+	// issue #414: si no ha pasado el intervalo configurado, reutiliza el último
+	// sondeo real para no martillear al switch con SNMP cada 5 s.
+	interval := cfg.SnmpPollInterval
+	if interval <= 0 {
+		interval = 60
+	}
+	now := l.now()
+	l.mu.Lock()
+	last, hasLast := l.lastPolled[cfg.ID]
+	lastPoll := l.snmpLastPoll[cfg.ID]
+	l.mu.Unlock()
+	if hasLast && last != nil && now.Sub(lastPoll) < time.Duration(interval)*time.Second {
+		return last, nil
+	}
+
 	session, err := npsnmp.NewSession(npsnmp.Config{
 		Host:      cfg.Host,
 		Port:      cfg.SnmpPort,
@@ -55,6 +70,10 @@ func (l *Live) pollRouterSNMP(cfg RouterConfig) (*routerPolled, error) {
 		})
 	}
 
+	for i := range ethPorts {
+		ethPorts[i].Snmp = true
+	}
+
 	prevPorts := l.snmpPrevPorts(cfg.ID)
 	l.mu.Lock()
 	l.snmpPortCache(cfg.ID, ethPorts)
@@ -92,12 +111,17 @@ func (l *Live) pollRouterSNMP(cfg RouterConfig) (*routerPolled, error) {
 		uptimeSec = float64(sysInfo.UpTimeSec)
 	}
 
-	return &routerPolled{
+	p := &routerPolled{
 		cfg:       cfg,
 		uptimeSec: uptimeSec,
 		ports:     ethPorts,
 		fdb:       fdbMap,
-	}, nil
+		polledAt:  now.UnixMilli(),
+	}
+	l.mu.Lock()
+	l.snmpLastPoll[cfg.ID] = now
+	l.mu.Unlock()
+	return p, nil
 }
 
 type snmpPortSample struct {

--- a/server-go/internal/adapters/snmp_live_test.go
+++ b/server-go/internal/adapters/snmp_live_test.go
@@ -1,0 +1,102 @@
+package adapters
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/alerts"
+)
+
+// issue #414: cuando no ha pasado el intervalo SNMP configurado, pollRouterSNMP
+// devuelve el snapshot cacheado sin tocar la red.
+func TestSNMPCachesWithinInterval(t *testing.T) {
+	l := NewLive(nil, nil, nil, nil)
+	l.now = time.Now
+	cfg := RouterConfig{ID: "sw1", Host: "192.168.1.10", SnmpEnabled: true, SnmpPollInterval: 60}
+
+	cached := &routerPolled{
+		cfg:       cfg,
+		uptimeSec: 123,
+		ports:     []EthPort{{ID: "snmp-1", Label: "1", Up: true}},
+		polledAt:  time.Now().Add(-30 * time.Second).UnixMilli(),
+	}
+	l.lastPolled[cfg.ID] = cached
+	l.snmpLastPoll[cfg.ID] = time.Now().Add(-30 * time.Second)
+
+	p, err := l.pollRouterSNMP(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p != cached {
+		t.Fatal("expected cached routerPolled pointer")
+	}
+}
+
+// issue #414: un router SNMP cacheado solo genera UNA fila de métricas por
+// poll real; los ticks intermedios se omiten.
+func TestSNMPMetricsRowsDedup(t *testing.T) {
+	l := NewLive(nil, nil, nil, nil)
+	cfg := RouterConfig{ID: "sw1", Host: "192.168.1.10", SnmpEnabled: true}
+	rx := 1e6
+	tx := 2e6
+	l.lastPolled["sw1"] = &routerPolled{
+		cfg:       cfg,
+		cpu:       1, ram: 2,
+		polledAt:  1000,
+		net:       &NetDevBps{RxBps: &rx, TxBps: &tx},
+	}
+
+	rows1 := l.GetMetricsRows(context.Background())
+	if len(rows1) != 1 {
+		t.Fatalf("first call rows = %d, want 1", len(rows1))
+	}
+
+	rows2 := l.GetMetricsRows(context.Background())
+	if len(rows2) != 0 {
+		t.Fatalf("second call rows = %d, want 0 (dedup)", len(rows2))
+	}
+}
+
+// issue #414: los puertos SNMP requieren un tiempo mínimo de silencio antes de
+// declarar ghost-port, aunque el contador de polls consecutivos sin tráfico ya
+// supere el umbral normal.
+func TestPortMonitorGhostSnmpHysteresis(t *testing.T) {
+	pm := NewPortMonitor(true)
+	engine := alerts.New(nil, nil)
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	pm.SetClock(func() time.Time { return now })
+
+	port := EthPort{ID: "snmp-1", Label: "Port1", Up: true, Speed: "1 Gbps", Snmp: true}
+	pm.Observe("r1", []EthPort{port}, engine)
+
+	// Historia suficiente con tráfico creciente.
+	for i := 0; i < ghostMinHistory; i++ {
+		port.RxBytes += 1000
+		port.TxBytes += 500
+		now = now.Add(60 * time.Second)
+		pm.SetClock(func() time.Time { return now })
+		pm.Observe("r1", []EthPort{port}, engine)
+	}
+
+	// Tráfico cero durante 4 minutos: el streak ya supera ghostConsecutive,
+	// pero el puerto es SNMP y aún no han pasado 5 minutos de silencio.
+	for i := 0; i < 4; i++ {
+		now = now.Add(60 * time.Second)
+		pm.SetClock(func() time.Time { return now })
+		pm.Observe("r1", []EthPort{port}, engine)
+	}
+
+	if n, _ := findAlerts(engine, "Ghost port: Port1 went silent"); n != 0 {
+		t.Fatalf("ghost alerts before min silence = %d, want 0", n)
+	}
+
+	// 70 segundos más de silencio: ahora sí se cumple la histeresis temporal.
+	now = now.Add(70 * time.Second)
+	pm.SetClock(func() time.Time { return now })
+	pm.Observe("r1", []EthPort{port}, engine)
+
+	if n, _ := findAlerts(engine, "Ghost port: Port1 went silent"); n != 1 {
+		t.Fatalf("ghost alerts after min silence = %d, want 1", n)
+	}
+}

--- a/server-go/internal/adapters/types.go
+++ b/server-go/internal/adapters/types.go
@@ -451,6 +451,9 @@ type EthPort struct {
 	ConnectedTo string   `json:"connectedTo,omitempty"`
 	DeviceMac   string   `json:"deviceMac,omitempty"`
 	Detail      string   `json:"detail,omitempty"`
+	// Snmp indica que el puerto proviene de un switch gestionado por SNMP
+	// (issue #414). Se usa para aplicar histeresis temporal en ghost-port.
+	Snmp bool `json:"-"`
 	// Health: per-port health score (issue #299). Ausente si no se ha
 	// calculado (demo sin datos, puertos sin muestras).
 	Health *PortHealth `json:"health,omitempty"`
@@ -711,9 +714,10 @@ type RouterConfig struct {
 	// SNMP (issue #309): credenciales para sondeo SNMP del switch gestionado.
 	// SnmpEnabled activa el poller SNMP; Community es la comunidad SNMPv2c
 	// ("" = "public"); Port es el puerto UDP (0 = 161 por defecto).
-	SnmpEnabled   bool   `json:"snmp_enabled"`
-	SnmpCommunity string `json:"snmp_community,omitempty"`
-	SnmpPort      int    `json:"snmp_port,omitempty"`
+	SnmpEnabled       bool `json:"snmp_enabled"`
+	SnmpCommunity     string `json:"snmp_community,omitempty"`
+	SnmpPort          int    `json:"snmp_port,omitempty"`
+	SnmpPollInterval  int    `json:"snmp_poll_interval,omitempty"` // segundos; 0 → default 60
 }
 
 // ---------------------------------------------------------------------------

--- a/server-go/internal/db/db.go
+++ b/server-go/internal/db/db.go
@@ -402,6 +402,8 @@ func Open(dataDir string, opts ...OpenOption) (*DB, error) {
 	migrate(sqldb, "routers", "snmp_enabled", "ALTER TABLE routers ADD COLUMN snmp_enabled INTEGER NOT NULL DEFAULT 0")
 	migrate(sqldb, "routers", "snmp_community", "ALTER TABLE routers ADD COLUMN snmp_community TEXT")
 	migrate(sqldb, "routers", "snmp_port", "ALTER TABLE routers ADD COLUMN snmp_port INTEGER NOT NULL DEFAULT 0")
+	// issue #414: intervalo de polling SNMP configurable (segundos; default 60).
+	migrate(sqldb, "routers", "snmp_poll_interval", "ALTER TABLE routers ADD COLUMN snmp_poll_interval INTEGER NOT NULL DEFAULT 60")
 
 	// Si no hubo migración Node (instalación fresca creada por Go), marca la
 	// DB para que el siguiente arranque no dispare una "migración" espuria

--- a/server-go/internal/discover/discover.go
+++ b/server-go/internal/discover/discover.go
@@ -41,6 +41,7 @@ const (
 // Result es un candidato a router.
 type Result struct {
 	Host       string  `json:"host"`
+	Hostname   string  `json:"hostname,omitempty"`
 	IsGateway  bool    `json:"isGateway"`
 	Authorized bool    `json:"authorized"`
 	Model      *string `json:"model"`
@@ -254,6 +255,29 @@ func probeSsh(ctx context.Context, host, keyPath string) (bool, *string) {
 	}
 }
 
+// reverseHostname intenta obtener el FQDN de una IP y validarlo con DNS
+// directo. Devuelve el hostname (sin punto final) o cadena vacía.
+func reverseHostname(ip string) string {
+	names, err := net.LookupAddr(ip)
+	if err != nil || len(names) == 0 {
+		return ""
+	}
+	for _, n := range names {
+		// Solo devolver nombres que resuelven de vuelta a la IP (evita
+		// fallback genéricos de PTR mal configurados).
+		ips, lerr := net.LookupIP(n)
+		if lerr != nil {
+			continue
+		}
+		for _, resolved := range ips {
+			if resolved.String() == ip {
+				return strings.TrimSuffix(n, ".")
+			}
+		}
+	}
+	return ""
+}
+
 // selfIPs: IPs propias del servidor (para excluirlas del barrido).
 func selfIPs() map[string]bool {
 	out, err := exec.Command("sh", "-c", `ip -o -4 addr show | grep -oP "inet \K[0-9.]+"`).Output()
@@ -339,8 +363,13 @@ func Routers(ctx context.Context, db *sql.DB, keyPath string, force bool) Respon
 			return Response{Subnet: &subnet, Results: []Result{}, Cached: false, Error: "cancelled"}
 		}
 		authorized, model := probeSsh(ctx, c.h, keyPath)
+		hostname := ""
+		if authorized {
+			hostname = reverseHostname(c.h)
+		}
 		results = append(results, Result{
 			Host:       c.h,
+			Hostname:   hostname,
 			IsGateway:  c.h == gwIP,
 			Authorized: authorized,
 			Model:      model,

--- a/server-go/internal/httpapi/config.go
+++ b/server-go/internal/httpapi/config.go
@@ -94,9 +94,10 @@ type routerInput struct {
 	// FirmwareTarget: versión objetivo del firmware (issue #241; opcional).
 	FirmwareTarget *string `json:"firmware_target"`
 	// SNMP (issue #309): credenciales para sondeo SNMP del switch gestionado.
-	SnmpEnabled   *bool   `json:"snmp_enabled"`
-	SnmpCommunity *string `json:"snmp_community"`
-	SnmpPort      *int    `json:"snmp_port"`
+	SnmpEnabled       *bool   `json:"snmp_enabled"`
+	SnmpCommunity     *string `json:"snmp_community"`
+	SnmpPort          *int    `json:"snmp_port"`
+	SnmpPollInterval  *int    `json:"snmp_poll_interval"` // issue #414; segundos
 }
 
 // validateHost replica hostSchema (trim, 1..253, regex). Devuelve el valor
@@ -198,6 +199,14 @@ func (s *server) handleAddConfigRouter(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	snmpInterval := 60
+	if in.SnmpPollInterval != nil {
+		snmpInterval = *in.SnmpPollInterval
+		if snmpInterval < 10 || snmpInterval > 3600 {
+			writeError(w, http.StatusBadRequest, "invalid_input", "snmp_poll_interval must be between 10 and 3600")
+			return
+		}
+	}
 	for _, rt := range routerstore.ListRouters(s.db.DB) {
 		if rt.Host == host {
 			writeError(w, http.StatusConflict, "duplicate_host", "Ya hay un router con "+host)
@@ -207,7 +216,7 @@ func (s *server) handleAddConfigRouter(w http.ResponseWriter, r *http.Request) {
 	created, err := routerstore.AddRouter(s.db.DB, routerstore.AddInput{
 		Name: name, Host: host, Type: typ, IsGateway: in.Gateway, AgentOnly: in.AgentOnly,
 		FirmwareTarget: firmwareTarget,
-		SnmpEnabled: snmpEnabled, SnmpCommunity: snmpCommunity, SnmpPort: snmpPort,
+		SnmpEnabled: snmpEnabled, SnmpCommunity: snmpCommunity, SnmpPort: snmpPort, SnmpPollInterval: snmpInterval,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error")
@@ -281,6 +290,15 @@ func (s *server) handleUpdateConfigRouter(w http.ResponseWriter, r *http.Request
 		v := strings.TrimSpace(*in.FirmwareTarget)
 		firmwareTarget = &v
 	}
+	var snmpPollInterval *int
+	if in.SnmpPollInterval != nil {
+		v := *in.SnmpPollInterval
+		if v < 10 || v > 3600 {
+			writeError(w, http.StatusBadRequest, "invalid_input", "snmp_poll_interval must be between 10 and 3600")
+			return
+		}
+		snmpPollInterval = &v
+	}
 	var snmpPort *int
 	if in.SnmpPort != nil {
 		p := *in.SnmpPort
@@ -299,7 +317,7 @@ func (s *server) handleUpdateConfigRouter(w http.ResponseWriter, r *http.Request
 		Name: name, Host: host, Type: typ,
 		IsGateway: &gw, AgentOnly: &ao,
 		FirmwareTarget: firmwareTarget,
-		SnmpEnabled: in.SnmpEnabled, SnmpCommunity: snmpCommunity, SnmpPort: snmpPort,
+		SnmpEnabled: in.SnmpEnabled, SnmpCommunity: snmpCommunity, SnmpPort: snmpPort, SnmpPollInterval: snmpPollInterval,
 	})
 	if !ok {
 		writeError(w, http.StatusNotFound, "not_found")

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -49,7 +49,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.23.5"
+var Version = "2.23.6"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {

--- a/server-go/internal/routerstore/routerstore.go
+++ b/server-go/internal/routerstore/routerstore.go
@@ -27,7 +27,7 @@ const probeTimeout = 4 * time.Second
 // ListRouters devuelve la tabla routers ordenada is_gateway DESC,
 // created_at ASC, con is_gateway como booleano.
 func ListRouters(db *sql.DB) []adapters.RouterConfig {
-	rows, err := db.Query("SELECT id, name, host, type, is_gateway, agent_only, firmware_target, created_at, snmp_enabled, snmp_community, snmp_port FROM routers ORDER BY is_gateway DESC, created_at ASC")
+	rows, err := db.Query("SELECT id, name, host, type, is_gateway, agent_only, firmware_target, created_at, snmp_enabled, snmp_community, snmp_port, snmp_poll_interval FROM routers ORDER BY is_gateway DESC, created_at ASC")
 	if err != nil {
 		return []adapters.RouterConfig{}
 	}
@@ -35,9 +35,9 @@ func ListRouters(db *sql.DB) []adapters.RouterConfig {
 	out := []adapters.RouterConfig{}
 	for rows.Next() {
 		var r adapters.RouterConfig
-		var gw, ao, snmpEn, snmpPort int
+		var gw, ao, snmpEn, snmpPort, snmpInterval int
 		var name, ft, snmpComm sql.NullString
-		if err := rows.Scan(&r.ID, &name, &r.Host, &r.Type, &gw, &ao, &ft, &r.CreatedAt, &snmpEn, &snmpComm, &snmpPort); err != nil {
+		if err := rows.Scan(&r.ID, &name, &r.Host, &r.Type, &gw, &ao, &ft, &r.CreatedAt, &snmpEn, &snmpComm, &snmpPort, &snmpInterval); err != nil {
 			continue
 		}
 		r.Name = name.String
@@ -47,6 +47,7 @@ func ListRouters(db *sql.DB) []adapters.RouterConfig {
 		r.SnmpEnabled = snmpEn == 1
 		r.SnmpCommunity = snmpComm.String
 		r.SnmpPort = snmpPort
+		r.SnmpPollInterval = snmpInterval
 		out = append(out, r)
 	}
 	return out
@@ -126,9 +127,10 @@ type AddInput struct {
 	// FirmwareTarget: versión objetivo (issue #241). "" = sin comprobar.
 	FirmwareTarget string
 	// SNMP (issue #309): credenciales para sondeo SNMP.
-	SnmpEnabled   bool
-	SnmpCommunity string
-	SnmpPort      int
+	SnmpEnabled       bool
+	SnmpCommunity     string
+	SnmpPort          int
+	SnmpPollInterval  int // issue #414; 0 = default 60
 }
 
 // AddRouter inserta un router (si IsGateway, el resto pierde el flag —
@@ -165,9 +167,17 @@ func AddRouter(db *sql.DB, in AddInput) (adapters.RouterConfig, error) {
 	if in.SnmpEnabled {
 		snmpEn = 1
 	}
+	snmpInterval := in.SnmpPollInterval
+	if snmpInterval <= 0 {
+		snmpInterval = 60
+	}
+	snmpPort := in.SnmpPort
+	if snmpPort <= 0 {
+		snmpPort = 161
+	}
 	if _, err := tx.Exec(
-		"INSERT INTO routers (id, name, host, type, is_gateway, agent_only, firmware_target, created_at, snmp_enabled, snmp_community, snmp_port) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-		id, name, in.Host, in.Type, gw, ao, in.FirmwareTarget, now, snmpEn, in.SnmpCommunity, in.SnmpPort,
+		"INSERT INTO routers (id, name, host, type, is_gateway, agent_only, firmware_target, created_at, snmp_enabled, snmp_community, snmp_port, snmp_poll_interval) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		id, name, in.Host, in.Type, gw, ao, in.FirmwareTarget, now, snmpEn, in.SnmpCommunity, snmpPort, snmpInterval,
 	); err != nil {
 		return adapters.RouterConfig{}, err
 	}
@@ -203,9 +213,10 @@ type UpdateInput struct {
 	// FirmwareTarget: versión objetivo (issue #241). nil = no tocar; "" = limpiar.
 	FirmwareTarget *string
 	// SNMP (issue #309): nil = no tocar; puntero a bool/string/int = aplicar.
-	SnmpEnabled   *bool
-	SnmpCommunity *string
-	SnmpPort      *int
+	SnmpEnabled       *bool
+	SnmpCommunity     *string
+	SnmpPort          *int
+	SnmpPollInterval  *int // issue #414
 }
 
 // UpdateRouter actualiza un router existente por id. Si IsGateway pasa a true,
@@ -278,6 +289,14 @@ func UpdateRouter(db *sql.DB, id string, in UpdateInput) (adapters.RouterConfig,
 	if in.SnmpPort != nil {
 		sets = append(sets, "snmp_port = ?")
 		args = append(args, *in.SnmpPort)
+	}
+	if in.SnmpPollInterval != nil {
+		v := *in.SnmpPollInterval
+		if v <= 0 {
+			v = 60
+		}
+		sets = append(sets, "snmp_poll_interval = ?")
+		args = append(args, v)
 	}
 	if len(sets) > 0 {
 		args = append(args, id)

--- a/server-go/internal/updater/updater.go
+++ b/server-go/internal/updater/updater.go
@@ -179,12 +179,13 @@ func gitShort(repoRoot string) string {
 
 // fetchLatestCommit consulta el último commit de main (modo rolling).
 // Errores → {error: ...}. El body (líneas tras el subject) se devuelve como
-// changelog del asistente.
-func (u *Updater) fetchLatestCommit(ctx context.Context) (sha, msg, body, errCode string) {
+// changelog del asistente. También devuelve el SHA completo para poder buscar
+// las notas del release asociado (#404).
+func (u *Updater) fetchLatestCommit(ctx context.Context) (sha, fullSHA, msg, body, errCode string) {
 	req, err := http.NewRequestWithContext(ctx, "GET",
 		fmt.Sprintf("%s/repos/%s/commits/main", APIBase, u.repo), nil)
 	if err != nil {
-		return "", "", "", "network"
+		return "", "", "", "", "network"
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", "netpulse-updater")
@@ -196,19 +197,19 @@ func (u *Updater) fetchLatestCommit(ctx context.Context) (sha, msg, body, errCod
 	res, err := client.Do(req)
 	if err != nil {
 		if ctx.Err() != nil {
-			return "", "", "", "timeout"
+			return "", "", "", "", "timeout"
 		}
-		return "", "", "", "network"
+		return "", "", "", "", "network"
 	}
 	defer res.Body.Close()
 	if res.StatusCode == 401 || res.StatusCode == 403 || res.StatusCode == 404 {
 		if u.token != "" {
-			return "", "", "", fmt.Sprintf("github_%d", res.StatusCode)
+			return "", "", "", "", fmt.Sprintf("github_%d", res.StatusCode)
 		}
-		return "", "", "", "no_token"
+		return "", "", "", "", "no_token"
 	}
 	if res.StatusCode != 200 {
-		return "", "", "", fmt.Sprintf("github_%d", res.StatusCode)
+		return "", "", "", "", fmt.Sprintf("github_%d", res.StatusCode)
 	}
 	var data struct {
 		SHA    string `json:"sha"`
@@ -217,9 +218,10 @@ func (u *Updater) fetchLatestCommit(ctx context.Context) (sha, msg, body, errCod
 		} `json:"commit"`
 	}
 	if err := json.NewDecoder(io.LimitReader(res.Body, 1<<20)).Decode(&data); err != nil {
-		return "", "", "", "network"
+		return "", "", "", "", "network"
 	}
-	sha = data.SHA
+	fullSHA = data.SHA
+	sha = fullSHA
 	if len(sha) > 7 {
 		sha = sha[:7]
 	}
@@ -240,7 +242,7 @@ func (u *Updater) fetchLatestCommit(ctx context.Context) (sha, msg, body, errCod
 		units += w
 	}
 	msg = msg[:cut]
-	return sha, msg, body, ""
+	return sha, fullSHA, msg, body, ""
 }
 
 // fetchLatestRelease consulta el último release tag (modo stable). Devuelve
@@ -292,6 +294,48 @@ func (u *Updater) fetchLatestRelease(ctx context.Context) (tag, name, body, errC
 	return tag, name, strings.TrimSpace(data.Body), ""
 }
 
+// fetchReleaseBody busca las notas del release asociado al commit dado. Si no
+// encuentra coincidencia o falla la red, devuelve cadena vacía (el asistente
+// usará el body del commit o el fallback a enlace).
+func (u *Updater) fetchReleaseBody(ctx context.Context, sha string) string {
+	if sha == "" {
+		return ""
+	}
+	req, err := http.NewRequestWithContext(ctx, "GET",
+		fmt.Sprintf("%s/repos/%s/releases?per_page=10", APIBase, u.repo), nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "netpulse-updater")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if u.token != "" {
+		req.Header.Set("Authorization", "Bearer "+u.token)
+	}
+	client := &http.Client{Timeout: httpTimeout}
+	res, err := client.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		return ""
+	}
+	var releases []struct {
+		Body            string `json:"body"`
+		TargetCommitish string `json:"target_commitish"`
+	}
+	if err := json.NewDecoder(io.LimitReader(res.Body, 1<<20)).Decode(&releases); err != nil {
+		return ""
+	}
+	for _, r := range releases {
+		if strings.EqualFold(r.TargetCommitish, sha) || strings.HasPrefix(strings.ToLower(r.TargetCommitish), strings.ToLower(sha)) {
+			return strings.TrimSpace(r.Body)
+		}
+	}
+	return ""
+}
+
 // compareSemver compara dos strings semver (con o sin prefijo "v").
 // Devuelve >0 si a > b, 0 si iguales, <0 si a < b. No-parseable → 0.
 func compareSemver(a, b string) int {
@@ -326,6 +370,7 @@ func parseSemver(s string) [3]int {
 // el último release tag (semver).
 func (u *Updater) Check(ctx context.Context) Status {
 	var current, latest, latestMsg, latestBody, errCode string
+	var latestSHA string
 
 	if u.mode == "stable" {
 		current = u.version
@@ -338,7 +383,14 @@ func (u *Updater) Check(ctx context.Context) Status {
 		if current == "" {
 			current = "desconocido"
 		}
-		latest, latestMsg, latestBody, errCode = u.fetchLatestCommit(ctx)
+		latest, latestSHA, latestMsg, latestBody, errCode = u.fetchLatestCommit(ctx)
+		// Issue #404: si el body del commit está vacío, intentar usar las
+		// notas del release asociado a ese commit (rolling en CTs reales).
+		if errCode == "" && latestBody == "" && latestSHA != "" {
+			if releaseBody := u.fetchReleaseBody(ctx, latestSHA); releaseBody != "" {
+				latestBody = releaseBody
+			}
+		}
 	}
 
 	now := time.Now().UnixMilli()

--- a/server-go/internal/updater/updater_test.go
+++ b/server-go/internal/updater/updater_test.go
@@ -28,11 +28,16 @@ func withAPI(t *testing.T, h http.HandlerFunc) {
 
 func TestCheckUpdateAvailable(t *testing.T) {
 	withAPI(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/repos/owner/netpulse/commits/main" {
+		switch r.URL.Path {
+		case "/repos/owner/netpulse/commits/main":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"sha":"abc1234deadbeef","commit":{"message":"feat: algo\n\nbody"}}`)
+		case "/repos/owner/netpulse/releases":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `[]`)
+		default:
 			t.Errorf("path: %s", r.URL.Path)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"sha":"abc1234deadbeef","commit":{"message":"feat: algo\n\nbody"}}`)
 	})
 	// repoRoot con git válido (commit distinto) para updateAvailable.
 	// deploy/update.sh → modo rolling (compara contra main HEAD).
@@ -65,6 +70,34 @@ func TestCheckUpdateAvailable(t *testing.T) {
 	}
 	if st.LastCheck == nil {
 		t.Fatal("lastCheck nil")
+	}
+}
+
+// Issue #404: si el body del commit está vacío, el backend debe buscar las
+// notas del release asociado al commit y devolverlas como changelog.
+func TestCheckUsesReleaseBodyWhenCommitBodyEmpty(t *testing.T) {
+	withAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/netpulse/commits/main":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"sha":"deadbeefabc1234","commit":{"message":"chore(release): v2.5.0"}}`)
+		case "/repos/owner/netpulse/releases":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `[{"body":"Release notes line 1\nRelease notes line 2","target_commitish":"deadbeefabc1234"}]`)
+		default:
+			t.Errorf("path: %s", r.URL.Path)
+		}
+	})
+	root := t.TempDir()
+	writeDeployScript(t, root)
+	writeGitHead(t, root)
+	u := New(root, "owner/netpulse", "", "2.0.0", nil)
+	st := u.Check(context.Background())
+	if st.Error != nil {
+		t.Fatalf("error: %v", *st.Error)
+	}
+	if st.LatestBody == nil || *st.LatestBody != "Release notes line 1\nRelease notes line 2" {
+		t.Fatalf("latestBody: %v", st.LatestBody)
 	}
 }
 


### PR DESCRIPTION
## Qué hace este PR

- Añade `snmp_poll_interval` configurable por router/switch (default 60 s, rango 10-3600 s).
- Cachea el snapshot SNMP entre polls reales para no martillear al switch cada 5 s.
- Evita filas de métricas duplicadas cuando se reutiliza el snapshot cacheado.
- Aplica una histeresis temporal de 5 minutos de silencio real antes de emitir alertas ghost-port en puertos SNMP.
- Expone el campo en el formulario de edición de router y actualiza traducciones ES/EN.

## Issue relacionado

Closes #414

## Verificación

- `go test ./...` verde.
- `npm run build` y `npm run lint` sin errores.
- Versión bump a v2.23.6 y CHANGELOG actualizado.
