### PR TITLE
fix(ui,server): timeline compacta de upgrades y comparación de builds (#446, #447, #449)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.25.0] - 2026-09-02
+
+### Added
+
+- **Acciones de router en la tabla y ocultar vitales inexistentes (#445)**: la tabla de routers añade acciones para abrir la web UI genérica y NetGrip; los routers sin métricas de sistema (SNMP/switches/beacon) ya no muestran CPU/RAM/temperatura en 0; las vitales anteriores se reciclan entre pushes parciales del agente.
+- **Timeline compacta de actualización de agentes (#446)**: el panel de agentes muestra el progreso del upgrade en una sola línea por agente, con desaparición rápida tras completarse (10 s) o fallar (60 s), evitando que rompa la tabla.
+
+### Fixed
+
+- **Botón "Actualizar agente" persistente tras upgrade (#447)**: `vercmp` ahora compara también el build del sufijo `-N` (`CmpBuild`), de modo que el frontend y el ciclo de upgrade usan el mismo criterio. Un agente con build más reciente ya no se considera desactualizado.
+- **Upgrade de agentes OpenWrt fallaba con 404 (#449)**: `agentbin.Open` normaliza `armv7`/`armv7l`/`armhf` a `arm`, `aarch64` a `arm64` y `x86_64` a `amd64`, coincidiendo con los nombres de los binarios embebidos.
+
 ## [2.24.0] - 2026-09-01
 
 ### Added

--- a/app/src/components/routers/AgentsSection.tsx
+++ b/app/src/components/routers/AgentsSection.tsx
@@ -66,6 +66,14 @@ function hhmmss(ts: number): string {
   })
 }
 
+// Ventanas de visibilidad de la timeline compacta (#446): mientras el reporte
+// está vivo se muestra (ventana de 120 s de activeUpgrade); "done" desaparece
+// en segundos; "failed" aguanta un poco para poder leer el error; un paso no
+// terminal sin reporte fresco (upgrade sin confirmar) tiene un margen corto.
+const TIMELINE_DONE_S = 10
+const TIMELINE_FAILED_S = 60
+const TIMELINE_STALLED_S = 90
+
 /** Fila de un agente con sus acciones de recuperación (estado local). */
 function AgentRow({ agent, router }: { agent?: AgentInfo; router: Router | undefined }) {
   const { t } = useTranslation()
@@ -90,20 +98,27 @@ function AgentRow({ agent, router }: { agent?: AgentInfo; router: Router | undef
   const lastSeen = agent?.lastSeen ? relTimeFromTs(agent.lastSeen) ?? t('routers.agents.never') : t('routers.agents.never')
   const live = agent ? activeUpgrade(agent, nowSec) : undefined
 
-  // Tick de 1 s mientras hay upgrade en marcha (elapsed de la timeline).
-  const ticking = live !== undefined
+  // Timeline compacta (#446): una sola línea por agente, visible mientras el
+  // upgrade está en marcha y un instante tras cerrarse (nada de 5 min).
+  const up = agent?.upgrade
+  const showTimeline =
+    up !== undefined &&
+    (live !== undefined
+      ? true
+      : up.step === 'done'
+        ? nowSec - up.ts < TIMELINE_DONE_S
+        : up.step === 'failed'
+          ? nowSec - up.ts < TIMELINE_FAILED_S
+          : up.step !== 'queued' && nowSec - up.ts < TIMELINE_STALLED_S)
+
+  // Tick de 1 s mientras la timeline es visible: progreso en vivo y cuenta
+  // atrás de la desaparición tras done/failed.
+  const ticking = showTimeline
   useEffect(() => {
     if (!ticking) return
     const timer = window.setInterval(() => setNowSec(Math.floor(Date.now() / 1000)), 1000)
     return () => window.clearInterval(timer)
   }, [ticking])
-
-  // Timeline visible mientras el upgrade está en marcha o hasta 5 min después
-  // del último paso: el recorrido completo queda visible aunque vaya rápido
-  // y sobrevive al parpadeo del poll de agentes (#284).
-  const up = agent?.upgrade
-  const showTimeline =
-    up !== undefined && (live !== undefined || (up.step !== 'queued' && nowSec - up.ts < 300))
 
   const reinstall = async () => {
     if (reinstallState === 'busy') return
@@ -284,49 +299,63 @@ function AgentRow({ agent, router }: { agent?: AgentInfo; router: Router | undef
         )}
       </td>
     </motion.tr>
-    {showTimeline && up && (
-      <motion.tr
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.2 }}
-        className="border-b border-border/60 last:border-0"
-      >
-        <td colSpan={6} className="pb-3">
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 rounded-xl bg-surface px-3.5 py-2.5">
-            <span className="inline-flex items-center gap-1.5 text-label font-medium uppercase text-text-muted">
-              <Clock className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden="true" />
-              {t('routers.agent.timeline')}
-              {(() => {
-                const h = up.steps ?? []
-                const first = h[0]
-                const last = h[h.length - 1]
-                if (!first || !last || h.length < 2) return null
-                const dur = Math.max(1, last.ts - first.ts)
-                return <span className="font-mono normal-case">{t('routers.agent.timelineSummary', { count: h.length, secs: dur })}</span>
-              })()}
-            </span>
-            {(up.steps ?? []).map((s, i) => {
-              const isCurrent = i === (up.steps?.length ?? 0) - 1 && live !== undefined
-              return (
-                <span key={`${s.step}-${s.ts}`} className="inline-flex items-center gap-1.5 text-caption">
-                  {isCurrent ? (
-                    <Loader2 className="h-3 w-3 animate-spin text-accent" strokeWidth={2} aria-hidden="true" />
-                  ) : (
-                    <Check className="h-3 w-3 text-ok" strokeWidth={2} aria-hidden="true" />
-                  )}
-                  <span className={isCurrent ? 'font-medium text-text-primary' : 'text-text-secondary'}>
-                    {upgradeStepText(s, t)}
-                    {isCurrent && s.step !== 'queued' ? ` · ${Math.max(0, nowSec - s.ts)}s` : ''}
-                  </span>
-                  <span className="font-mono text-text-muted">{hhmmss(s.ts)}</span>
+    {showTimeline && up &&
+      (() => {
+        // Resumen de una línea (#446): paso actual en vivo, resultado terminal
+        // o último paso conocido si el reporte dejó de llegar. El detalle
+        // completo (paso + HH:MM:SS) queda en tooltip y aria-label.
+        const steps = up.steps ?? []
+        const first = steps[0]
+        const last = steps[steps.length - 1]
+        const dur = first && last && steps.length >= 2 ? Math.max(1, last.ts - first.ts) : undefined
+        const done = up.step === 'done' && live === undefined
+        const failed = up.step === 'failed'
+        const summary =
+          live !== undefined
+            ? `${upgradeStepText(up, t)} · ${Math.max(0, nowSec - (first?.ts ?? up.ts))}s`
+            : done
+              ? t('routers.agent.upgraded') +
+                (dur !== undefined ? ' ' + t('routers.agent.timelineSummary', { count: steps.length, secs: dur }) : '')
+              : failed
+                ? `${t('routers.agent.upgradeFail')}${up.error ? `: ${up.error}` : ''}`
+                : `${upgradeStepText(up, t)} · ${Math.max(0, nowSec - up.ts)}s`
+        const detail = steps.map((s) => `${upgradeStepText(s, t)} ${hhmmss(s.ts)}`).join(' · ')
+        return (
+          <motion.tr
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.2 }}
+            className="border-b border-border/60 last:border-0"
+          >
+            <td colSpan={6} className="pb-2 pt-0">
+              <div
+                role="status"
+                aria-live="polite"
+                title={detail}
+                aria-label={`${t('routers.agent.timeline')}: ${detail}`}
+                className="flex items-center gap-2 overflow-hidden whitespace-nowrap rounded-lg bg-canvas/60 px-3 py-1 text-caption"
+              >
+                {live !== undefined ? (
+                  <Loader2 className="h-3 w-3 shrink-0 animate-spin text-accent" strokeWidth={2} aria-hidden="true" />
+                ) : done ? (
+                  <Check className="h-3 w-3 shrink-0 text-ok" strokeWidth={2} aria-hidden="true" />
+                ) : (
+                  <Clock className={cn('h-3 w-3 shrink-0', failed ? 'text-danger' : 'text-text-muted')} strokeWidth={2} aria-hidden="true" />
+                )}
+                <span className="shrink-0 text-label font-medium uppercase text-text-muted">{t('routers.agent.timeline')}</span>
+                <span className={cn('truncate font-mono', failed ? 'text-danger' : done ? 'text-ok' : 'text-text-secondary')}>
+                  {summary}
                 </span>
-              )
-            })}
-            {live === undefined && <span className="text-caption text-ok">{t('routers.agent.timelineDone')}</span>}
-          </div>
-        </td>
-      </motion.tr>
-    )}
+                {live !== undefined && up.step === 'downloading' && (up.pct ?? 0) > 0 && (
+                  <span className="h-1 w-16 shrink-0 overflow-hidden rounded-full bg-border" aria-hidden="true">
+                    <span className="block h-full rounded-full bg-accent transition-[width]" style={{ width: `${up.pct ?? 0}%` }} />
+                  </span>
+                )}
+              </div>
+            </td>
+          </motion.tr>
+        )
+      })()}
     </>
   )
 }

--- a/server-go/internal/agentbin/agentbin.go
+++ b/server-go/internal/agentbin/agentbin.go
@@ -37,10 +37,10 @@ var (
 	digestMu    sync.Mutex
 	digestCache = map[string]string{}
 )
-
 // Digest devuelve el sha256 (hex) del binario embebido para arch, o "" si no
-// existe o no se puede leer. Cacheado.
+// existe o no se puede leer. Cacheado. Normaliza armv7 -> arm como Open.
 func Digest(arch string) string {
+	arch = normalizeArch(arch)
 	digestMu.Lock()
 	defer digestMu.Unlock()
 	if d, ok := digestCache[arch]; ok {
@@ -73,11 +73,24 @@ func HasBinaries() bool {
 //go:embed agents/*
 var agentsFS embed.FS
 
+func normalizeArch(arch string) string {
+	switch arch {
+	case "aarch64":
+		return "arm64"
+	case "armv7l", "armv7", "armhf":
+		return "arm"
+	case "x86_64":
+		return "amd64"
+	}
+	return arch
+}
+
 // Open devuelve el binario para la arquitectura dada, o error si no existe.
 // Las arquitecturas válidas son las mismas que las builds de goreleaser:
-// "amd64", "arm64", "armv7".
+// "amd64", "arm64", "armv7". Normaliza sinónimos (armv7 -> arm) para que el
+// one-liner del agente, que reporta GOARCH=armv7, encuentre el binario.
 func Open(arch string) (fs.File, error) {
-	name := "agents/netpulse-agent-" + arch
+	name := "agents/netpulse-agent-" + normalizeArch(arch)
 	f, err := agentsFS.Open(name)
 	if err != nil {
 		return nil, err

--- a/server-go/internal/agentbin/arch_test.go
+++ b/server-go/internal/agentbin/arch_test.go
@@ -1,0 +1,18 @@
+package agentbin
+
+import "testing"
+
+func TestOpenArmVariants(t *testing.T) {
+	for _, arch := range []string{"amd64", "arm64", "arm", "armv7", "armv7l", "aarch64", "x86_64"} {
+		f, err := Open(arch)
+		if err != nil {
+			t.Fatalf("Open(%q) failed: %v", arch, err)
+		}
+		st, _ := f.Stat()
+		if st.Size() == 0 {
+			t.Fatalf("Open(%q) size 0", arch)
+		}
+		f.Close()
+		t.Logf("Open(%q) ok size=%d", arch, st.Size())
+	}
+}

--- a/server-go/internal/httpapi/agent.go
+++ b/server-go/internal/httpapi/agent.go
@@ -474,10 +474,14 @@ func (s *server) handleAgentsList(w http.ResponseWriter, _ *http.Request) {
 				// #363: un agente embebido en NetGrip se actualiza vía el
 				// evento SSE upgrade (NetGrip corre su propio self-update);
 				// "hay novedad" = versión reportada < última release de NetGrip.
+				// #447: hay upgrade disponible solo si el agente reporta una
+				// versión MÁS VIEJA que la del binario embebido, build incluido
+				// (mismo criterio que finishIfTarget y upgrade-all: un agente
+				// más nuevo que el embebido no está desactualizado).
 				if agentKind == "netgrip" {
 					item.UpdateAvailable = item.Version != "" && cmpSemver(netgripLatest(), item.Version) > 0
 				} else {
-					item.UpdateAvailable = agentUpgradeable(matchedType) && item.Version != "" && item.Version != agentbin.EmbeddedAgentVersion
+					item.UpdateAvailable = agentUpgradeable(matchedType) && item.Version != "" && vercmp.CmpBuild(item.Version, agentbin.EmbeddedAgentVersion) < 0
 				}
 				// Progreso en vivo del upgrade (#284), si hay actividad reciente.
 				if st, ok := s.upgrades.snapshot(slug); ok {

--- a/server-go/internal/httpapi/upgrade.go
+++ b/server-go/internal/httpapi/upgrade.go
@@ -159,7 +159,9 @@ func (u *upgradeTracker) finishIfTarget(slug, version string) bool {
 	case upgradeStepDone, upgradeStepFailed, upgradeStepQueued:
 		return false
 	}
-	if vercmp.Cmp(version, st.Target) < 0 {
+	// #447: comparación con build (-N) para no cerrar el ciclo con un push
+	// que reporte el mismo x.y.z con build más viejo que el objetivo.
+	if vercmp.CmpBuild(version, st.Target) < 0 {
 		return false
 	}
 	u.setLocked(slug, upgradeStepDone, 0, "")
@@ -388,7 +390,10 @@ func (s *server) handleAgentsUpgradeAll(w http.ResponseWriter, r *http.Request) 
 				// external son scrapers que no entienden el comando "upgrade".
 				if !s.routerUpgradeable(slug) {
 					item.Status = "not_openwrt"
-				} else if version != "" && version != agentbin.EmbeddedAgentVersion {
+				// #447: solo hay novedad si el agente es MÁS VIEJO que el
+				// binario embebido (build incluido); un agente más nuevo no
+				// está desactualizado y el botón ofrecería un downgrade.
+				} else if version != "" && vercmp.CmpBuild(version, agentbin.EmbeddedAgentVersion) < 0 {
 					item.Status = s.sendOrQueueUpgrade(slug)
 					item.Upgraded = item.Status == "sent"
 					if item.Status == "sent" {

--- a/server-go/internal/httpapi/upgrade_api_test.go
+++ b/server-go/internal/httpapi/upgrade_api_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/gnacho/netpulse/server-go/internal/adapters"
+	"github.com/gnacho/netpulse/server-go/internal/agentbin"
 	"github.com/gnacho/netpulse/server-go/internal/auth"
 	"github.com/gnacho/netpulse/server-go/internal/config"
 	"github.com/gnacho/netpulse/server-go/internal/db"
@@ -312,7 +313,9 @@ func TestUpgradeResultBearer(t *testing.T) {
 }
 
 // TestAgentsListUpdateAvailable: el campo updateAvailable refleja si la versión
-// reportada por el agente difiere del binario embebido (agentbin.EmbeddedAgentVersion).
+// reportada por el agente es MÁS VIEJA que la del binario embebido
+// (agentbin.EmbeddedAgentVersion), build incluido (#447). Un agente más nuevo
+// que el embebido no está desactualizado (el botón ofrecería un downgrade).
 func TestAgentsListUpdateAvailable(t *testing.T) {
 	ts := makeUpgradeTestServer(t)
 	st, tok := createUpgradeToken(t, ts, "patio")
@@ -338,10 +341,30 @@ func TestAgentsListUpdateAvailable(t *testing.T) {
 		t.Fatalf("versión 0.1.0 debe dar updateAvailable=false: %v", patio)
 	}
 
-	// Push con versión distinta → updateAvailable=true.
-	upgradeIngest(t, ts, tok, upgradePayload("9.9.9"))
+	// Push con versión más vieja → updateAvailable=true.
+	upgradeIngest(t, ts, tok, upgradePayload("0.0.9"))
 	if patio := agentItem(); patio["updateAvailable"] != true {
-		t.Fatalf("versión 9.9.9 debe dar updateAvailable=true: %v", patio)
+		t.Fatalf("versión 0.0.9 debe dar updateAvailable=true: %v", patio)
+	}
+
+	// Push con versión MÁS NUEVA que la embebida → false (no se ofrece
+	// downgrade; antes cualquier versión distinta marcaba novedad, #447).
+	upgradeIngest(t, ts, tok, upgradePayload("9.9.9"))
+	if patio := agentItem(); patio["updateAvailable"] != false {
+		t.Fatalf("versión 9.9.9 (más nueva) debe dar updateAvailable=false: %v", patio)
+	}
+
+	// #447: builds del mismo x.y.z: -437 < -443 marca novedad; -443 no.
+	saved := agentbin.EmbeddedAgentVersion
+	t.Cleanup(func() { agentbin.EmbeddedAgentVersion = saved })
+	agentbin.EmbeddedAgentVersion = "2.25.0-443"
+	upgradeIngest(t, ts, tok, upgradePayload("2.25.0-437"))
+	if patio := agentItem(); patio["updateAvailable"] != true {
+		t.Fatalf("2.25.0-437 contra embebido 2.25.0-443 debe dar updateAvailable=true: %v", patio)
+	}
+	upgradeIngest(t, ts, tok, upgradePayload("2.25.0-443"))
+	if patio := agentItem(); patio["updateAvailable"] != false {
+		t.Fatalf("2.25.0-443 contra embebido 2.25.0-443 debe dar updateAvailable=false: %v", patio)
 	}
 }
 
@@ -359,12 +382,12 @@ func TestAgentsUpgradeAll(t *testing.T) {
 		t.Fatalf("sin admin: got %d want 403/401", res.StatusCode)
 	}
 
-	// "patio" desactualizado y conectado → sent.
+	// "patio" desactualizado (versión más vieja que la embebida) y conectado → sent.
 	st, tok := createUpgradeToken(t, ts, "patio")
 	if st != 201 {
 		t.Fatalf("create patio: %d", st)
 	}
-	upgradeIngest(t, ts, tok, upgradePayload("9.9.9"))
+	upgradeIngest(t, ts, tok, upgradePayload("0.0.9"))
 	cancel, done := openStream(t, ts, "patio", tok)
 	defer func() { cancel(); <-done }()
 
@@ -372,7 +395,7 @@ func TestAgentsUpgradeAll(t *testing.T) {
 	if st, tokO := createUpgradeToken(t, ts, "otro"); st != 201 {
 		t.Fatalf("create otro: %d", st)
 	} else {
-		upgradeIngest(t, ts, tokO, upgradePayloadFor("otro", "9.9.9"))
+		upgradeIngest(t, ts, tokO, upgradePayloadFor("otro", "0.0.9"))
 	}
 	// "aldia" con versión == embebida → up_to_date.
 	st2, tok2 := createUpgradeToken(t, ts, "aldia")

--- a/server-go/internal/httpapi/upgrade_finish_test.go
+++ b/server-go/internal/httpapi/upgrade_finish_test.go
@@ -59,6 +59,22 @@ func TestUpgradeTrackerFinishPrefixesAndStates(t *testing.T) {
 		t.Fatal("v0.26.1 debe cerrar contra target 0.26.1")
 	}
 
+	// #447: mismo x.y.z con build más viejo que el target NO cierra el ciclo
+	// (vercmp.Cmp ignora los sufijos y cerraba con la versión vieja).
+	u4 := newUpgradeTracker()
+	u4.now = func() time.Time { return now }
+	u4.begin("gateway", "2.25.0-443")
+	u4.set("gateway", upgradeStepRestarting, 0, "")
+	if u4.finishIfTarget("gateway", "2.25.0-437") {
+		t.Fatal("2.25.0-437 no debe cerrar contra target 2.25.0-443")
+	}
+	if st, _ := u4.snapshot("gateway"); st.Step != upgradeStepRestarting {
+		t.Fatalf("debe seguir en restarting: %+v", st)
+	}
+	if !u4.finishIfTarget("gateway", "v2.25.0-443") {
+		t.Fatal("v2.25.0-443 debe cerrar contra target 2.25.0-443")
+	}
+
 	// Sin target (estados escritos a mano, upgrades legados): nunca cierra.
 	u.set("solo", upgradeStepRestarting, 0, "")
 	if u.finishIfTarget("solo", "9.9.9") {

--- a/server-go/internal/vercmp/vercmp.go
+++ b/server-go/internal/vercmp/vercmp.go
@@ -29,13 +29,58 @@ func Cmp(a, b string) int {
 
 // Parse3 devuelve [major, minor, patch]; false si no parsea como x.y.z.
 func Parse3(v string) ([3]int, bool) {
+	x, _, ok := parse3Build(v)
+	return x, ok
+}
+
+// CmpBuild compara dos versiones x.y.z incluyendo el número de build del
+// sufijo (-N/+N, también -rN): 2.25.0-437 < 2.25.0-443. Una versión sin
+// sufijo numérico válido cuenta como build 0, de modo que 2.25.0 < 2.25.0-437.
+// Malparseo → 0 (misma política que Cmp). Las señales de actualización que
+// dependen del build (updateAvailable, cierre del ciclo de upgrade) DEBEN
+// usar esta variante: Cmp ignora los sufijos y considera iguales dos builds
+// distintos del mismo x.y.z.
+func CmpBuild(a, b string) int {
+	pa, ba, okA := parse3Build(a)
+	pb, bb, okB := parse3Build(b)
+	if !okA || !okB {
+		return 0
+	}
+	for i := 0; i < 3; i++ {
+		if pa[i] != pb[i] {
+			if pa[i] > pb[i] {
+				return 1
+			}
+			return -1
+		}
+	}
+	switch {
+	case ba > bb:
+		return 1
+	case ba < bb:
+		return -1
+	}
+	return 0
+}
+
+// parse3Build: [major, minor, patch] + build numérico del sufijo (-437, +2,
+// -r3). Sufijo no numérico (beta, dev) → build 0.
+func parse3Build(v string) ([3]int, int, bool) {
 	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
-	if i := strings.IndexAny(v, "- +"); i >= 0 {
+	build := 0
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		suf := v[i+1:]
 		v = v[:i]
+		if len(suf) > 0 && suf[0] == 'r' {
+			suf = suf[1:]
+		}
+		if n, _ := fmt.Sscanf(suf, "%d", &build); n != 1 {
+			build = 0
+		}
 	}
 	var x [3]int
 	if n, _ := fmt.Sscanf(v, "%d.%d.%d", &x[0], &x[1], &x[2]); n != 3 {
-		return x, false
+		return x, 0, false
 	}
-	return x, true
+	return x, build, true
 }

--- a/server-go/internal/vercmp/vercmp_test.go
+++ b/server-go/internal/vercmp/vercmp_test.go
@@ -22,3 +22,36 @@ func TestCmp(t *testing.T) {
 		}
 	}
 }
+
+func TestCmpBuild(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		// x.y.z manda igual que Cmp.
+		{"2.25.0-437", "2.24.9-999", 1},
+		{"2.24.0-443", "2.25.0-437", -1},
+		// Mismo x.y.z: decide el build (#447).
+		{"2.25.0-437", "2.25.0-443", -1},
+		{"2.25.0-443", "2.25.0-437", 1},
+		{"2.25.0-443", "2.25.0-443", 0},
+		{"2.25.0+2", "2.25.0+10", -1},
+		{"0.26.1-r3", "0.26.1-r4", -1},
+		// Sin sufijo numérico → build 0 (desnuda < con build).
+		{"2.25.0", "2.25.0-437", -1},
+		{"v0.26.1", "0.26.1", 0},
+		{"v0.26.1", "0.26.1-r1", -1},
+		// Sufijo no numérico → build 0.
+		{"2.25.0-beta", "2.25.0-437", -1},
+		{"2.25.0-beta", "2.25.0", 0},
+		// Malparseo → 0 (sin señal).
+		{"dev", "2.25.0-437", 0},
+		{"2.25", "2.25.0-437", 0},
+		{"", "2.25.0-437", 0},
+	}
+	for _, c := range cases {
+		if got := CmpBuild(c.a, c.b); got != c.want {
+			t.Errorf("CmpBuild(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Qué arregla / mejora

- #446: la timeline de upgrade del panel de agentes era demasiado grande y persistía 5 min. Ahora es una línea compacta por agente con progreso en vivo y desaparece rápido (10 s tras éxito, 60 s tras fallo, 90 s si se queda atascado).
- #447: el botón de actualizar agente se quedaba visible porque `vercmp` ignoraba el sufijo `-N` del build. Se añade `CmpBuild` y se usa tanto en `updateAvailable` como en `finishIfTarget`, de modo que un agente con build más reciente no se marque como desactualizado.
- #449: el upgrade de agentes OpenWrt fallaba con HTTP 404 porque el agente pide `arch=armv7` y el binario embebido se llama `netpulse-agent-arm`. Se normaliza `armv7`/`aarch64`/`x86_64` en `agentbin.Open`/`Digest`.

## Cómo se ha probado

- `go test ./...` en `server-go` pasa.
- Desplegado en preview (`192.168.1.226:3000`) con versión `2.25.0-450`:
  - `gateway`, `redmi-ax6` y `redmi-ax6-3` actualizaron de `2.25.0-437` a `2.25.0-450`.
  - `redmi-ax6-2` (NetGrip) completó su propio upgrade.
  - Todos los agentes nativos terminan con `updateAvailable: false`.

## Pendiente fuera de este PR

- #448: pánico periódico en `iwevents` del agente del gateway. Se deja abierto para siguiente tanda.

## Checklist

- [x] CHANGELOG actualizado con `v2.25.0`.
- [x] Tests del backend pasan.
- [x] Preview desplegado y validado.

closes #446, closes #447, closes #449
