### PR TITLE
Hide vitals for sources without system metrics, open web UI/NetGrip actions, reinstall in Agents section

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -533,19 +533,12 @@
       "firmwareBase": "(base {{base}})",
       "firmwareTarget": "Target: {{target}}",
       "lastReboot": "Last reboot",
-      "openLuci": "Open LuCI",
+      "openWebUi": "Open web UI",
+      "openNetgrip": "Open NetGrip",
+      "netgripTip": "The NetGrip panel runs on port 8080",
       "timezone": "Timezone",
       "title": "Information",
-      "updated": "Up to date",
-      "reinstall": "Reinstall agent",
-      "reinstalling": "Reinstalling…",
-      "reinstalled": "Reinstalled",
-      "reinstallRetry": "Retry reinstall",
-      "reinstallTip": "Reinstall the agent on this router (binary, config and service) via SSH. Use this if the agent was removed by a firmware update or manual uninstall.",
-      "reinstallConfirm": "Reinstall the agent on {{router}}? The current agent (if any) will be replaced and its token rotated.",
-      "reinstallDone": "Agent reinstalled and reporting again.",
-      "reinstallPending": "Agent installed; waiting for it to report (up to 40s).",
-      "reinstallFail": "Reinstall failed"
+      "updated": "Up to date"
     },
     "latency": {
       "24h": "Latency 24 h",
@@ -559,7 +552,9 @@
       "maxTemp": "max {{temp}} °C",
       "peakCpu": "peak {{pct}} % at {{t}}",
       "ramUsed": "{{used}} MB used of {{total}} MB",
-      "tableCaption": "Performance data ({{range}})"
+      "tableCaption": "Performance data ({{range}})",
+      "unavailableTitle": "No system metrics",
+      "unavailableBody": "This device is monitored through SNMP or a beacon pusher (managed switch): it does not report CPU, RAM or temperature, so there are no charts to show."
     },
     "performance": "Performance",
     "performanceRange": "Performance range",
@@ -771,7 +766,9 @@
       "netgripTip": "The agent lives inside this router's NetGrip panel",
       "netgripHint": "The agent lives in the NetGrip panel: Update upgrades the panel itself"
     },
-    "upgradeUpdatedDetail": "Updated · {{count}} steps · {{secs}} s"
+    "upgradeUpdatedDetail": "Updated · {{count}} steps · {{secs}} s",
+    "noVitals": "No system metrics",
+    "noVitalsTip": "Monitored through SNMP or a beacon: this device does not report CPU, RAM or temperature"
   },
   "reports": {
     "availability": "Availability",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -533,19 +533,12 @@
       "firmwareBase": "(base {{base}})",
       "firmwareTarget": "Objetivo: {{target}}",
       "lastReboot": "Último reinicio",
-      "openLuci": "Abrir LuCI",
+      "openWebUi": "Abrir WebUI",
+      "openNetgrip": "Abrir NetGrip",
+      "netgripTip": "El panel NetGrip corre en el puerto 8080",
       "timezone": "Zona horaria",
       "title": "Información",
-      "updated": "Actualizado",
-      "reinstall": "Reinstalar agente",
-      "reinstalling": "Reinstalando…",
-      "reinstalled": "Reinstalado",
-      "reinstallRetry": "Reintentar reinstall",
-      "reinstallTip": "Reinstala el agente en este router (binario, config y servicio) vía SSH. Úsalo si el agente fue borrado por una actualización de firmware o una desinstalación manual.",
-      "reinstallConfirm": "¿Reinstalar el agente en {{router}}? El agente actual (si lo hay) será sustituido y su token rotado.",
-      "reinstallDone": "Agente reinstalado y empujando de nuevo.",
-      "reinstallPending": "Agente instalado; esperando a que empuje (hasta 40 s).",
-      "reinstallFail": "Fallo al reinstalar"
+      "updated": "Actualizado"
     },
     "latency": {
       "24h": "Latencia 24 h",
@@ -559,7 +552,9 @@
       "maxTemp": "máx {{temp}} °C",
       "peakCpu": "pico {{pct}} % a las {{t}}",
       "ramUsed": "{{used}} MB usados de {{total}} MB",
-      "tableCaption": "Datos de rendimiento ({{range}})"
+      "tableCaption": "Datos de rendimiento ({{range}})",
+      "unavailableTitle": "Sin métricas de sistema",
+      "unavailableBody": "Este dispositivo se monitoriza por SNMP o beacon (switch gestionado): no reporta CPU, RAM ni temperatura, así que no hay gráficas que mostrar."
     },
     "performance": "Rendimiento",
     "performanceRange": "Rango de rendimiento",
@@ -771,7 +766,9 @@
       "netgripTip": "El agente vive dentro del panel NetGrip de este router",
       "netgripHint": "El agente vive en el panel NetGrip: Actualizar actualiza el propio panel"
     },
