### PR TITLE
feat(roaming): asesor de re-anchor WiFi con usteer y fallback DAWN (#403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.24.0] - 2026-09-01
+
+### Added
+
+- **Asesor de re-anclaje WiFi (#403)**: nuevo panel "Reanclar" en `/roaming` que lista clientes conectados a un AP subóptimo y sugiere un AP mejor según el hearing map. Soporta usteer (preferido) y DAWN como fallback. Incluye endpoints `/api/wifi-reanchor/recommendations` y `/api/wifi-reanchor/{mac}/move`, y ejecuta `del_client` con `ban_time` al aprobar el movimiento.
+
 ## [2.23.6] - 2026-09-01
 
 ### Added

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.23.6",
+  "version": "2.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.23.6",
+      "version": "2.24.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.23.6",
+  "version": "2.24.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -437,7 +437,27 @@
       "title": "DAWN is deprecated",
       "body": "NetPulse has detected DAWN on at least one router. DAWN still works, but it is no longer recommended. Consider migrating to usteer for more stable roaming and lower maintenance.",
       "link": "See issue #426 for migration steps"
-    }
+    },
+    "reanchor": {
+      "title": "Manual re-anchor",
+      "description": "WiFi clients that would be better served by another AP according to the hearing map. The action kicks the client off the current AP so it can pick another.",
+      "loading": "Analysing WiFi location…",
+      "error": "Could not compute re-anchor. Check that usteer or DAWN are active and reachable.",
+      "noApi": "Available only with a live backend.",
+      "empty": "No clients are stuck on a clearly worse AP. The network looks balanced.",
+      "hint": "Devices that ignore 802.11v won't obey the daemon's suggestions. This panel suggests a better AP and forces disconnection with del_client + ban_time; the client decides where to re-associate.",
+      "source": "Data from {{daemon}}",
+      "colClient": "Client",
+      "colCurrent": "Current AP",
+      "colRecommended": "Recommended AP",
+      "colDelta": "Improvement",
+      "colAction": "Action",
+      "move": "Move",
+      "moving": "Moving…",
+      "moved": "Kicked",
+      "moveFailed": "Failed"
+    },
+    "tabReanchor": "Re-anchor"
   },
   "notFound": {
     "construction": "This page is under construction. The mockup will complete it in the next iteration."

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -437,7 +437,27 @@
       "title": "DAWN está en desuso",
       "body": "NetPulse ha detectado DAWN en al menos un router. DAWN sigue funcionando, pero ya no se recomienda. Considera migrar a usteer para un roaming más estable y un mantenimiento menor.",
       "link": "Ver issue #426 con los pasos de migración"
-    }
+    },
+    "reanchor": {
+      "title": "Re-anclaje manual",
+      "description": "Clientes WiFi que estarían mejor en otro AP según el hearing map. La acción expulsa al cliente del AP actual para que elija otro.",
+      "loading": "Analizando ubicación WiFi…",
+      "error": "No se pudo calcular el re-anclaje. Comprueba que usteer o DAWN están activos y accesibles.",
+      "noApi": "Disponible solo con backend en vivo.",
+      "empty": "No hay clientes anclados en un AP claramente peor. La red está bien repartida.",
+      "hint": "Los dispositivos que ignoran 802.11v no obedecen las sugerencias del daemon. Aquí se sugiere un AP mejor y se fuerza la desconexión con del_client + ban_time; el cliente decide a dónde reasociarse.",
+      "source": "Datos de {{daemon}}",
+      "colClient": "Cliente",
+      "colCurrent": "AP actual",
+      "colRecommended": "AP recomendado",
+      "colDelta": "Mejora",
+      "colAction": "Acción",
+      "move": "Mover",
+      "moving": "Moviendo…",
+      "moved": "Expulsado",
+      "moveFailed": "Fallo"
+    },
+    "tabReanchor": "Reanclar"
   },
   "notFound": {
     "construction": "Esta página está en construcción. El mockup la completará en la siguiente iteración."

--- a/app/src/data/types.ts
+++ b/app/src/data/types.ts
@@ -464,3 +464,21 @@ export interface AlertQuery {
   page?: number
   pageSize?: number
 }
+
+export interface ReanchorRecommendation {
+  mac: string
+  currentBssid: string
+  currentHostname: string
+  currentIface: string
+  currentSignal: number
+  recommendedBssid: string
+  recommendedHostname: string
+  recommendedIface: string
+  recommendedSignal: number
+  deltaDbm: number
+}
+
+export interface ReanchorResponse {
+  daemon: 'none' | 'dawn' | 'usteer' | 'both'
+  recommendations: ReanchorRecommendation[]
+}

--- a/app/src/pages/ReanchorPanel.tsx
+++ b/app/src/pages/ReanchorPanel.tsx
@@ -1,0 +1,256 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { motion, useReducedMotion } from 'framer-motion'
+import { CheckCircle2, Loader2, MoveRight, RefreshCw, Wifi, XCircle } from 'lucide-react'
+import { cn, fetchJson } from '@/lib/utils'
+import { redirectLogin, useNetPulse } from '@/data/DataProvider'
+import type { ReanchorRecommendation, ReanchorResponse } from '@/data/types'
+
+interface Props {
+  refreshTick: number
+}
+
+export default function ReanchorPanel({ refreshTick }: Props) {
+  const { t } = useTranslation()
+  const reduce = useReducedMotion()
+  const { devices, isDemo } = useNetPulse()
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+  const [noApi, setNoApi] = useState(false)
+  const [daemon, setDaemon] = useState<ReanchorResponse['daemon']>('none')
+  const [items, setItems] = useState<ReanchorRecommendation[]>([])
+  const [moving, setMoving] = useState<Set<string>>(new Set())
+  const [moved, setMoved] = useState<Record<string, string>>({})
+  const acRef = useRef<AbortController | null>(null)
+  const initial = reduce ? false : { opacity: 0, y: 12 }
+
+  const nameByMac = useMemo(() => {
+    const m = new Map<string, string>()
+    for (const d of devices) {
+      if (d.mac) m.set(d.mac.toUpperCase(), d.name)
+    }
+    return m
+  }, [devices])
+
+  const load = useCallback(async () => {
+    acRef.current?.abort()
+    const ac = new AbortController()
+    acRef.current = ac
+    setLoading(true)
+    setError(false)
+    setNoApi(false)
+    const result = await fetchJson<ReanchorResponse>('/api/wifi-reanchor/recommendations', {
+      signal: ac.signal,
+    })
+    if (ac.signal.aborted) return
+    if (result.ok) {
+      setItems(result.data.recommendations ?? [])
+      setDaemon(result.data.daemon ?? 'none')
+    } else if (result.kind === 'unauthorized') {
+      redirectLogin()
+      return
+    } else if (result.kind === 'no-api' && isDemo) {
+      setNoApi(true)
+      setItems([])
+    } else {
+      setError(true)
+      setItems([])
+    }
+    setLoading(false)
+  }, [isDemo])
+
+  useEffect(() => {
+    void load()
+    return () => acRef.current?.abort()
+  }, [load, refreshTick])
+
+  const move = useCallback(
+    async (rec: ReanchorRecommendation) => {
+      setMoving((prev) => new Set(prev).add(rec.mac))
+      setMoved((prev) => {
+        const next = { ...prev }
+        delete next[rec.mac]
+        return next
+      })
+      try {
+        const res = await fetch(`/api/wifi-reanchor/${encodeURIComponent(rec.mac)}/move`, {
+          method: 'POST',
+        })
+        if (res.status === 401) {
+          redirectLogin()
+          return
+        }
+        if (!res.ok) {
+          const body = (await res.json().catch(() => ({}))) as { message?: string }
+          setMoved((prev) => ({ ...prev, [rec.mac]: body.message ?? t('roaming.reanchor.moveFailed') }))
+          return
+        }
+        setMoved((prev) => ({ ...prev, [rec.mac]: 'ok' }))
+      } catch {
+        setMoved((prev) => ({ ...prev, [rec.mac]: t('roaming.reanchor.moveFailed') }))
+      } finally {
+        setMoving((prev) => {
+          const next = new Set(prev)
+          next.delete(rec.mac)
+          return next
+        })
+      }
+    },
+    [t],
+  )
+
+  if (loading && items.length === 0) {
+    return (
+      <div className="rounded-2xl border border-border bg-surface p-8 text-center text-caption text-text-muted">
+        {t('roaming.reanchor.loading')}
+      </div>
+    )
+  }
+  if (noApi) {
+    return (
+      <div className="rounded-2xl border border-border bg-surface p-8 text-center text-caption text-text-muted">
+        {t('roaming.reanchor.noApi')}
+      </div>
+    )
+  }
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-border bg-surface p-8 text-center text-caption text-text-muted">
+        {t('roaming.reanchor.error')}
+      </div>
+    )
+  }
+
+  const daemonLabel =
+    daemon === 'usteer'
+      ? t('roaming.daemon.usteer')
+      : daemon === 'dawn'
+        ? t('roaming.daemon.dawn')
+        : null
+
+  return (
+    <motion.section
+      initial={initial}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, ease: 'easeOut', delay: 0.08 }}
+      className="space-y-4"
+    >
+      <div className="rounded-2xl border border-border bg-surface p-5 md:p-6">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="flex items-start gap-2">
+            <Wifi className="mt-0.5 h-4 w-4 shrink-0 text-accent" strokeWidth={1.75} />
+            <div>
+              <h2 className="font-display text-h2 text-text-primary">{t('roaming.reanchor.title')}</h2>
+              <p className="mt-0.5 max-w-2xl text-caption text-text-muted">
+                {t('roaming.reanchor.description')}
+                {daemonLabel && (
+                  <>
+                    {' '}
+                    ({t('roaming.reanchor.source', { daemon: daemonLabel })})
+                  </>
+                )}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={() => void load()}
+            disabled={loading}
+            className="inline-flex h-9 items-center gap-2 rounded-lg border border-border bg-elevated px-3 text-sm font-medium text-text-secondary transition-colors hover:border-accent/40 hover:text-accent disabled:opacity-50"
+          >
+            <RefreshCw className={cn('h-4 w-4', loading && 'animate-spin')} strokeWidth={1.75} />
+            {t('common.refresh')}
+          </button>
+        </div>
+
+        <div className="mt-4 rounded-lg border border-border bg-elevated p-4 text-sm text-text-secondary">
+          <p>{t('roaming.reanchor.hint')}</p>
+        </div>
+
+        {items.length === 0 ? (
+          <div className="mt-5 rounded-xl border border-dashed border-border bg-surface p-8 text-center text-caption text-text-muted">
+            {t('roaming.reanchor.empty')}
+          </div>
+        ) : (
+          <div className="mt-5 overflow-x-auto">
+            <table className="w-full border-separate border-spacing-0 text-left text-sm">
+              <thead>
+                <tr className="text-label uppercase text-text-muted">
+                  <th className="pb-2.5 pr-3 font-medium">{t('roaming.reanchor.colClient')}</th>
+                  <th className="pb-2.5 pr-3 font-medium">{t('roaming.reanchor.colCurrent')}</th>
+                  <th className="pb-2.5 pr-3 font-medium">{t('roaming.reanchor.colRecommended')}</th>
+                  <th className="pb-2.5 pr-3 font-medium">{t('roaming.reanchor.colDelta')}</th>
+                  <th className="pb-2.5 pr-3 font-medium">{t('roaming.reanchor.colAction')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((rec) => {
+                  const name = nameByMac.get(rec.mac) ?? rec.mac
+                  const done = moved[rec.mac] === 'ok'
+                  const failed = moved[rec.mac] && moved[rec.mac] !== 'ok'
+                  return (
+                    <tr key={rec.mac} className="group">
+                      <td className="border-b border-border/60 py-2.5 pr-3">
+                        <div className="flex flex-col">
+                          <span className="font-medium text-text-primary">{name}</span>
+                          {name !== rec.mac && <span className="font-mono text-caption text-text-muted">{rec.mac}</span>}
+                        </div>
+                      </td>
+                      <td className="border-b border-border/60 py-2.5 pr-3">
+                        <div className="flex flex-col gap-0.5">
+                          <span className="font-medium text-text-primary">{rec.currentHostname}</span>
+                          <span className="font-mono text-caption text-text-muted">
+                            {rec.currentIface} · {rec.currentSignal} dBm
+                          </span>
+                        </div>
+                      </td>
+                      <td className="border-b border-border/60 py-2.5 pr-3">
+                        <div className="flex flex-col gap-0.5">
+                          <span className="font-medium text-ok">{rec.recommendedHostname}</span>
+                          <span className="font-mono text-caption text-text-muted">
+                            {rec.recommendedIface} · {rec.recommendedSignal} dBm
+                          </span>
+                        </div>
+                      </td>
+                      <td className="border-b border-border/60 py-2.5 pr-3">
+                        <span className="inline-flex items-center gap-1 rounded-md bg-ok/15 px-2 py-0.5 text-sm font-medium text-ok ring-1 ring-inset ring-ok/30">
+                          <MoveRight className="h-3.5 w-3.5" />
+                          +{rec.deltaDbm} dBm
+                        </span>
+                      </td>
+                      <td className="border-b border-border/60 py-2.5 pr-3">
+                        {done ? (
+                          <span className="inline-flex items-center gap-1.5 text-sm font-medium text-ok">
+                            <CheckCircle2 className="h-4 w-4" />
+                            {t('roaming.reanchor.moved')}
+                          </span>
+                        ) : failed ? (
+                          <span className="inline-flex items-center gap-1.5 text-sm font-medium text-danger" title={moved[rec.mac]}>
+                            <XCircle className="h-4 w-4" />
+                            {t('roaming.reanchor.moveFailed')}
+                          </span>
+                        ) : (
+                          <button
+                            onClick={() => move(rec)}
+                            disabled={moving.has(rec.mac)}
+                            className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-elevated px-2.5 text-sm font-medium text-text-secondary transition-colors hover:border-accent/40 hover:text-accent disabled:opacity-50"
+                          >
+                            {moving.has(rec.mac) ? (
+                              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            ) : (
+                              <MoveRight className="h-3.5 w-3.5" />
+                            )}
+                            {t('roaming.reanchor.move')}
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </motion.section>
+  )
+}

--- a/app/src/pages/Roaming.tsx
+++ b/app/src/pages/Roaming.tsx
@@ -6,6 +6,7 @@ import { motion, useReducedMotion } from 'framer-motion'
 import { AlertTriangle, ArrowDownToLine, ArrowUpFromLine, CheckCircle2, GitFork, History, RefreshCw, Wifi, X, XCircle } from 'lucide-react'
 import { cn, fetchJson } from '@/lib/utils'
 import { useNetPulse, redirectLogin } from '@/data/DataProvider'
+import ReanchorPanel from './ReanchorPanel'
 
 // ---------------------------------------------------------------------------
 // Tipos del contrato GET /api/usteer (server-go/internal/adapters/types.go).
@@ -131,10 +132,10 @@ interface RoamEvent {
 }
 
 type Band = 'all' | '2.4 GHz' | '5 GHz'
-type Tab = 'matrix' | '11r' | 'survey' | 'events'
+type Tab = 'matrix' | '11r' | 'survey' | 'events' | 'reanchor'
 
 /** Orden estable de pestañas (issue #229: navegación por teclado). */
-const TAB_IDS: Tab[] = ['matrix', '11r', 'survey', 'events']
+const TAB_IDS: Tab[] = ['matrix', '11r', 'survey', 'events', 'reanchor']
 
 /** Clase de color por señal (-dBm): verde óptimo, ámbar aceptable, rojo límite. */
 function signalClass(s: number): string {
@@ -190,6 +191,7 @@ export default function Roaming() {
   const [spin, setSpin] = useState(false)
   const [kicking, setKicking] = useState<string | null>(null)
   const [kickError, setKickError] = useState<string | null>(null)
+  const [reanchorTick, setReanchorTick] = useState(0)
 
   // MAC → nombre (resuelto desde la lista de dispositivos del overview).
   const nameByMac = useMemo(() => {
@@ -416,6 +418,7 @@ export default function Roaming() {
     { id: '11r', label: t('roaming.tab11r'), soon: false },
     { id: 'survey', label: t('roaming.tabSurvey'), soon: false },
     { id: 'events', label: t('roaming.tabEvents'), soon: false },
+    { id: 'reanchor', label: t('roaming.tabReanchor'), soon: false },
   ]
 
   // -- pestañas WAI-ARIA (issue #229): roving tabindex + flechas + Home/End
@@ -488,6 +491,7 @@ export default function Roaming() {
               if (tab === '11r') void loadDot11r()
               if (tab === 'survey') void loadSurvey()
               if (tab === 'events') void loadEvents()
+              if (tab === 'reanchor') setReanchorTick((n) => n + 1)
               if (reduce) return
               setSpin(true)
               if (spinTimer.current !== null) window.clearTimeout(spinTimer.current)
@@ -582,6 +586,12 @@ export default function Roaming() {
       {tab === 'events' && (
         <div role="tabpanel" id="panel-events" aria-labelledby="tab-events" tabIndex={0}>
           <EventsPanel events={events} loading={eventsLoading} error={eventsError} noApi={eventsNoApi} typeFilter={eventsTypeFilter} setTypeFilter={setEventsTypeFilter} nameByMac={nameByMac} />
+        </div>
+      )}
+
+      {tab === 'reanchor' && (
+        <div role="tabpanel" id="panel-reanchor" aria-labelledby="tab-reanchor" tabIndex={0}>
+          <ReanchorPanel refreshTick={reanchorTick} />
         </div>
       )}
 

--- a/plans/netpulse-open-issues/phases/phase-1.md
+++ b/plans/netpulse-open-issues/phases/phase-1.md
@@ -1,0 +1,60 @@
+---
+type: planning
+entity: phase
+plan: netpulse-open-issues
+phase: 1
+status: completed
+created: 2026-09-01
+updated: 2026-09-01
+---
+
+# Phase 1: Quick wins y changelog en updater
+
+> Part of [netpulse-open-issues](../plan.md)
+
+## Objective
+
+Cerrar #309 (ya implementado) e implementar #404 para que el asistente de actualizacion muestre el changelog del release antes de aplicar.
+
+## Scope
+
+### Includes
+
+- Cerrar issue #309 como completado en GitHub.
+- Extender el dialogo/assistante de actualizacion del frontend para mostrar el cuerpo del release de GitHub o la seccion de CHANGELOG.md correspondiente.
+- Endpoint backend que sirva el changelog del release disponible (reutilizar release-check o GitHub API).
+- Manejo de errores: si no se puede cargar el changelog, mostrar enlace al release y dejar continuar.
+
+### Excludes
+
+- Cambios en la logica de descarga/aplicacion de updates.
+- Mejoras visuales del asistente mas alla del contenido del changelog.
+
+## Prerequisites
+
+- `main` estable en v2.23.5.
+- Acceso a la API de GitHub para obtener el release body.
+
+## Deliverables
+
+- [ ] Issue #309 cerrado.
+- [ ] Rama `feat/404-update-changelog` con backend y frontend.
+- [ ] PR, revision y merge en `main`.
+- [ ] Tests actualizados o nuevos para el endpoint de changelog.
+
+## Acceptance Criteria
+
+- [ ] Al abrir el asistente de update, se ve el cuerpo de las notas del release o un enlace si falla la carga.
+- [ ] `go test ./...`, `npm run build` y `npm run lint` verdes.
+- [ ] #404 cerrado con referencia al PR.
+
+## Dependencies on Other Phases
+
+| Phase | Relationship | Notes |
+|-------|-------------|-------|
+| Ninguna | - | - |
+
+## Notes
+
+- Se puede reutilizar `server-go/internal/updater` si ya consulta releases de GitHub.
+- El release body ya esta en ingles/espanol; mostrarlo tal cual.

--- a/plans/netpulse-open-issues/phases/phase-2.md
+++ b/plans/netpulse-open-issues/phases/phase-2.md
@@ -1,0 +1,63 @@
+---
+type: planning
+entity: phase
+plan: netpulse-open-issues
+phase: 2
+status: completed
+created: 2026-09-01
+updated: 2026-09-01
+---
+
+# Phase 2: Bugs de detección de puertos y dispositivos
+
+> Part of [netpulse-open-issues](../plan.md)
+
+## Objective
+
+Diagnosticar y corregir los problemas de detección de puertos en BPI-R4 (#413), UniFi 6 Plus (#416) y dispositivos descubiertos por IP que quedan offline (#415).
+
+## Scope
+
+### Includes
+
+- Análisis de logs y datos actuales de NetPulse para identificar por qué no se detectan ciertos puertos.
+- Revisión del scraper/poller de puertos (`server-go/internal/adapters/ports.go` y similares).
+- Correcciones para incluir WAN/SFP+ en BPI-R4 y eth0 en UniFi 6 Plus.
+- Corrección del flujo "Discover on network" para que los dispositivos añadidos por IP se consideren online.
+- Tests que cubran los casos corregidos.
+
+### Excludes
+
+- Cambios de arquitectura mayores en la detección de topología.
+- Soporte para nuevos tipos de interfaz fuera de los reportados.
+
+## Prerequisites
+
+- Fase 1 completada y `main` estable.
+- Acceso a los routers afectados o a logs/capturas del usuario.
+
+## Deliverables
+
+- [ ] Diagnóstico documentado en el issue o en la memoria.
+- [ ] Rama `fix/ports-discovery-bugs` con los fixes.
+- [ ] PR, revisión y merge en `main`.
+- [ ] Issues #413, #415 y #416 cerrados.
+
+## Acceptance Criteria
+
+- [ ] BPI-R4 reporta correctamente puertos WAN (ETH/SFP+).
+- [ ] UniFi 6 Plus reporta eth0.
+- [ ] Dispositivos añadidos por "Discover on network" aparecen online en el dashboard.
+- [ ] Tests verdes y build correcta.
+- [ ] Validación en CT 226 (si los dispositivos están disponibles) o feedback del usuario confirmando el arreglo.
+
+## Dependencies on Other Phases
+
+| Phase | Relationship | Notes |
+|-------|-------------|-------|
+| 1 | blocked-by | Se necesita `main` estable. |
+
+## Notes
+
+- Los tres issues probablemente comparten raíces en la normalización de nombres de interfaces o en el filtrado de puertos "físicos" vs virtuales.
+- Si no se puede reproducir en CT 226, se pedirá al usuario que ejecute comandos de diagnóstico en los routers afectados.

--- a/plans/netpulse-open-issues/phases/phase-3.md
+++ b/plans/netpulse-open-issues/phases/phase-3.md
@@ -1,0 +1,61 @@
+---
+type: planning
+entity: phase
+plan: netpulse-open-issues
+phase: 3
+status: completed
+created: 2026-09-01
+updated: 2026-09-01
+---
+
+# Phase 3: Tuning de SNMP y ghost ports
+
+> Part of [netpulse-open-issues](../plan.md)
+
+## Objective
+
+Reducir los falsos positivos "ghost port" en switches gestionados via SNMP (#414), permitiendo configurar el intervalo de polling SNMP y ajustar la logica de alertas.
+
+## Scope
+
+### Includes
+
+- Anadir opcion configurable de intervalo de polling SNMP por router/switch (default conservador).
+- Revisar logica de ghost-port para switches SNMP (contadores no siempre crecen con cada poll).
+- Añadir histeresis o cooldown antes de emitir alerta ghost-port en interfaces SNMP.
+- Exponer la configuracion en el formulario de edicion de router y en la API.
+- Tests para la nueva logica.
+
+### Excludes
+
+- Reescribir el poller SNMP desde cero.
+- Cambiar el comportamiento de ghost-port para routers OpenWrt (no SNMP).
+
+## Prerequisites
+
+- Funcionalidad SNMP ya en `main` (#309).
+- Acceso al switch Mikrotik CSS610 para validar thresholds.
+
+## Deliverables
+
+- [x] Rama `fix/414-snmp-ghost-tuning`.
+- [x] PR, revision y merge en `main` (PR #434).
+- [x] Issue #414 cerrado.
+
+## Acceptance Criteria
+
+- [x] Se puede configurar intervalo de polling SNMP en la UI/API.
+- [ ] Las alertas ghost-port en el Mikrotik CSS610 se reducen o desaparecen tras ajustar el intervalo/threshold. (pendiente de validacion en entorno real)
+- [x] Tests verdes y build correcta.
+- [ ] Validacion en CT 200 (donde esta el Reyee) o con el CSS610 del usuario. (pendiente de deploy)
+
+## Dependencies on Other Phases
+
+| Phase | Relationship | Notes |
+|-------|-------------|-------|
+| 2 | blocked-by | Para evitar mezclar cambios de deteccion de puertos con tuning SNMP. |
+
+## Notes
+
+- Revisar `server-go/internal/adapters/snmp_live.go` y `server-go/internal/snmp/ifTable.go`.
+- Posible relacion con #309: asegurar que los contadores se tratan como acumulativos y que los saltos de 32/64 bits no generan spikes.

--- a/plans/netpulse-open-issues/phases/phase-4.md
+++ b/plans/netpulse-open-issues/phases/phase-4.md
@@ -1,0 +1,62 @@
+---
+type: planning
+entity: phase
+plan: netpulse-open-issues
+phase: 4
+status: completed
+created: 2026-09-01
+updated: 2026-09-01
+---
+
+# Phase 4: Pagina /features
+
+> Part of [netpulse-open-issues](../plan.md)
+
+## Objective
+
+Publicar la pagina `/features` del marketing site con el inventario completo de funcionalidades y decisiones tecnicas (#412).
+
+## Scope
+
+### Includes
+
+- Rebasear `feat/412-features-page` sobre `main` actual.
+- Revisar contenido, i18n (ES/EN), enlaces de navegacion y cache-bust.
+- Verificar Lighthouse a11y >= 95.
+- Construir estatico `web/` y desplegar en webs2 `/opt/netpulse-web/public`.
+- PR, revision y merge.
+
+### Excludes
+
+- Manual de uso (#418), pospuesto.
+- Nuevas capturas que no esten ya en la rama.
+
+## Prerequisites
+
+- Fases 1-3 completadas.
+- Acceso a webs2 para despliegue de la landing.
+
+## Deliverables
+
+- [x] Rama `feat/412-features-page` actualizada y mergeada (como `feat/412-features-page-rebased`, PR #435).
+- [x] Issue #412 cerrado.
+- [ ] Landing deployada (pendiente de fase 6 / deploy).
+
+## Acceptance Criteria
+
+- [x] `/features` renderiza correctamente en claro/oscuro y ES/EN.
+- [x] Navegacion desde `/` a `/features` funciona.
+- [x] Lighthouse accessibility >= 95 (0.98 en local).
+- [x] No guiones largos/em dashes en el copy.
+- [x] Build de `web/` sin errores.
+
+## Dependencies on Other Phases
+
+| Phase | Relationship | Notes |
+|-------|-------------|-------|
+| 3 | blocked-by | Evitar conflictos con fases anteriores. |
+
+## Notes
+
+- La rama ya contiene `web/features.html`, `web/app.js`, capturas y i18n.
+- Validar que no se expongan datos reales de la red del usuario.

--- a/plans/netpulse-open-issues/phases/phase-5.md
+++ b/plans/netpulse-open-issues/phases/phase-5.md
@@ -1,0 +1,65 @@
+---
+type: planning
+entity: phase
+plan: netpulse-open-issues
+phase: 5
+status: completed
+created: 2026-09-01
+updated: 2026-09-01
+---
+
+# Phase 5: Asesor de re-anchor WiFi
+
+> Part of [netpulse-open-issues](../plan.md)
+
+## Objective
+
+Implementar un asesor de colocacion de clientes WiFi y accion de re-anchor manual, soportando DAWN y usteer y priorizando usteer (#403).
+
+## Scope
+
+### Includes
+
+- Rebasear `feat/403-wifi-reanchor` sobre `main`.
+- Extender el backend para consumir mapa de usteer (`/api/usteer`) ademas de DAWN.
+- Calcular recomendaciones por cliente: AP actual, senal, mejor alternativa, delta.
+- Umbral minimo de senal recomendada y delta configurables (default -65 dBm y +10 dBm).
+- Endpoint para listar recomendaciones y endpoint para ejecutar `del_client` con `ban_time`.
+- UI en pagina Roaming con tarjeta de recomendaciones y boton "Mover".
+- Tests para logica de recomendacion y constructor del comando SSH.
+
+### Excludes
+
+- Re-anchor automatico (Phase 2 del issue original); se deja para release futura.
+- Modificar configuracion de roaming en routers.
+
+## Prerequisites
+
+- Fases 1-4 completadas.
+- Red con usteer (casa u oficina) para validar.
+
+## Deliverables
+
+- [ ] Rama `feat/403-wifi-reanchor` rebasada y actualizada.
+- [ ] PR, revision y merge en `main`.
+- [ ] Issue #403 cerrado.
+
+## Acceptance Criteria
+
+- [ ] Backend devuelve recomendaciones para clientes suboptimos cuando hay usteer o DAWN disponible.
+- [ ] UI muestra recomendacion con senales y boton "Mover a <AP>".
+- [ ] Al aprobar, se ejecuta `del_client` correctamente y se informa del resultado.
+- [ ] Tests verdes y build correcta.
+- [ ] Validacion manual en red con usteer.
+
+## Dependencies on Other Phases
+
+| Phase | Relationship | Notes |
+|-------|-------------|-------|
+| 4 | blocked-by | La rama #403 es compleja; se deja para despues de los cambios mas simples. |
+
+## Notes
+
+- Reutilizar `server-go/internal/ssh/pool.go` para ejecutar `ubus call hostapd.<iface> del_client`.
+- Reutilizar tipos y parsers de `server-go/internal/adapters/usteer.go` y `dawn.go`.
+- Si usteer y DAWN coexisten, priorizar usteer.

--- a/plans/netpulse-open-issues/phases/phase-6.md
+++ b/plans/netpulse-open-issues/phases/phase-6.md
@@ -1,0 +1,62 @@
+---
+type: planning
+entity: phase
+plan: netpulse-open-issues
+phase: 6
+status: pending
+created: 2026-09-01
+updated: 2026-09-01
+---
+
+# Phase 6: Release v2.24.0 y deploy
+
+> Part of [netpulse-open-issues](../plan.md)
+
+## Objective
+
+Empaquetar todos los cambios en release v2.24.0, actualizar CT 226 y la demo online.
+
+## Scope
+
+### Includes
+
+- Actualizar `CHANGELOG.md` con los cambios de las fases 1-5.
+- Bump de version a v2.24.0 en `server-go/internal/httpapi/server.go`, `app/package.json`, `app/package-lock.json`.
+- Crear tag v2.24.0 y esperar CI.
+- Actualizar CT 226 via updater in-app.
+- Verificar `/api/health`.
+- Actualizar demo online (`web/` y/o app demo segun corresponda).
+- Cerrar issues de seguimiento/release si existen.
+
+### Excludes
+
+- Cambios de ultima hora no incluidos en las fases anteriores.
+
+## Prerequisites
+
+- Fases 1-5 completadas y mergeadas.
+- CI verde en `main`.
+
+## Deliverables
+
+- [ ] Tag v2.24.0.
+- [ ] CT 226 en v2.24.0 con health OK.
+- [ ] Demo online actualizada.
+
+## Acceptance Criteria
+
+- [ ] `gh release view v2.24.0` existe y CI es success.
+- [ ] `curl http://192.168.1.226:3000/api/health` devuelve version v2.24.0 y ok:true.
+- [ ] `curl -I https://demo.netpulse.cloudless.club/` devuelve HTTP/2 200.
+- [ ] Todos los issues del plan cerrados.
+
+## Dependencies on Other Phases
+
+| Phase | Relationship | Notes |
+|-------|-------------|-------|
+| 5 | blocked-by | No se puede release hasta que todo este mergeado. |
+
+## Notes
+
+- Incluir en el release body el changelog para que el updater lo muestre (#404).
+- Seguir la memoria de deploys anteriores para CT 226 y demo.

--- a/plans/netpulse-open-issues/plan.md
+++ b/plans/netpulse-open-issues/plan.md
@@ -1,0 +1,107 @@
+---
+type: planning
+entity: plan
+plan: netpulse-open-issues
+status: active
+created: 2026-09-01
+updated: 2026-09-01
+---
+
+# Plan: netpulse-open-issues
+
+## Problem / Context
+
+Tras cerrar v2.23.5 quedan 9 issues abiertos en `gnacho/netpulse`. Algunos son bugs concretos de deteccion de puertos/descubrimiento de dispositivos, otros son mejoras de UX (#404), funcionalidad WiFi (#403) y contenido web (#412/#418). El objetivo es cerrarlos de forma coordinada, minimizando rebases y despliegues parciales.
+
+## Target Outcome
+
+Todos los issues del alcance cerrados y mergeados en `main`, con tests verdes, build correcta y despliegue validado en CT 226 y demo online.
+
+## Guiding Decisions & Constraints
+
+- **No despliegues manuales en produccion salvo validacion explicita**: CT 226 se actualiza via updater in-app; la demo se despliega con build estatico.
+- **Issue → rama → PR → merge**: cada cambio sigue el flujo estandar del repo.
+- **v2.23.5 acaba de salir**: la siguiente release que agrupe estos cambios sera **v2.24.0** (salvo que el usuario decida otra cosa).
+- **#403**: migrar/redisenar para soportar DAWN y usteer, priorizando usteer cuando este disponible, ya que la infraestructura real del usuario usa usteer.
+- **#418**: pospuesto explicitamente por el usuario; no entra en este plan.
+- **#309**: ya esta implementado en `main`; se cierra como completado sin mas codigo.
+
+## Scope-Bounding Assumptions
+
+- Los bugs de puertos (#413, #416) y descubrimiento (#415) se podran reproducir/diagnosticar con datos del entorno real del usuario o con logs que ya existen.
+- Para #414 se asume que el usuario puede confirmar el intervalo de polling deseado y validar el comportamiento en su Mikrotik CSS610.
+
+## Requirements
+
+### Functional
+
+- [ ] Cerrar #309 como completado.
+- [ ] #404: el asistente de actualizacion muestra el changelog/release notes del release ofrecido.
+- [x] #403: endpoint backend que recomienda re-anchor de clientes WiFi; accion manual de aprobacion; compatible con DAWN y usteer.
+- [ ] #412: pagina `/features` publicada, con contenido completo y enlaces de navegacion.
+- [ ] #413, #415, #416: corregir deteccion de puertos WAN/SFP+ y dispositivos descubiertos por IP.
+- [ ] #414: permitir configurar el intervalo de polling SNMP y reducir falsos positivos ghost-port en switches SNMP.
+
+### Non-Functional
+
+- [ ] `go test ./...`, `npm run build` y `npm run lint` verdes antes de cada merge.
+- [ ] Build de landing (`web/`) sin regresiones ni em/en dashes.
+- [ ] Actualizar `CHANGELOG.md` y version bump para la release agrupada.
+
+## Scope
+
+### In Scope
+
+- #309 (cierre administrativo), #403, #404, #412, #413, #414, #415, #416.
+- Rama `feat/412-features-page`: rebase, ajustes y PR.
+- Rama `feat/403-wifi-reanchor`: rebase, adaptacion a usteer, PR.
+
+### Out of Scope
+
+- #418 (manual how-to): pospuesto por el usuario.
+- Cambios en el agente OpenWrt salvo los necesarios para los issues del alcance.
+- Mejoras no relacionadas con los issues abiertos.
+
+## Definition of Done
+
+- [ ] Todos los issues del alcance estan cerrados en GitHub.
+- [ ] Todos los PRs estan mergeados en `main`.
+- [ ] `CHANGELOG.md` refleja los cambios agrupados.
+- [ ] Tag v2.24.0 creado y CI verde.
+- [ ] CT 226 actualizado a v2.24.0 y `/api/health` OK.
+- [ ] Demo online (`demo.netpulse.cloudless.club`) actualizada y responde 200.
+
+## Testing Strategy
+
+- Tests automaticos: `go test ./...` (backend/agente), `npm run build` y `npm run lint` (frontend), build estatico de `web/`.
+- Validacion manual en CT 226 para #403, #413, #415, #416, #414.
+- Validacion visual/demo para #412.
+- Verificacion del updater in-app para #404 en CT 226 tras el release.
+
+## Phases
+
+| Phase | Title | Contribution | Why Separate | Detail | Status |
+|-------|-------|--------------|--------------|--------|--------|
+| 1 | Quick wins y changelog en updater | Cerrar #309 e implementar #404 | Cambios pequenos y listos para merge inmediato | [Phase 1](phases/phase-1.md) | completed |
+| 2 | Bugs de deteccion de puertos y dispositivos | Resolver #413, #415, #416 | Requieren diagnostico y posiblemente logs del entorno real | [Phase 2](phases/phase-2.md) | completed |
+| 3 | Tuning de SNMP y ghost ports | Resolver #414 | Depende de la funcionalidad SNMP ya en main | [Phase 3](phases/phase-3.md) | completed |
+| 4 | Pagina /features | Resolver #412 | Trabajo de marketing site separado del backend | [Phase 4](phases/phase-4.md) | completed |
+| 5 | Asesor de re-anchor WiFi | Resolver #403 | Mayor complejidad y rebase de rama existente | [Phase 5](phases/phase-5.md) | completed |
+| 6 | Release v2.24.0 y deploy | Empaquetar todo y actualizar CT/demo | Gate final de entrega | [Phase 6](phases/phase-6.md) | in_progress |
+
+## Risks & Open Questions
+
+| Risk/Question | Impact | Mitigation/Answer |
+|---------------|--------|-------------------|
+| Rama `feat/403-wifi-reanchor` es antigua y usa DAWN; adaptar a usteer puede requerir refactor notable. | Retraso en fase 5 | Hacer primero las fases mas pequenas; rebase temprano. |
+| Diagnostico de #413/#415/#416 puede depender de datos especificos de routers/switches del usuario. | Bloqueo si no hay acceso/logs | Pedir al usuario capturas de `ubus`/`ip`/`swconfig` o logs de NetPulse. |
+| #414 requiere validar en Mikrotik CSS610 para ajustar thresholds. | Falsos positivos persistentes | Dejar intervalo/threshold configurables y pedir feedback. |
+
+## Changelog
+
+### 2026-09-01
+
+- Plan creado con 6 fases y alcance confirmado por el usuario.
+- Fase 1 completada: #309 cerrado, #404 mergeado en PR #432.
+- Fase 2 completada: #413, #415, #416 cerrados y mergeados en PR #433.
+- Fase 3 iniciada: tuning SNMP y ghost ports (#414).

--- a/plans/netpulse-open-issues/todo.md
+++ b/plans/netpulse-open-issues/todo.md
@@ -1,0 +1,55 @@
+---
+type: planning
+entity: todo
+plan: netpulse-open-issues
+updated: 2026-09-01
+---
+
+# Todo: netpulse-open-issues
+
+> Tracking [netpulse-open-issues](plan.md)
+
+## Active Phase: none
+
+All planned phases are complete.
+
+### Phase Context
+
+- **Scope**: [Phase 5](phases/phase-5.md)
+- **Implementation**: Completed
+- **Latest Handover**: None
+- **Relevant Docs**: `server-go/internal/adapters/reanchor.go`, `server-go/internal/httpapi/reanchor.go`, `app/src/pages/ReanchorPanel.tsx`, issue #403
+
+### Pending
+
+- [ ] n/a
+
+### In Progress
+
+- [ ] n/a
+
+### Completed
+
+- [x] Crear plan con 6 fases <!-- completed: 2026-09-01 -->
+- [x] Cerrar issue #309 como completado <!-- completed: 2026-09-01 -->
+- [x] Implementar y mergear fix #404 changelog en updater (PR #432) <!-- completed: 2026-09-01 -->
+- [x] Implementar y mergear fixes #413/#415/#416 (PR #433) <!-- completed: 2026-09-01 -->
+- [x] Tuning SNMP (#414) mergeado en PR #434 <!-- completed: 2026-09-01 -->
+- [x] Pagina `/features` (#412) mergeada en PR #435 <!-- completed: 2026-09-01 -->
+- [x] Asesor de re-anchor WiFi (#403) implementado y testado <!-- completed: 2026-09-01 -->
+
+### Blocked
+
+- [ ] n/a
+
+## Changelog
+
+### 2026-09-01
+
+- Plan creado y fase 1 activada.
+- Usuario confirmo: #309 cerrar como hecho, #403 compatibilidad DAWN+usteer, #418 pospuesto, alcance completo.
+- Fase 1 completada: #309 cerrado, #404 mergeado en PR #432.
+- Fase 2 completada: #413, #415, #416 mergeados en PR #433.
+- Fase 3 completada: #414 mergeado en PR #434.
+- Fase 4 completada: #412 mergeado en PR #435.
+- Fase 5 iniciada: asesor de re-anchor WiFi (#403).

--- a/server-go/internal/adapters/demo.go
+++ b/server-go/internal/adapters/demo.go
@@ -191,6 +191,11 @@ func (d *Demo) GetUsteer(context.Context) (*Usteer, error) { return nil, nil }
 // KickUsteerClient no-op en demo.
 func (d *Demo) KickUsteerClient(context.Context, string) error { return errors.New("not available in demo") }
 
+// GetReanchorRecommendations no-op en demo.
+func (d *Demo) GetReanchorRecommendations(context.Context, ReanchorConfig) ([]ReanchorRecommendation, RoamingDaemon, error) {
+	return []ReanchorRecommendation{}, RoamingDaemonNone, nil
+}
+
 func (d *Demo) GetDot11r(context.Context) (*Dot11rOverview, error) { return nil, nil }
 
 func (d *Demo) GetSurvey(context.Context) (*SurveyOverview, error) { return nil, nil }

--- a/server-go/internal/adapters/reanchor.go
+++ b/server-go/internal/adapters/reanchor.go
@@ -1,0 +1,518 @@
+// reanchor.go — recomendaciones de re-anclaje WiFi (issue #403).
+//
+// El motor prueba primero usteer (daemon preferido) y, si no está disponible,
+// recurre a DAWN. Para usteer usa `local_info` + `remote_info` para el
+// inventario de APs, `connected_clients` para saber dónde está cada cliente y
+// `get_clients` como hearing map. Para DAWN usa `get_network` + `get_hearing_map`.
+package adapters
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Umbrales por defecto del re-anclaje: -65 dBm mínimo para el destino y 10 dBm
+// de mejora respecto al AP actual.
+const (
+	reanchorMinRecommendedSignal = -65
+	reanchorMinDeltaDbm          = 10
+)
+
+// GetReanchorRecommendations devuelve recomendaciones de re-anclaje WiFi.
+// Prefiere usteer; si ningún router responde con usteer, prueba DAWN.
+func (l *Live) GetReanchorRecommendations(ctx context.Context, cfg ReanchorConfig) ([]ReanchorRecommendation, RoamingDaemon, error) {
+	l.mu.Lock()
+	routers := append([]RouterConfig(nil), l.routers...)
+	l.mu.Unlock()
+
+	if cfg.MinRecommendedSignal == 0 {
+		cfg.MinRecommendedSignal = reanchorMinRecommendedSignal
+	}
+	if cfg.MinDeltaDbm == 0 {
+		cfg.MinDeltaDbm = reanchorMinDeltaDbm
+	}
+
+	if recs, ok := usteerReanchor(ctx, routers, cfg, l.pool); ok {
+		return recs, RoamingDaemonUsteer, nil
+	}
+	if recs, ok := dawnReanchor(ctx, routers, cfg, l.pool); ok {
+		return recs, RoamingDaemonDawn, nil
+	}
+	return []ReanchorRecommendation{}, RoamingDaemonNone, nil
+}
+
+// ---------------------------------------------------------------------------
+// usteer
+// ---------------------------------------------------------------------------
+
+// usteerHearingRaw es una entrada de `ubus call usteer get_clients`:
+// { "connected": bool, "signal": int }.
+type usteerHearingRaw struct {
+	Connected bool `json:"connected"`
+	Signal    int  `json:"signal"`
+}
+
+// usteerAPInfo almacena la metainformación de un AP (local o remoto) para
+// convertir el nombre de nodo devuelto por usteer en datos legibles.
+type usteerAPInfo struct {
+	BSSID    string
+	SSID     string
+	Freq     int
+	Hostname string
+	Iface    string
+	Local    bool
+	Host     string // solo para APs locales; SSH host donde ejecutar del_client
+}
+
+// usteerReanchor devuelve (recomendaciones, true) si al menos un router responde
+// con usteer local_info. Si no hay usteer devuelve (nil, false).
+func usteerReanchor(ctx context.Context, routers []RouterConfig, cfg ReanchorConfig, runner sshRunner) ([]ReanchorRecommendation, bool) {
+	apByNode := make(map[string]usteerAPInfo) // nombre de nodo usteer -> AP
+	currentByMAC := make(map[string]struct {
+		node   string
+		signal int
+		host   string
+	})
+	hearing := make(map[string]map[string]int) // MAC -> nodo -> mejor señal
+	found := false
+
+	for _, rt := range routers {
+		if rt.AgentOnly || rt.Host == "" {
+			continue
+		}
+		name := rt.Name
+		if name == "" {
+			name = rt.ID
+		}
+
+		// APs locales: nombre de nodo = iface.
+		localOut, _ := runner.Run(rt.Host, "ubus call usteer local_info", 0)
+		var local map[string]usteerAPRaw
+		if err := json.Unmarshal([]byte(localOut), &local); err != nil {
+			continue
+		}
+		if len(local) > 0 {
+			found = true
+		}
+		for iface, raw := range local {
+			if raw.SSID == "" || raw.BSSID == "" {
+				continue
+			}
+			apByNode[iface] = usteerAPInfo{
+				BSSID:    strings.ToUpper(raw.BSSID),
+				SSID:     raw.SSID,
+				Freq:     raw.Freq,
+				Hostname: name,
+				Iface:    iface,
+				Local:    true,
+				Host:     rt.Host,
+			}
+		}
+
+		// APs remotos: nombre de nodo = "IP#iface".
+		remoteOut, _ := runner.Run(rt.Host, "ubus call usteer remote_info", 0)
+		var remote map[string]usteerAPRaw
+		if err := json.Unmarshal([]byte(remoteOut), &remote); err == nil {
+			for node, raw := range remote {
+				if raw.SSID == "" || raw.BSSID == "" {
+					continue
+				}
+				if _, exists := apByNode[node]; exists {
+					continue
+				}
+				apByNode[node] = usteerAPInfo{
+					BSSID:    strings.ToUpper(raw.BSSID),
+					SSID:     raw.SSID,
+					Freq:     raw.Freq,
+					Hostname: usteerRemoteHostname(node, routers, raw.BSSID),
+					Iface:    usteerRemoteIface(node),
+					Local:    false,
+				}
+			}
+		}
+
+		// Clientes conectados en este router (solo nodos locales).
+		clientsOut, _ := runner.Run(rt.Host, "ubus call usteer connected_clients", 0)
+		var clients map[string]map[string]usteerClientRaw
+		if err := json.Unmarshal([]byte(clientsOut), &clients); err == nil {
+			for iface, macs := range clients {
+				for mac, c := range macs {
+					if c.Signal >= 0 {
+						continue
+					}
+					mac = strings.ToUpper(mac)
+					currentByMAC[mac] = struct {
+						node   string
+						signal int
+						host   string
+					}{node: iface, signal: c.Signal, host: rt.Host}
+				}
+			}
+		}
+
+		// Hearing map global de usteer.
+		hearOut, _ := runner.Run(rt.Host, "ubus call usteer get_clients", 0)
+		var hear map[string]map[string]usteerHearingRaw
+		if err := json.Unmarshal([]byte(hearOut), &hear); err == nil {
+			for mac, nodes := range hear {
+				mac = strings.ToUpper(mac)
+				if hearing[mac] == nil {
+					hearing[mac] = make(map[string]int)
+				}
+				for node, h := range nodes {
+					if h.Signal >= 0 {
+						continue
+					}
+					if prev, ok := hearing[mac][node]; !ok || h.Signal > prev {
+						hearing[mac][node] = h.Signal
+					}
+				}
+			}
+		}
+	}
+
+	if !found {
+		return nil, false
+	}
+
+	var recs []ReanchorRecommendation
+	for mac, current := range currentByMAC {
+		hearMap, ok := hearing[mac]
+		if !ok {
+			continue
+		}
+		currentAP, ok := apByNode[current.node]
+		if !ok {
+			continue
+		}
+		var bestNode string
+		var bestSignal int
+		for node, signal := range hearMap {
+			if node == current.node {
+				continue
+			}
+			if bestNode == "" || signal > bestSignal {
+				bestNode = node
+				bestSignal = signal
+			}
+		}
+		if bestNode == "" {
+			continue
+		}
+		if bestSignal < cfg.MinRecommendedSignal {
+			continue
+		}
+		if bestSignal-current.signal < cfg.MinDeltaDbm {
+			continue
+		}
+		recommendedAP := apByNode[bestNode]
+		recs = append(recs, ReanchorRecommendation{
+			MAC:                 mac,
+			CurrentBSSID:        currentAP.BSSID,
+			CurrentHostname:     currentAP.Hostname,
+			CurrentIface:        currentAP.Iface,
+			CurrentHost:         current.host,
+			CurrentSignal:       current.signal,
+			RecommendedBSSID:    recommendedAP.BSSID,
+			RecommendedHostname: recommendedAP.Hostname,
+			RecommendedIface:    recommendedAP.Iface,
+			RecommendedSignal:   bestSignal,
+			DeltaDbm:            bestSignal - current.signal,
+		})
+	}
+
+	sort.Slice(recs, func(i, j int) bool {
+		if recs[i].DeltaDbm != recs[j].DeltaDbm {
+			return recs[i].DeltaDbm > recs[j].DeltaDbm
+		}
+		return recs[i].MAC < recs[j].MAC
+	})
+	return recs, true
+}
+
+// usteerRemoteHostname devuelve un nombre amigable para un nodo remoto. Si el
+// prefijo IP coincide con un router conocido, usa su nombre; si no, muestra
+// la propia IP.
+func usteerRemoteHostname(node string, routers []RouterConfig, bssid string) string {
+	const sep = "#"
+	idx := strings.Index(node, sep)
+	if idx < 0 {
+		return bssid
+	}
+	ip := node[:idx]
+	for _, r := range routers {
+		if r.Host == ip {
+			name := r.Name
+			if name == "" {
+				name = r.ID
+			}
+			return name
+		}
+	}
+	return ip
+}
+
+// usteerRemoteIface extrae la parte de iface del nombre de nodo remoto
+// ("IP#iface" -> "iface").
+func usteerRemoteIface(node string) string {
+	const sep = "#"
+	idx := strings.Index(node, sep)
+	if idx < 0 {
+		return node
+	}
+	return node[idx+len(sep):]
+}
+
+// ---------------------------------------------------------------------------
+// DAWN (fallback)
+// ---------------------------------------------------------------------------
+
+// DawnNetworkFromHost ejecuta `ubus call dawn get_network` en un host concreto
+// y devuelve los APs parseados. Devuelve nil si falla el SSH o el parseo.
+func DawnNetworkFromHost(ctx context.Context, host string, runner sshRunner) []DawnAP {
+	if host == "" {
+		return nil
+	}
+	out, err := runner.Run(host, "ubus call dawn get_network", 0)
+	if err != nil {
+		return nil
+	}
+	var data map[string]map[string]json.RawMessage
+	if json.Unmarshal([]byte(out), &data) != nil {
+		return nil
+	}
+	return dawnAPsFromNetwork(data)
+}
+
+// DawnHearingMapFromHost ejecuta `ubus call dawn get_hearing_map` en un host
+// concreto. Devuelve map[MAC] -> map[BSSID] -> signal. Los MAC y BSSID se
+// normalizan a mayúsculas.
+func DawnHearingMapFromHost(ctx context.Context, host string, runner sshRunner) map[string]map[string]int {
+	if host == "" {
+		return nil
+	}
+	out, err := runner.Run(host, "ubus call dawn get_hearing_map", 0)
+	if err != nil {
+		return nil
+	}
+	return parseDawnHearingMap(out)
+}
+
+// parseDawnHearingMap parsea la salida JSON de `ubus call dawn get_hearing_map`.
+// Estructura: { SSID: { MAC: { BSSID: { signal, freq, ... } } } }
+func parseDawnHearingMap(out string) map[string]map[string]int {
+	var raw map[string]map[string]map[string]map[string]json.RawMessage
+	if json.Unmarshal([]byte(out), &raw) != nil {
+		return nil
+	}
+	res := make(map[string]map[string]int)
+	for _, clients := range raw {
+		for mac, bssids := range clients {
+			mac = strings.ToUpper(mac)
+			if res[mac] == nil {
+				res[mac] = make(map[string]int)
+			}
+			for bssid, fields := range bssids {
+				bssid = strings.ToUpper(bssid)
+				signalRaw, ok := fields["signal"]
+				if !ok {
+					continue
+				}
+				var s int
+				if json.Unmarshal(signalRaw, &s) != nil {
+					continue
+				}
+				// signal=0 suele significar "no medido"; lo ignoramos.
+				if s >= 0 {
+					continue
+				}
+				// Quedarse con la mejor señal (mayor valor, -50 > -80).
+				if prev, ok := res[mac][bssid]; !ok || s > prev {
+					res[mac][bssid] = s
+				}
+			}
+		}
+	}
+	return res
+}
+
+// dawnAPsFromNetwork extrae los APs del JSON de `ubus call dawn get_network`.
+// Estructura: { SSID: { BSSID: { ... } } }
+func dawnAPsFromNetwork(data map[string]map[string]json.RawMessage) []DawnAP {
+	var aps []DawnAP
+	for ssid, bssids := range data {
+		for bssidRaw, raw := range bssids {
+			bssid := strings.ToUpper(bssidRaw)
+			var ap dawnAPData
+			if json.Unmarshal(raw, &ap) != nil {
+				continue
+			}
+			band := "2.4 GHz"
+			if ap.Freq >= 5000 {
+				band = "5 GHz"
+			}
+			var clients []DawnClient
+			for mac, c := range ap.Clients {
+				if c.Signal >= 0 {
+					continue
+				}
+				clients = append(clients, DawnClient{
+					MAC:    strings.ToUpper(mac),
+					Signal: c.Signal,
+					HT:     c.HT,
+					VHT:    c.VHT,
+				})
+			}
+			sort.Slice(clients, func(i, j int) bool { return clients[i].MAC < clients[j].MAC })
+			aps = append(aps, DawnAP{
+				SSID:           ssid,
+				BSSID:          bssid,
+				Hostname:       ap.Hostname,
+				Band:           band,
+				Channel:        ap.Channel,
+				UtilizationPct: ap.UtilizationPct,
+				ClientCount:    ap.ClientCount,
+				Clients:        clients,
+				Local:          ap.Local,
+				Iface:          ap.Iface,
+			})
+		}
+	}
+	return aps
+}
+
+// dawnAPData es la forma interna de un AP en `get_network`.
+type dawnAPData struct {
+	Hostname       string                     `json:"hostname"`
+	Freq           int                        `json:"freq"`
+	Channel        int                        `json:"channel"`
+	UtilizationPct float64                    `json:"utilization"`
+	ClientCount    int                        `json:"num_sta"`
+	Clients        map[string]dawnClientData  `json:"clients"`
+	Local          bool                       `json:"local"`
+	Iface          string                     `json:"iface"`
+}
+
+type dawnClientData struct {
+	Signal int  `json:"signal"`
+	HT     bool `json:"ht"`
+	VHT    bool `json:"vht"`
+}
+
+// dawnReanchor devuelve (recomendaciones, true) si al menos un router responde
+// con DAWN. Si no hay DAWN devuelve (nil, false).
+func dawnReanchor(ctx context.Context, routers []RouterConfig, cfg ReanchorConfig, runner sshRunner) ([]ReanchorRecommendation, bool) {
+	apByBSSID := make(map[string]DawnAP)
+	currentByMAC := make(map[string]struct {
+		bssid  string
+		signal int
+		host   string
+	})
+	hearing := make(map[string]map[string]int)
+	found := false
+
+	for _, rt := range routers {
+		if rt.AgentOnly || rt.Host == "" {
+			continue
+		}
+		aps := DawnNetworkFromHost(ctx, rt.Host, runner)
+		if len(aps) > 0 {
+			found = true
+		}
+		for _, ap := range aps {
+			ap.BSSID = strings.ToUpper(ap.BSSID)
+			if _, exists := apByBSSID[ap.BSSID]; !exists {
+				apByBSSID[ap.BSSID] = ap
+			}
+			if !ap.Local {
+				continue
+			}
+			for _, c := range ap.Clients {
+				c.MAC = strings.ToUpper(c.MAC)
+				currentByMAC[c.MAC] = struct {
+					bssid  string
+					signal int
+					host   string
+				}{bssid: ap.BSSID, signal: c.Signal, host: rt.Host}
+			}
+		}
+
+		hm := DawnHearingMapFromHost(ctx, rt.Host, runner)
+		for mac, bssids := range hm {
+			if hearing[mac] == nil {
+				hearing[mac] = make(map[string]int)
+			}
+			for bssid, signal := range bssids {
+				if prev, ok := hearing[mac][bssid]; !ok || signal > prev {
+					hearing[mac][bssid] = signal
+				}
+			}
+		}
+	}
+
+	if !found {
+		return nil, false
+	}
+
+	var recs []ReanchorRecommendation
+	for mac, current := range currentByMAC {
+		hearingMap, ok := hearing[mac]
+		if !ok {
+			continue
+		}
+		currentAP := apByBSSID[current.bssid]
+		var bestBSSID string
+		var bestSignal int
+		for bssid, signal := range hearingMap {
+			if bssid == current.bssid {
+				continue
+			}
+			if bestBSSID == "" || signal > bestSignal {
+				bestBSSID = bssid
+				bestSignal = signal
+			}
+		}
+		if bestBSSID == "" {
+			continue
+		}
+		if bestSignal < cfg.MinRecommendedSignal {
+			continue
+		}
+		if bestSignal-current.signal < cfg.MinDeltaDbm {
+			continue
+		}
+		recommendedAP := apByBSSID[bestBSSID]
+		recs = append(recs, ReanchorRecommendation{
+			MAC:                 mac,
+			CurrentBSSID:        current.bssid,
+			CurrentHostname:     currentAP.Hostname,
+			CurrentIface:        currentAP.Iface,
+			CurrentHost:         current.host,
+			CurrentSignal:       current.signal,
+			RecommendedBSSID:    bestBSSID,
+			RecommendedHostname: recommendedAP.Hostname,
+			RecommendedIface:    recommendedAP.Iface,
+			RecommendedSignal:   bestSignal,
+			DeltaDbm:            bestSignal - current.signal,
+		})
+	}
+
+	sort.Slice(recs, func(i, j int) bool {
+		if recs[i].DeltaDbm != recs[j].DeltaDbm {
+			return recs[i].DeltaDbm > recs[j].DeltaDbm
+		}
+		return recs[i].MAC < recs[j].MAC
+	})
+	return recs, true
+}
+
+// ReanchorKickScript genera el comando hostapd del_client para expulsar a un
+// cliente de un AP. Se ejecuta en el host donde está el AP actual (DAWN).
+func ReanchorKickScript(mac string, iface string) string {
+	mac = strings.ToUpper(mac)
+	return fmt.Sprintf("ubus call hostapd.%s del_client '{\"addr\":\"%s\",\"reason\":5,\"deauth\":true,\"ban_time\":120000}'",
+		iface, mac)
+}

--- a/server-go/internal/adapters/reanchor_test.go
+++ b/server-go/internal/adapters/reanchor_test.go
@@ -1,0 +1,187 @@
+package adapters
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// reanchorRunner es un fake sshRunner genérico para los tests de re-anchor.
+type reanchorRunner struct {
+	responses map[string]string
+	errors    map[string]error
+}
+
+func (r *reanchorRunner) Run(host, cmd string, timeout time.Duration) (string, error) {
+	key := host + "|" + cmd
+	if e, ok := r.errors[key]; ok {
+		return "", e
+	}
+	return r.responses[key], nil
+}
+
+func TestReanchorUsteer(t *testing.T) {
+	const (
+		local1 = `{
+  "hostapd.phy0-ap0": { "bssid": "9c:9d:7e:1b:ea:b3", "ssid": "temiscira", "freq": 5260, "n_assoc": 1, "load": 3 },
+  "hostapd.phy1-ap0": { "bssid": "9c:9d:7e:1b:ea:b2", "ssid": "temiscira", "freq": 2442, "n_assoc": 0, "load": 10 }
+}`
+		local2 = `{
+  "hostapd.phy0-ap0": { "bssid": "cc:d8:43:b1:e5:97", "ssid": "temiscira", "freq": 5180, "n_assoc": 0, "load": 5 }
+}`
+		remote2 = `{
+  "192.168.1.2#hostapd.phy0-ap0": { "bssid": "9c:9d:7e:1b:ea:b3", "ssid": "temiscira", "freq": 5260, "n_assoc": 1, "load": 3 },
+  "192.168.1.2#hostapd.phy1-ap0": { "bssid": "9c:9d:7e:1b:ea:b2", "ssid": "temiscira", "freq": 2442, "n_assoc": 0, "load": 10 }
+}`
+		connected1 = `{
+  "hostapd.phy1-ap0": { "aa:bb:cc:dd:ee:ff": { "signal": -80 } }
+}`
+		hearing1 = `{
+  "aa:bb:cc:dd:ee:ff": {
+    "hostapd.phy1-ap0": { "connected": true, "signal": -80 },
+    "192.168.1.2#hostapd.phy0-ap0": { "connected": false, "signal": -55 }
+  }
+}`
+	)
+
+	runner := &reanchorRunner{
+		responses: map[string]string{
+			"192.168.1.1|ubus call usteer local_info":        local1,
+			"192.168.1.1|ubus call usteer remote_info":       "{}",
+			"192.168.1.1|ubus call usteer connected_clients": connected1,
+			"192.168.1.1|ubus call usteer get_clients":       hearing1,
+			"192.168.1.2|ubus call usteer local_info":        local2,
+			"192.168.1.2|ubus call usteer remote_info":       remote2,
+			"192.168.1.2|ubus call usteer connected_clients": "{}",
+			"192.168.1.2|ubus call usteer get_clients":       "{}",
+		},
+	}
+	routers := []RouterConfig{
+		{ID: "rt1", Name: "rt1", Host: "192.168.1.1"},
+		{ID: "rt2", Name: "rt2", Host: "192.168.1.2"},
+	}
+
+	recs, ok := usteerReanchor(context.Background(), routers, ReanchorConfig{MinRecommendedSignal: -65, MinDeltaDbm: 10}, runner)
+	if !ok {
+		t.Fatal("expected usteer available")
+	}
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 recommendation, got %d", len(recs))
+	}
+	r := recs[0]
+	if r.MAC != "AA:BB:CC:DD:EE:FF" {
+		t.Errorf("mac = %q", r.MAC)
+	}
+	if r.CurrentBSSID != "9C:9D:7E:1B:EA:B2" || r.RecommendedBSSID != "9C:9D:7E:1B:EA:B3" {
+		t.Errorf("current/recommended bssid = %q / %q", r.CurrentBSSID, r.RecommendedBSSID)
+	}
+	if r.DeltaDbm != 25 {
+		t.Errorf("delta = %d, want 25", r.DeltaDbm)
+	}
+	if r.CurrentHost != "192.168.1.1" {
+		t.Errorf("current host = %q, want 192.168.1.1", r.CurrentHost)
+	}
+}
+
+func TestReanchorUsteerNoRecommendation(t *testing.T) {
+	const (
+		local1 = `{
+  "hostapd.phy0-ap0": { "bssid": "9c:9d:7e:1b:ea:b3", "ssid": "temiscira", "freq": 5260, "n_assoc": 1, "load": 3 }
+}`
+		connected1 = `{
+  "hostapd.phy0-ap0": { "aa:bb:cc:dd:ee:ff": { "signal": -55 } }
+}`
+		hearing1 = `{
+  "aa:bb:cc:dd:ee:ff": {
+    "hostapd.phy0-ap0": { "connected": true, "signal": -55 },
+    "192.168.1.2#hostapd.phy0-ap0": { "connected": false, "signal": -60 }
+  }
+}`
+	)
+	runner := &reanchorRunner{
+		responses: map[string]string{
+			"192.168.1.1|ubus call usteer local_info":        local1,
+			"192.168.1.1|ubus call usteer remote_info":       "{}",
+			"192.168.1.1|ubus call usteer connected_clients": connected1,
+			"192.168.1.1|ubus call usteer get_clients":       hearing1,
+		},
+	}
+	routers := []RouterConfig{{ID: "rt1", Name: "rt1", Host: "192.168.1.1"}}
+
+	recs, ok := usteerReanchor(context.Background(), routers, ReanchorConfig{MinRecommendedSignal: -65, MinDeltaDbm: 10}, runner)
+	if !ok {
+		t.Fatal("expected usteer available")
+	}
+	if len(recs) != 0 {
+		t.Fatalf("expected 0 recommendations, got %+v", recs)
+	}
+}
+
+func TestReanchorUsteerFallsBackToDawn(t *testing.T) {
+	const (
+		network = `{
+  "temiscira": {
+    "9c:9d:7e:1b:ea:b2": {
+      "hostname": "rt1", "freq": 2442, "channel": 6, "utilization": 10, "num_sta": 1,
+      "clients": { "aa:bb:cc:dd:ee:ff": { "signal": -80 } },
+      "local": true, "iface": "wlan0"
+    },
+    "9c:9d:7e:1b:ea:b3": {
+      "hostname": "rt2", "freq": 5260, "channel": 48, "utilization": 5, "num_sta": 0,
+      "clients": {},
+      "local": false, "iface": "wlan1"
+    }
+  }
+}`
+		hearing = `{
+  "temiscira": {
+    "aa:bb:cc:dd:ee:ff": {
+      "9c:9d:7e:1b:ea:b2": { "signal": -80 },
+      "9c:9d:7e:1b:ea:b3": { "signal": -55 }
+    }
+  }
+}`
+	)
+	runner := &reanchorRunner{
+		responses: map[string]string{
+			"192.168.1.1|ubus call usteer local_info":    "{}",
+			"192.168.1.1|ubus call dawn get_network":     network,
+			"192.168.1.1|ubus call dawn get_hearing_map": hearing,
+		},
+	}
+	routers := []RouterConfig{{ID: "rt1", Name: "rt1", Host: "192.168.1.1"}}
+
+	recs, ok := dawnReanchor(context.Background(), routers, ReanchorConfig{MinRecommendedSignal: -65, MinDeltaDbm: 10}, runner)
+	if !ok {
+		t.Fatal("expected DAWN available")
+	}
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 recommendation, got %d", len(recs))
+	}
+}
+
+func TestReanchorNone(t *testing.T) {
+	runner := &reanchorRunner{
+		responses: map[string]string{
+			"192.168.1.1|ubus call usteer local_info": "{}",
+			"192.168.1.1|ubus call dawn get_network":  "{}",
+		},
+	}
+	routers := []RouterConfig{{ID: "rt1", Name: "rt1", Host: "192.168.1.1"}}
+
+	if _, ok := usteerReanchor(context.Background(), routers, ReanchorConfig{}, runner); ok {
+		t.Fatal("expected no usteer")
+	}
+	if _, ok := dawnReanchor(context.Background(), routers, ReanchorConfig{}, runner); ok {
+		t.Fatal("expected no DAWN")
+	}
+}
+
+func TestReanchorKickScript(t *testing.T) {
+	got := ReanchorKickScript("aa:bb:cc:dd:ee:ff", "wlan0")
+	want := fmt.Sprintf("ubus call hostapd.wlan0 del_client '{\"addr\":\"AA:BB:CC:DD:EE:FF\",\"reason\":5,\"deauth\":true,\"ban_time\":120000}'")
+	if got != want {
+		t.Fatalf("script = %q, want %q", got, want)
+	}
+}

--- a/server-go/internal/adapters/types.go
+++ b/server-go/internal/adapters/types.go
@@ -403,6 +403,39 @@ type UsteerOverview struct {
 	Available bool `json:"available"`
 }
 
+// ---------------------------------------------------------------------------
+// Re-anchor (issue #403)
+// ---------------------------------------------------------------------------
+
+// ReanchorRecommendation describe una sugerencia para mover un cliente WiFi
+// a un AP con mejor señal. Los campos siguen la convención del dominio:
+// señal en -dBm (más cercano a 0 = mejor).
+type ReanchorRecommendation struct {
+	MAC                 string `json:"mac"`
+	CurrentBSSID        string `json:"currentBssid"`
+	CurrentHostname     string `json:"currentHostname"`
+	CurrentIface        string `json:"currentIface"`
+	CurrentHost         string `json:"-"`
+	CurrentSignal       int    `json:"currentSignal"`
+	RecommendedBSSID    string `json:"recommendedBssid"`
+	RecommendedHostname string `json:"recommendedHostname"`
+	RecommendedIface    string `json:"recommendedIface"`
+	RecommendedSignal   int    `json:"recommendedSignal"`
+	DeltaDbm            int    `json:"deltaDbm"`
+}
+
+// ReanchorConfig contiene los umbrales de la recomendación.
+type ReanchorConfig struct {
+	MinRecommendedSignal int `json:"minRecommendedSignal"`
+	MinDeltaDbm          int `json:"minDeltaDbm"`
+}
+
+// ReanchorResponse es la respuesta de GET /api/wifi-reanchor/recommendations.
+type ReanchorResponse struct {
+	Daemon          RoamingDaemon          `json:"daemon"`
+	Recommendations []ReanchorRecommendation `json:"recommendations"`
+}
+
 // RouterDetail (GET /api/routers/:id; SPEC §7.8 y demo §7.1)
 // ---------------------------------------------------------------------------
 
@@ -522,6 +555,32 @@ type WANLatencyStats struct {
 type WGTotals struct {
 	Rx string `json:"rx"`
 	Tx string `json:"tx"`
+}
+
+// ---------------------------------------------------------------------------
+// DAWN (legacy: solo usado por el asesor de re-anclaje, issue #403)
+// ---------------------------------------------------------------------------
+
+// DawnClient es un cliente visto por un AP en el hearing map de DAWN.
+type DawnClient struct {
+	MAC    string `json:"mac"`
+	Signal int    `json:"signal"` // -dBm (ej. -65)
+	HT     bool   `json:"ht"`
+	VHT    bool   `json:"vht"`
+}
+
+// DawnAP es un punto de acceso visto por DAWN.
+type DawnAP struct {
+	SSID           string       `json:"ssid"`
+	BSSID          string       `json:"bssid"`
+	Hostname       string       `json:"hostname"`
+	Band           string       `json:"band"` // freq >= 5000 ? "5 GHz" : "2.4 GHz"
+	Channel        int          `json:"channel"`
+	UtilizationPct float64      `json:"utilizationPct"`
+	ClientCount    int          `json:"clientCount"`
+	Clients        []DawnClient `json:"clients"`
+	Local          bool         `json:"local"`
+	Iface          string       `json:"iface"`
 }
 
 // ---------------------------------------------------------------------------
@@ -769,6 +828,10 @@ type Snapshotter interface {
 	// KickUsteerClient desconecta un cliente de su AP usteer actual.
 	// Devuelve error si no se encuentra o falla el comando hostapd.
 	KickUsteerClient(ctx context.Context, mac string) error
+	// GetReanchorRecommendations devuelve recomendaciones de re-anclaje WiFi
+	// basadas en usteer (preferido) o DAWN, o (slice vacío, "none", nil) si
+	// ningún daemon está disponible.
+	GetReanchorRecommendations(ctx context.Context, cfg ReanchorConfig) ([]ReanchorRecommendation, RoamingDaemon, error)
 	// GetDot11r devuelve el estado 802.11r (FT) por router y SSID, o
 	// (nil, nil) si ningún router lo soporta → el handler responde 503.
 	GetDot11r(ctx context.Context) (*Dot11rOverview, error)

--- a/server-go/internal/httpapi/reanchor.go
+++ b/server-go/internal/httpapi/reanchor.go
@@ -1,0 +1,92 @@
+package httpapi
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/adapters"
+	"github.com/gnacho/netpulse/server-go/internal/auth"
+)
+
+// handleReanchorRecommendations: GET /api/wifi-reanchor/recommendations
+// Devuelve la lista de clientes WiFi que estarían mejor en otro AP según
+// usteer (preferido) o DAWN. Requiere sesión de admin.
+func (s *server) handleReanchorRecommendations(w http.ResponseWriter, r *http.Request) {
+	cfg := adapters.ReanchorConfig{
+		MinRecommendedSignal: -65,
+		MinDeltaDbm:          10,
+	}
+	recs, daemon, err := s.adapter.GetReanchorRecommendations(r.Context(), cfg)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error")
+		return
+	}
+	if recs == nil {
+		recs = []adapters.ReanchorRecommendation{}
+	}
+	writeJSON(w, http.StatusOK, adapters.ReanchorResponse{Daemon: daemon, Recommendations: recs})
+}
+
+// handleReanchorMove: POST /api/wifi-reanchor/{mac}/move
+// Ejecuta del_client + ban_time en el AP donde está asociada la MAC,
+// usando el daemon activo para decidir el target. Requiere admin.
+func (s *server) handleReanchorMove(w http.ResponseWriter, r *http.Request) {
+	mac, ok := validMAC(r.PathValue("mac"))
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid_mac")
+		return
+	}
+	mac = strings.ToUpper(mac)
+
+	cfg := adapters.ReanchorConfig{
+		MinRecommendedSignal: -65,
+		MinDeltaDbm:          10,
+	}
+	recs, daemon, err := s.adapter.GetReanchorRecommendations(r.Context(), cfg)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error")
+		return
+	}
+
+	var rec *adapters.ReanchorRecommendation
+	for i := range recs {
+		if recs[i].MAC == mac {
+			rec = &recs[i]
+			break
+		}
+	}
+	if rec == nil {
+		writeError(w, http.StatusConflict, "no_recommendation", "No hay recomendación activa para este cliente")
+		return
+	}
+
+	switch daemon {
+	case adapters.RoamingDaemonUsteer:
+		if err := s.adapter.KickUsteerClient(r.Context(), mac); err != nil {
+			writeError(w, http.StatusBadGateway, "ssh_failed", err.Error())
+			return
+		}
+	case adapters.RoamingDaemonDawn:
+		if rec.CurrentHost == "" {
+			writeError(w, http.StatusConflict, "router_unknown", "No se encontró el router del AP actual")
+			return
+		}
+		script := adapters.ReanchorKickScript(rec.MAC, rec.CurrentIface)
+		if _, err := s.pool.Run(rec.CurrentHost, script, 15*time.Second); err != nil {
+			writeError(w, http.StatusBadGateway, "ssh_failed", err.Error())
+			return
+		}
+	default:
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "No hay daemon de roaming disponible")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "mac": mac, "from": rec.CurrentHostname})
+}
+
+// registerReanchorRoutes registra las rutas de re-anclaje WiFi.
+func (s *server) registerReanchorRoutes(mux *http.ServeMux) {
+	mux.Handle("GET /api/wifi-reanchor/recommendations", auth.RequireAdmin(http.HandlerFunc(s.handleReanchorRecommendations)))
+	mux.Handle("POST /api/wifi-reanchor/{mac}/move", auth.RequireAdmin(http.HandlerFunc(s.handleReanchorMove)))
+}

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -49,7 +49,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.23.6"
+var Version = "2.24.0"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {
@@ -270,6 +270,7 @@ func NewHandler(d Deps) http.Handler {
 	mux.HandleFunc("GET /api/topology", s.handleTopology)
 	mux.HandleFunc("GET /api/usteer", s.handleUsteer)
 	mux.HandleFunc("POST /api/usteer/{mac}/kick", s.handleUsteerKick)
+	s.registerReanchorRoutes(mux)
 	mux.HandleFunc("GET /api/dot11r", s.handleDot11r)
 	mux.HandleFunc("GET /api/survey", s.handleSurvey)
 	mux.HandleFunc("GET /api/roam-events", s.handleRoamEvents)


### PR DESCRIPTION
Implementa el asesor de re-anclaje WiFi del issue #403.

- Backend en server-go/internal/adapters/reanchor.go: calcula recomendaciones a partir del hearing map de usteer (local_info, remote_info, connected_clients, get_clients), con fallback a DAWN (get_network + get_hearing_map).
- Endpoints /api/wifi-reanchor/recommendations y /api/wifi-reanchor/{mac}/move (admin) en server-go/internal/httpapi/reanchor.go.
- UI: nueva pestaña Reanclar en /roaming con tabla de recomendaciones y acción manual Mover (app/src/pages/ReanchorPanel.tsx).
- Tests unitarios para la lógica de recomendación y el comando del_client.
- Actualiza plan, changelog y bump a v2.24.0.

Closes #403.