-    "upgradeUpdatedDetail": "Actualizado · {{count}} pasos · {{secs}} s"
+    "upgradeUpdatedDetail": "Actualizado · {{count}} pasos · {{secs}} s",
+    "noVitals": "Sin métricas de sistema",
+    "noVitalsTip": "Monitorizado por SNMP o beacon: este dispositivo no reporta CPU, RAM ni temperatura"
   },
   "reports": {
     "availability": "Disponibilidad",

--- a/app/src/components/RouterCard.tsx
+++ b/app/src/components/RouterCard.tsx
@@ -91,9 +91,14 @@ export function RouterCard({ router, index = 0, className }: RouterCardProps) {
         </div>
 
         <div className="mt-4 grid grid-cols-2 gap-x-3 gap-y-2">
-          <MiniMetric icon={Cpu} value={`${router.cpu} %`} label="CPU" hot={router.hotMetric === 'cpu'} />
-          <MiniMetric icon={MemoryStick} value={`${router.ram} %`} label="RAM" hot={router.hotMetric === 'ram'} />
-          <MiniMetric icon={Thermometer} value={`${router.temp} °C`} label={t('common.temperature')} hot={router.hotMetric === 'temp'} />
+          {/* #441: sin vitals (switch SNMP/beacon) no se pintan ceros falsos */}
+          {router.vitalsAvailable !== false && (
+            <>
+              <MiniMetric icon={Cpu} value={`${router.cpu} %`} label="CPU" hot={router.hotMetric === 'cpu'} />
+              <MiniMetric icon={MemoryStick} value={`${router.ram} %`} label="RAM" hot={router.hotMetric === 'ram'} />
+              <MiniMetric icon={Thermometer} value={`${router.temp} °C`} label={t('common.temperature')} hot={router.hotMetric === 'temp'} />
+            </>
+          )}
           <MiniMetric icon={Users} value={String(router.clients)} label={t('common.clients')} />
         </div>
 

--- a/app/src/components/routers/AgentsSection.tsx
+++ b/app/src/components/routers/AgentsSection.tsx
@@ -81,6 +81,10 @@ function AgentRow({ agent, router }: { agent?: AgentInfo; router: Router | undef
   const isStale = agent !== undefined && !agent.fresh
   const isMissing = agent === undefined && router?.agentOnly === true
   const canRecover = isOpenWrt && (isStale || isMissing) && auth?.role === 'admin'
+  // #443: reinstall disponible SIEMPRE para admins en agentes nativos OpenWrt
+  // (sanos o caídos): antes solo aparecía cuando estaba stale o faltaba, y el
+  // duplicado vivía en la tarjeta Info del detalle.
+  const canReinstall = auth?.role === 'admin' && isOpenWrt && (agent !== undefined || isMissing)
 
   const slug = agent?.slug ?? router?.id ?? ''
   const lastSeen = agent?.lastSeen ? relTimeFromTs(agent.lastSeen) ?? t('routers.agents.never') : t('routers.agents.never')
@@ -216,7 +220,10 @@ function AgentRow({ agent, router }: { agent?: AgentInfo; router: Router | undef
               Solo agentes NATIVOS OpenWrt: los externos (switch por beacon)
               no tienen SSH - solo alertan (#291). */}
           {agent && agent.kind !== 'external' && agent.kind !== 'netgrip' && <AgentRearmButton agent={agent} />}
-          {canRecover && (
+          {/* #443: Reinstalar vía SSH desde el server; siempre visible para
+              admins en agentes nativos OpenWrt (la acción se mudó aquí desde
+              la tarjeta Info del detalle). */}
+          {canReinstall && (
             <button
               type="button"
               onClick={() => void reinstall()}

--- a/app/src/components/routers/FleetCard.tsx
+++ b/app/src/components/routers/FleetCard.tsx
@@ -199,18 +199,26 @@ export function FleetCard({ router, index = 0, refreshKey = 0 }: FleetCardProps)
           ))}
         </div>
 
-        {/* Métricas con barras */}
+        {/* Métricas con barras (#441: sin pintar para fuentes sin vitals) */}
         <div key={refreshKey} className="mt-4 space-y-2.5">
-          <MetricRow icon={Cpu} label="CPU" value={`${router.cpu} %`} pct={router.cpu} hot={router.hotMetric === 'cpu'} />
-          <MetricRow icon={MemoryStick} label={t('common.memory')} value={`${router.ram} %`} pct={router.ram} hot={router.hotMetric === 'ram'} />
-          <MetricRow
-            icon={Thermometer}
-            label={t('common.temperature')}
-            value={`${router.temp} °C`}
-            pct={Math.min(100, (router.temp / 90) * 100)}
-            hot={router.hotMetric === 'temp'}
-            title={router.hotMetric === 'temp' ? t('routers.tempThreshold') : undefined}
-          />
+          {router.vitalsAvailable === false ? (
+            <p className="text-caption text-text-muted" title={t('routers.noVitalsTip')}>
+              {t('routers.noVitals')}
+            </p>
+          ) : (
+            <>
+              <MetricRow icon={Cpu} label="CPU" value={`${router.cpu} %`} pct={router.cpu ?? 0} hot={router.hotMetric === 'cpu'} />
+              <MetricRow icon={MemoryStick} label={t('common.memory')} value={`${router.ram} %`} pct={router.ram ?? 0} hot={router.hotMetric === 'ram'} />
+              <MetricRow
+                icon={Thermometer}
+                label={t('common.temperature')}
+                value={`${router.temp} °C`}
+                pct={Math.min(100, ((router.temp ?? 0) / 90) * 100)}
+                hot={router.hotMetric === 'temp'}
+                title={router.hotMetric === 'temp' ? t('routers.tempThreshold') : undefined}
+              />
+            </>
+          )}
         </div>
 
         {/* Mini-gráfico de tráfico 24h */}

--- a/app/src/components/routers/FleetTable.tsx
+++ b/app/src/components/routers/FleetTable.tsx
@@ -41,12 +41,13 @@ function sortValue(r: Router, key: SortKey): string | number {
       return r.name
     case 'status':
       return STATUS_ORDER[r.status]
+    // #441: sin vitals → -1 para ordenarlos al final en asc.
     case 'cpu':
-      return r.cpu
+      return r.cpu ?? -1
     case 'ram':
-      return r.ram
+      return r.ram ?? -1
     case 'temp':
-      return r.temp
+      return r.temp ?? -1
     case 'clients':
       return r.clients
     case 'traffic':
@@ -59,6 +60,9 @@ function sortValue(r: Router, key: SortKey): string | number {
 function TempCell({ router }: { router: Router }) {
   const { t } = useTranslation()
   const hot = router.hotMetric === 'temp'
+  if (router.temp === null) {
+    return <span className="font-mono text-mono-sm text-text-faint">—</span>
+  }
   return (
     <span
       className={cn(
@@ -69,6 +73,19 @@ function TempCell({ router }: { router: Router }) {
     >
       {router.temp} °C
     </span>
+  )
+}
+
+/** Celda CPU/RAM con barra; sin vitals (#441) un guion discreto. */
+function VitalCell({ value }: { value: number | null }) {
+  if (value === null) {
+    return <span className="font-mono text-mono-sm text-text-faint">—</span>
+  }
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-9 font-mono text-mono-sm text-text-primary">{value} %</span>
+      <div className="w-[60px]"><MetricBar value={value} /></div>
+    </div>
   )
 }
 
@@ -180,16 +197,10 @@ export function FleetTable({ refreshKey = 0 }: { refreshKey?: number }) {
                     />
                   </td>
                   <td className="py-3 pr-3">
-                    <div key={refreshKey} className="flex items-center gap-2">
-                      <span className="w-9 font-mono text-mono-sm text-text-primary">{r.cpu} %</span>
-                      <div className="w-[60px]"><MetricBar value={r.cpu} /></div>
-                    </div>
+                    <div key={refreshKey}><VitalCell value={r.cpu} /></div>
                   </td>
                   <td className="py-3 pr-3">
-                    <div key={refreshKey} className="flex items-center gap-2">
-                      <span className="w-9 font-mono text-mono-sm text-text-primary">{r.ram} %</span>
-                      <div className="w-[60px]"><MetricBar value={r.ram} /></div>
-                    </div>
+                    <div key={refreshKey}><VitalCell value={r.ram} /></div>
                   </td>
                   <td className="py-3 pr-3"><TempCell router={r} /></td>
                   <td className="py-3 pr-3 text-right font-mono text-mono-sm text-text-primary">{r.clients}</td>
@@ -238,7 +249,7 @@ export function FleetTable({ refreshKey = 0 }: { refreshKey?: number }) {
                     pulse={r.status !== 'online'}
                   />
                   <span className={cn('font-mono text-mono-sm', r.hotMetric === 'temp' ? 'text-warn' : 'text-text-secondary')}>
-                    {r.temp} °C
+                    {r.temp === null ? '—' : `${r.temp} °C`}
                   </span>
                   <ChevronDown className={cn('h-4 w-4 text-text-muted transition-transform', open && 'rotate-180')} strokeWidth={1.75} />
                 </span>
@@ -253,9 +264,9 @@ export function FleetTable({ refreshKey = 0 }: { refreshKey?: number }) {
                   >
                     <div className="grid grid-cols-2 gap-x-4 gap-y-2.5 border-t border-border px-3.5 py-3">
                       {[
-                        ['CPU', `${r.cpu} %`],
-                        ['RAM', `${r.ram} %`],
-                        [t('routers.colTemp'), `${r.temp} °C`],
+                        ['CPU', r.cpu === null ? '—' : `${r.cpu} %`],
+                        ['RAM', r.ram === null ? '—' : `${r.ram} %`],
+                        [t('routers.colTemp'), r.temp === null ? '—' : `${r.temp} °C`],
                         [t('routers.colClients'), String(r.clients)],
                         [t('routers.colTraffic'), `↓ ${fmtEs(extras.trafficNow, 1)} Mbps`],
                         ['Uptime', fmtUptime(r.uptime)],

--- a/app/src/components/routers/RouterInfo.tsx
+++ b/app/src/components/routers/RouterInfo.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Check, ExternalLink, RotateCcw, Terminal } from 'lucide-react'
+import { Check, ExternalLink, LayoutDashboard, Terminal } from 'lucide-react'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
 import { fmtUptime } from '@/i18n'
@@ -9,7 +9,6 @@ import { StatusPill } from '@/components/StatusPill'
 import { getRouterExtras } from '@/components/routers/routerExtras'
 import type { RouterExtras } from '@/components/routers/routerExtras'
 import { EMPTY_EXTRAS, useNetPulse } from '@/data/DataProvider'
-import { useAuth } from '@/data/AuthContext'
 import { useAgentFor } from '@/hooks/useAgentFor'
 
 function Row({ label, children }: { label: string; children: React.ReactNode }) {
@@ -24,18 +23,13 @@ function Row({ label, children }: { label: string; children: React.ReactNode }) 
 /** ③ Info + Red (router-detail.md §③) — definition list + acciones ghost. */
 export function RouterInfo({ router, extras }: { router: Router; extras?: RouterExtras }) {
   const { t } = useTranslation()
-  const { isDemo, reinstallAgent } = useNetPulse()
-  const auth = useAuth()
-  const agent = useAgentFor(router.id)
-  // Solo los dispositivos OpenWrt (glinet/openwrt, o sin tipo conocido) usan
-  // el agente nativo: en managed-switch/external (scrapers) no hay reinstall.
-  const isOpenWrt = router.type === undefined || router.type === '' || router.type === 'glinet' || router.type === 'openwrt'
-  const agentMissing = isOpenWrt && agent === undefined && router.agentOnly
+  const { isDemo } = useNetPulse()
+  // #442: routers con el panel NetGrip (agente embebido) tienen una segunda
+  // web UI en el puerto 8080.
+  const hasNetgrip = useAgentFor(router.id)?.kind === 'netgrip'
   const ex = extras ?? (isDemo ? getRouterExtras(router.id) : EMPTY_EXTRAS)
   const reduce = useReducedMotion()
   const [toast, setToast] = useState(false)
-  const [reinstallState, setReinstallState] = useState<'idle' | 'busy' | 'done' | 'fail'>('idle')
-  const [reinstallMsg, setReinstallMsg] = useState('')
   const timer = useRef<number | null>(null)
 
   useEffect(() => () => {
@@ -74,22 +68,6 @@ export function RouterInfo({ router, extras }: { router: Router; extras?: Router
     setToast(ok)
     if (timer.current) window.clearTimeout(timer.current)
     timer.current = window.setTimeout(() => setToast(false), 1800)
-  }
-
-  const reinstall = async () => {
-    if (reinstallState === 'busy') return
-    if (!window.confirm(t('routerDetail.info.reinstallConfirm', { router: router.name }))) return
-    setReinstallState('busy')
-    setReinstallMsg('')
-    const res = await reinstallAgent(router.id)
-    if (res && !res.error) {
-      setReinstallState('done')
-      setReinstallMsg(res.recovered ? t('routerDetail.info.reinstallDone') : t('routerDetail.info.reinstallPending'))
-    } else {
-      setReinstallState('fail')
-      setReinstallMsg(res?.error ?? t('routerDetail.info.reinstallFail'))
-    }
-    window.setTimeout(() => setReinstallState('idle'), 8000)
   }
 
   const rows: { label: string; node: React.ReactNode }[] = [
@@ -148,6 +126,8 @@ export function RouterInfo({ router, extras }: { router: Router; extras?: Router
         ))}
       </dl>
       <div className="mt-3 flex flex-wrap gap-2 border-t border-border pt-3.5">
+        {/* #442: "Abrir WebUI" genérico: LuCI en OpenWrt, web del fabricante
+            en switches gestionados/beacon (ninguno de los dos es "LuCI"). */}
         <a
           href={`http://${router.ip}`}
           target="_blank"
@@ -155,8 +135,20 @@ export function RouterInfo({ router, extras }: { router: Router; extras?: Router
           className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-border px-3 text-caption font-semibold text-text-secondary transition-colors hover:border-accent/40 hover:text-accent"
         >
           <ExternalLink className="h-3.5 w-3.5" strokeWidth={1.75} />
-          {t('routerDetail.info.openLuci')}
+          {t('routerDetail.info.openWebUi')}
         </a>
+        {hasNetgrip && (
+          <a
+            href={`http://${router.ip}:8080`}
+            target="_blank"
+            rel="noreferrer"
+            title={t('routerDetail.info.netgripTip')}
+            className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-border px-3 text-caption font-semibold text-text-secondary transition-colors hover:border-accent/40 hover:text-accent"
+          >
+            <LayoutDashboard className="h-3.5 w-3.5" strokeWidth={1.75} />
+            {t('routerDetail.info.openNetgrip')}
+          </a>
+        )}
         <button
           onClick={copySsh}
           className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-border px-3 text-caption font-semibold text-text-secondary transition-colors hover:border-accent/40 hover:text-accent"
@@ -164,35 +156,7 @@ export function RouterInfo({ router, extras }: { router: Router; extras?: Router
           <Terminal className="h-3.5 w-3.5" strokeWidth={1.75} />
           {t('routerDetail.info.copySsh')}
         </button>
-        {isOpenWrt && (agent || router.agentOnly) && auth?.role === 'admin' && (
-          <button
-            onClick={() => void reinstall()}
-            disabled={reinstallState === 'busy'}
-            title={t('routerDetail.info.reinstallTip')}
-            className={`inline-flex h-9 items-center gap-1.5 rounded-lg border px-3 text-caption font-semibold transition-colors disabled:opacity-50 ${
-              reinstallState === 'done'
-                ? 'border-ok/40 bg-ok/10 text-ok'
-                : reinstallState === 'fail'
-                  ? 'border-danger/40 bg-danger/10 text-danger'
-                  : agentMissing || !agent?.fresh
-                    ? 'border-danger/40 bg-danger/10 text-danger hover:border-danger hover:bg-danger/20'
-                    : 'border-border text-text-secondary hover:border-accent/40 hover:text-accent'
-            }`}
-          >
-            <RotateCcw className={`h-3.5 w-3.5 ${reinstallState === 'busy' ? 'animate-spin' : ''}`} strokeWidth={1.75} />
-            {reinstallState === 'busy'
-              ? t('routerDetail.info.reinstalling')
-              : reinstallState === 'done'
-                ? t('routerDetail.info.reinstalled')
-                : reinstallState === 'fail'
-                  ? t('routerDetail.info.reinstallRetry')
-                  : t('routerDetail.info.reinstall')}
-          </button>
-        )}
       </div>
-      {reinstallMsg && reinstallState !== 'idle' && (
-        <p className={`mt-2 text-caption ${reinstallState === 'fail' ? 'text-danger' : 'text-text-muted'}`}>{reinstallMsg}</p>
-      )}
 
       {/* Toast "Comando copiado" */}
       <AnimatePresence>

--- a/app/src/components/routers/RouterPerformance.tsx
+++ b/app/src/components/routers/RouterPerformance.tsx
@@ -66,7 +66,9 @@ export function RouterPerformance({ router }: { router: Router }) {
   const data = useMemo(() => perfSeries(router, range), [router, range])
   const captions = useMemo(() => perfCaptions(router, data), [router, data])
 
-  const current: Record<SeriesDef['key'], number> = { cpu: router.cpu, ram: router.ram, temp: router.temp }
+  // #441: null cuando la fuente no reporta vitals (el panel no se monta,
+  // pero el tipo lo exige); se normaliza a 0 para el render defensivo.
+  const current: Record<SeriesDef['key'], number> = { cpu: router.cpu ?? 0, ram: router.ram ?? 0, temp: router.temp ?? 0 }
   const captionByKey: Record<SeriesDef['key'], string> = { cpu: captions.cpu, ram: captions.ram, temp: captions.temp }
 
   return (

--- a/app/src/components/routers/routerExtras.ts
+++ b/app/src/components/routers/routerExtras.ts
@@ -286,8 +286,8 @@ export function perfSeries(router: Router, range: '1h' | '24h' | '7d'): PerfPoin
 
   // Índice del pico: 21:00 en 24h, penúltimo tramo en 1h, viernes en 7d
   const peakIdx = range === '24h' ? 21 : range === '1h' ? 15 : 4
-  const cpuPeak = isGateway ? 61 : Math.min(88, router.cpu + 34)
-  const tempPeak = isGateway ? 58 : router.temp + 4
+  const cpuPeak = isGateway ? 61 : Math.min(88, (router.cpu ?? 0) + 34)
+  const tempPeak = isGateway ? 58 : (router.temp ?? 0) + 4
 
   const points: PerfPoint[] = []
   for (let i = 0; i < n; i++) {
@@ -297,15 +297,15 @@ export function perfSeries(router: Router, range: '1h' | '24h' | '7d'): PerfPoin
         ? 0.7 + 0.3 * (i / (n - 1))
         : 0.55 + 0.45 * Math.sin(((i - 6) / n) * Math.PI * 2 - Math.PI / 2) ** 2
     const wob = noise(i, seed)
-    let cpu = Math.max(2, Math.round(router.cpu * dayShape + wob * 6))
-    const ram = Math.max(10, Math.round(router.ram - 6 + wob * 10 + (i / n) * 4))
-    let temp = Math.max(30, Math.round(router.temp - 5 + wob * 4 + dayShape * 4))
+    let cpu = Math.max(2, Math.round((router.cpu ?? 0) * dayShape + wob * 6))
+    const ram = Math.max(10, Math.round((router.ram ?? 0) - 6 + wob * 10 + (i / n) * 4))
+    let temp = Math.max(30, Math.round((router.temp ?? 0) - 5 + wob * 4 + dayShape * 4))
     if (i === peakIdx) cpu = cpuPeak
     if (i === peakIdx) temp = tempPeak
     points.push({ t: labels[i]!, cpu, ram, temp })
   }
   // La serie termina SIEMPRE en el valor canónico actual
-  points[n - 1] = { t: labels[n - 1]!, cpu: router.cpu, ram: router.ram, temp: router.temp }
+  points[n - 1] = { t: labels[n - 1]!, cpu: router.cpu ?? 0, ram: router.ram ?? 0, temp: router.temp ?? 0 }
   return points
 }
 
@@ -314,7 +314,7 @@ export function perfCaptions(router: Router, data: PerfPoint[]): { cpu: string; 
   if (data.length === 0) throw new Error('perfCaptions: empty perf series')
   const cpuMax = data.reduce((m, p) => (p.cpu > m.cpu ? p : m), data[0]!)
   const tempMax = data.reduce((m, p) => (p.temp > m.temp ? p : m), data[0]!)
-  const ramUsed = Math.round((router.ram / 100) * extras.ramMb)
+  const ramUsed = Math.round(((router.ram ?? 0) / 100) * extras.ramMb)
   return {
     cpu: i18n.t('routerDetail.perf.peakCpu', { pct: cpuMax.cpu, t: cpuMax.t }),
     ram: i18n.t('routerDetail.perf.ramUsed', { used: ramUsed, total: extras.ramMb }),

--- a/app/src/components/topology/TopologyMap.tsx
+++ b/app/src/components/topology/TopologyMap.tsx
@@ -143,9 +143,10 @@ function TooltipCard({
           </div>
           <div className="mt-0.5 text-caption text-text-muted">{tip.router.modelShort} · {tip.router.ip}</div>
           <div className="mt-2 grid grid-cols-2 gap-1.5">
-            <MiniStat label="CPU" value={`${tip.router.cpu} %`} />
-            <MiniStat label="RAM" value={`${tip.router.ram} %`} />
-            <MiniStat label={t('routers.colTemp')} value={`${tip.router.temp} °C`} hot={tip.router.hotMetric === 'temp'} />
+            {/* #441: sin vitals (switch SNMP/beacon) se muestra un guion */}
+            <MiniStat label="CPU" value={tip.router.cpu === null ? '—' : `${tip.router.cpu} %`} />
+            <MiniStat label="RAM" value={tip.router.ram === null ? '—' : `${tip.router.ram} %`} />
+            <MiniStat label={t('routers.colTemp')} value={tip.router.temp === null ? '—' : `${tip.router.temp} °C`} hot={tip.router.hotMetric === 'temp'} />
             <MiniStat label={t('routers.colClients')} value={String(tip.router.clients)} />
           </div>
           <div className="mt-2 text-caption font-semibold text-accent">

--- a/app/src/data/DataProvider.tsx
+++ b/app/src/data/DataProvider.tsx
@@ -357,9 +357,9 @@ const walkPct = (v: number, pct = 5, min = 0) =>
 function demoTick(prev: NetPulseData): NetPulseData {
   const routers = prev.routers.map((r) => ({
     ...r,
-    cpu: walkInt(r.cpu, 2, 2, 97),
-    ram: walkInt(r.ram, 2, 5, 97),
-    temp: walkInt(r.temp, 2, 30, 90),
+    cpu: walkInt(r.cpu ?? 0, 2, 2, 97),
+    ram: walkInt(r.ram ?? 0, 2, 5, 97),
+    temp: walkInt(r.temp ?? 0, 2, 30, 90),
   }))
   const wan: WanInfo = {
     ...prev.wan,

--- a/app/src/data/types.ts
+++ b/app/src/data/types.ts
@@ -39,9 +39,15 @@ export interface Router {
   status: Status
   /** Salud 0–100 */
   health: number
-  cpu: number // %
-  ram: number // %
-  temp: number // °C
+  /**
+   * #441: false cuando la fuente del router no puede reportar métricas de
+   * sistema (switch SNMP o pusher beacon/scraper). En ese caso cpu/ram/temp
+   * llegan a null y la UI no los pinta. Ausente = disponibles.
+   */
+  vitalsAvailable?: boolean
+  cpu: number | null // %
+  ram: number | null // %
+  temp: number | null // °C
   uptime: string
   clients: number
   /** Métrica en umbral (se pinta --warn), p. ej. 'temp' en Patio */

--- a/app/src/pages/RouterDetail.tsx
+++ b/app/src/pages/RouterDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useLocation, useParams } from 'react-router'
-import { AlertTriangle, ArrowLeft, Router as RouterIcon } from 'lucide-react'
+import { AlertTriangle, ArrowLeft, Gauge, Router as RouterIcon } from 'lucide-react'
 import { motion, useReducedMotion } from 'framer-motion'
 import { relTime } from '@/i18n'
 import { useNetPulse } from '@/data/DataProvider'
@@ -119,9 +119,21 @@ export default function RouterDetail() {
         </motion.div>
       )}
 
-      {/* ② Rendimiento */}
+      {/* ② Rendimiento (#441: placeholder si la fuente no puede dar vitals) */}
       <div className="lg:col-span-8">
-        <RouterPerformance router={router} />
+        {router.vitalsAvailable === false ? (
+          <section className="flex h-full flex-col items-center justify-center gap-3 rounded-2xl border border-border bg-surface p-8 text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-elevated text-text-muted">
+              <Gauge className="h-6 w-6" strokeWidth={1.75} />
+            </div>
+            <div>
+              <h2 className="font-display text-h2 text-text-primary">{t('routerDetail.perf.unavailableTitle')}</h2>
+              <p className="mx-auto mt-1 max-w-md text-sm text-text-secondary">{t('routerDetail.perf.unavailableBody')}</p>
+            </div>
+          </section>
+        ) : (
+          <RouterPerformance router={router} />
+        )}
       </div>
 
       {/* ③ Info + Red (en móvil va la última) */}

--- a/server-go/internal/adapters/agent.go
+++ b/server-go/internal/adapters/agent.go
@@ -470,6 +470,9 @@ func (l *Live) polledFromAgent(cfg RouterConfig, p *probe.Payload) *routerPolled
 	l.mu.Unlock()
 
 	out := &routerPolled{cfg: cfg, client: l.clients[cfg.ID], net: &NetDevBps{}, polledAt: time.Now().UnixMilli()}
+	// #441: conservar el kind del agente: los pushers externos (beacon/
+	// scraper) no llevan sección system y el router queda sin vitals.
+	out.agentKind = p.Kind
 	sysInfo := &SysInfo{}
 	ramPct := 0
 

--- a/server-go/internal/adapters/agent.go
+++ b/server-go/internal/adapters/agent.go
@@ -497,6 +497,21 @@ func (l *Live) polledFromAgent(cfg RouterConfig, p *probe.Payload) *routerPolled
 		out.lossPct = sd.LossPct
 		out.backhaul = sd.Backhaul
 		out.brMac = sd.BridgeMAC
+	} else if cached != nil && cached.system != nil {
+		// #441: push event-driven (wireless-only) sin system → conserva las
+		// últimas vitals buenas cacheadas en vez de pintar ceros falsos.
+		// Solo vitals/uptime: net/latencia/backhaul no se reciclan (evita
+		// duplicar tráfico con muestras viejas).
+		sd := cached.system
+		if sd.CPU != nil {
+			out.cpu = *sd.CPU
+		}
+		if sd.Temp != nil {
+			out.temp = *sd.Temp
+		}
+		if sd.SysInfo != nil {
+			sysInfo = sd.SysInfo
+		}
 	}
 	mem := sysInfo.Memory
 	if mem.Total > 0 {
@@ -608,8 +623,14 @@ func (l *Live) polledFromAgent(cfg RouterConfig, p *probe.Payload) *routerPolled
 	if freshPayload {
 		l.lastObsTs[cfg.ID] = p.Ts
 	}
+	// #441: el cache de system guarda la última sección BUENA (un push
+	// wireless-only no la invalida).
+	sysSnap := p.Data.System
+	if sysSnap == nil && cached != nil {
+		sysSnap = cached.system
+	}
 	l.extrasCache[cfg.ID] = &extrasSnapshot{ports: out.ports, radios: out.radios,
-		wireless: out.wireless, fdb: out.fdb, luci: out.luci}
+		wireless: out.wireless, fdb: out.fdb, luci: out.luci, system: sysSnap}
 	l.mu.Unlock()
 
 	// Solo con un payload NUEVO alimentamos las series y el monitor de

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -154,6 +154,10 @@ type extrasSnapshot struct {
 	fdb      map[string]string
 	luci     *probe.LuCILabels
 	vlans    []VlanPort
+	// system (#441): última sección system BUENA del payload del agente.
+	// Los pushes event-driven (wireless-only) van sin ella; sin este cache
+	// las vitals del router parpadeaban a 0 entre pushes completos.
+	system *probe.SystemData
 }
 
 // backhaulCacheTTL: el medio del uplink cambia muy raro; no se sondea cada 5 s.

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -140,6 +140,10 @@ type routerPolled struct {
 	// polledAt (issue #414): epoch ms en que se realizó el sondeo real. Se
 	// usa para deduplicar filas de métricas cuando SNMP se cachea.
 	polledAt int64
+	// agentKind (#441): kind del agente cuyo payload construyó este sondeo
+	// ("" = sondeo SSH/SNMP directo). "external" = pusher beacon/scraper sin
+	// sección system → sin vitals.
+	agentKind string
 }
 
 // extrasSnapshot es la caché anti-parpadeo por router.
@@ -1032,12 +1036,19 @@ func (l *Live) buildRouter(p *routerPolled, history []histPoint) Router {
 	for _, h := range history {
 		sparkline = append(sparkline, h.down)
 	}
+	// #441: SNMP y pushers externos no pueden reportar CPU/RAM/temp. Se marca
+	// el router y las vitals van a null (la UI no pinta ceros falsos).
+	noVitals := p.cfg.SnmpEnabled || p.agentKind == "external"
 	r := Router{
 		ID: p.cfg.ID, Name: name, Model: model, ModelShort: model,
 		IP: p.cfg.Host, Status: status, Health: health,
 		CPU: iptr(p.cpu), RAM: iptr(p.ram), Temp: iptr(p.temp),
 		Uptime: fmtUptime(p.uptimeSec), Clients: len(p.leases),
 		Sparkline: sparkline,
+	}
+	if noVitals {
+		r.VitalsAvailable = bptr(false)
+		r.CPU, r.RAM, r.Temp = nil, nil, nil
 	}
 	if isGw {
 		r.Role, r.RoleBadge = "Gateway principal", "Principal"
@@ -2753,6 +2764,11 @@ func (l *Live) GetMetricsRows(context.Context) []MetricsRow {
 			RAM:       fptr(float64(p.ram)),
 			Temp:      fptr(float64(p.temp)),
 			LatencyMs: p.latencyMs,
+		}
+		// #441: SNMP/pushers externos no tienen vitals reales; no se
+		// persisten ceros que luego pintan series planas.
+		if p.cfg.SnmpEnabled || p.agentKind == "external" {
+			row.CPU, row.RAM, row.Temp = nil, nil, nil
 		}
 		if p.net != nil {
 			row.RxBps = p.net.RxBps

--- a/server-go/internal/adapters/live_vitals_test.go
+++ b/server-go/internal/adapters/live_vitals_test.go
@@ -1,0 +1,95 @@
+package adapters
+
+import (
+	"context"
+	"testing"
+)
+
+// #441: los routers cuya fuente no puede reportar métricas de sistema (SNMP,
+// pushers externos por beacon/scraper) se marcan sin vitals y no sirven
+// cpu/ram/temp (null en el contrato) para que la UI no pinte ceros falsos.
+func TestBuildRouterVitalsUnavailable(t *testing.T) {
+	l := NewLive(nil, nil, nil, nil)
+
+	// SNMP: marcado y sin vitals.
+	p := &routerPolled{
+		cfg:      RouterConfig{ID: "sw1", Host: "192.168.1.10", SnmpEnabled: true},
+		polledAt: 1000,
+	}
+	r := l.buildRouter(p, nil)
+	if r.VitalsAvailable == nil || *r.VitalsAvailable {
+		t.Fatalf("VitalsAvailable=%v, esperaba false (SNMP)", r.VitalsAvailable)
+	}
+	if r.CPU != nil || r.RAM != nil || r.Temp != nil {
+		t.Fatalf("vitals deberían ser nil: cpu=%v ram=%v temp=%v", r.CPU, r.RAM, r.Temp)
+	}
+
+	// Agente externo (beacon/scraper): mismo tratamiento.
+	p2 := &routerPolled{
+		cfg:       RouterConfig{ID: "sw2", Host: "192.168.1.11"},
+		agentKind: "external",
+	}
+	r2 := l.buildRouter(p2, nil)
+	if r2.VitalsAvailable == nil || *r2.VitalsAvailable {
+		t.Fatalf("VitalsAvailable=%v, esperaba false (external)", r2.VitalsAvailable)
+	}
+	if r2.CPU != nil || r2.RAM != nil || r2.Temp != nil {
+		t.Fatalf("vitals deberían ser nil: cpu=%v ram=%v temp=%v", r2.CPU, r2.RAM, r2.Temp)
+	}
+
+	// Sondeo normal (SSH/agente nativo): sin marca y con vitals.
+	p3 := &routerPolled{
+		cfg:      RouterConfig{ID: "rt1", Host: "192.168.1.2"},
+		cpu:      12,
+		ram:      34,
+		temp:     45,
+		polledAt: 1000,
+	}
+	r3 := l.buildRouter(p3, nil)
+	if r3.VitalsAvailable != nil {
+		t.Fatalf("VitalsAvailable=%v, esperaba nil (sondeo normal)", r3.VitalsAvailable)
+	}
+	if r3.CPU == nil || *r3.CPU != 12 || r3.RAM == nil || *r3.RAM != 34 || r3.Temp == nil || *r3.Temp != 45 {
+		t.Fatalf("vitals normales mal servidas: cpu=%v ram=%v temp=%v", r3.CPU, r3.RAM, r3.Temp)
+	}
+}
+
+// #441: el poller no persiste cpu/ram/temp (nil) para routers sin vitals.
+func TestMetricsRowsWithoutVitals(t *testing.T) {
+	l := NewLive(nil, nil, nil, nil)
+	l.lastPolled["sw1"] = &routerPolled{
+		cfg:      RouterConfig{ID: "sw1", Host: "192.168.1.10", SnmpEnabled: true},
+		polledAt: 1000,
+	}
+	l.lastPolled["sw2"] = &routerPolled{
+		cfg:       RouterConfig{ID: "sw2", Host: "192.168.1.11"},
+		agentKind: "external",
+		polledAt:  1000,
+	}
+	l.lastPolled["rt1"] = &routerPolled{
+		cfg:      RouterConfig{ID: "rt1", Host: "192.168.1.2"},
+		cpu:      12,
+		ram:      34,
+		temp:     45,
+		polledAt: 1000,
+	}
+
+	rows := l.GetMetricsRows(context.Background())
+	if len(rows) != 3 {
+		t.Fatalf("rows=%d, esperaba 3", len(rows))
+	}
+	byID := map[string]MetricsRow{}
+	for _, row := range rows {
+		byID[row.RouterID] = row
+	}
+	for _, id := range []string{"sw1", "sw2"} {
+		row := byID[id]
+		if row.CPU != nil || row.RAM != nil || row.Temp != nil {
+			t.Fatalf("%s: vitals deberían ser nil: %+v", id, row)
+		}
+	}
+	row := byID["rt1"]
+	if row.CPU == nil || *row.CPU != 12 {
+		t.Fatalf("rt1: CPU=%v, esperaba 12", row.CPU)
+	}
+}

--- a/server-go/internal/adapters/live_vitals_test.go
+++ b/server-go/internal/adapters/live_vitals_test.go
@@ -3,6 +3,8 @@ package adapters
 import (
 	"context"
 	"testing"
+
+	"github.com/gnacho/netpulse/agent/probe"
 )
 
 // #441: los routers cuya fuente no puede reportar métricas de sistema (SNMP,
@@ -91,5 +93,42 @@ func TestMetricsRowsWithoutVitals(t *testing.T) {
 	row := byID["rt1"]
 	if row.CPU == nil || *row.CPU != 12 {
 		t.Fatalf("rt1: CPU=%v, esperaba 12", row.CPU)
+	}
+}
+
+// #441: los pushes event-driven del agente (BuildWireless, sin sección
+// system) no deben tumbar las vitals a 0: polledFromAgent conserva la última
+// sección system buena cacheada (anti-parpadeo, igual que ports/radios/fdb).
+func TestPolledFromAgentSystemAntiparpadeo(t *testing.T) {
+	l := NewLive(nil, nil, []RouterConfig{{ID: "ap1", Host: "192.168.8.4", Name: "AP1"}}, nil)
+	cfg := l.routers[0]
+
+	cpu, temp := 23, 51
+	full := &probe.Payload{Router: "ap1", Ts: 1000, Version: "t", Kind: "netgrip"}
+	sys := &probe.SysInfo{Uptime: 98765}
+	sys.Memory.Total = 400
+	sys.Memory.Available = 200 // 50% usado
+	full.Data.System = &probe.SystemData{SysInfo: sys, CPU: &cpu, Temp: &temp}
+
+	out := l.polledFromAgent(cfg, full)
+	if out.cpu != 23 || out.temp != 51 || out.ram != 50 {
+		t.Fatalf("vitals del push completo: cpu=%d ram=%d temp=%d", out.cpu, out.ram, out.temp)
+	}
+	if out.agentKind != "netgrip" {
+		t.Fatalf("agentKind=%q, esperaba netgrip", out.agentKind)
+	}
+
+	// Push event-driven (wireless-only): SIN system → conserva las vitals.
+	partial := &probe.Payload{Router: "ap1", Ts: 1010, Version: "t", Kind: "netgrip"}
+	partial.Data.Wireless = &probe.WirelessData{Clients: map[string]probe.WirelessClient{}}
+	out2 := l.polledFromAgent(cfg, partial)
+	if out2.cpu != 23 || out2.temp != 51 || out2.ram != 50 {
+		t.Fatalf("anti-parpadeo vitals: cpu=%d ram=%d temp=%d", out2.cpu, out2.ram, out2.temp)
+	}
+
+	// Un router con agente netgrip nativo SÍ tiene vitals (no se marca).
+	r := l.buildRouter(out2, nil)
+	if r.VitalsAvailable != nil {
+		t.Fatalf("VitalsAvailable=%v, esperaba nil (agente netgrip con system)", r.VitalsAvailable)
 	}
 }

--- a/server-go/internal/adapters/types.go
+++ b/server-go/internal/adapters/types.go
@@ -162,9 +162,14 @@ type Router struct {
 	// configurado (clave del servidor no autorizada) — issue #257. La UI lo
 	// pinta como "sin acceso" en vez de "offline" (config issue, no power).
 	AccessMissing bool      `json:"accessMissing,omitempty"`
-	CPU           *int      `json:"cpu"`
-	RAM           *int      `json:"ram"`
-	Temp          *int      `json:"temp"`
+	// VitalsAvailable: false cuando la fuente de datos del router no puede
+	// reportar métricas de sistema (#441): switches sondeados por SNMP (#309)
+	// o pushers externos por beacon/scraper (#291). En ese caso CPU/RAM/Temp
+	// van a null y la UI no los pinta. Ausente = vitals disponibles.
+	VitalsAvailable *bool  `json:"vitalsAvailable,omitempty"`
+	CPU             *int   `json:"cpu"`
+	RAM             *int   `json:"ram"`
+	Temp            *int   `json:"temp"`
 	Uptime        string    `json:"uptime"` // "<d>d <h>h" | "—"
 	Clients       int       `json:"clients"`
 	HotMetric     string    `json:"hotMetric,omitempty"` // "temp" solo si temp>65


### PR DESCRIPTION
Closes #441
Closes #442
Closes #443

## What

- **#441**: routers polled through SNMP or external beacon/scraper pushers are marked `vitalsAvailable: false`, cpu/ram/temp are served as null and not persisted as zero rows. The UI stops painting fake zeros: home cards, fleet cards (hint instead), fleet table (dash), topology tooltip, and the detail performance panel becomes an explanatory placeholder.
- **#441 (bonus fix)**: event-driven agent pushes (BuildWireless on iw events) carry no system section and zeroed the vitals of routers with active WiFi (e.g. NetGrip-powered APs). The system section is now cached in the extras snapshot like ports/radios/fdb, so vitals survive between full pushes.
- **#442**: the detail info card action becomes a generic "Open web UI" (managed switches do not run LuCI), plus an "Open NetGrip" action on port 8080 when the agent kind is netgrip.
- **#443**: the reinstall action moves from the device detail info card to the Agents section, now available to admins for every native OpenWrt agent (healthy or broken). External and NetGrip agents stay excluded.

## Verification

- `go test ./...` green in server-go and agent (3 new tests around vitals marking, metric rows and system anti-flap).
- `tsc`, `npm run build` and `npm run lint` clean.
- Live deploy verified via API (SNMP/beacon switch marked with null vitals, NetGrip AP back to real values) and a 24-check Playwright pass over the running instance (0 JS errors).