### PR TITLE
fix(agent): evitar panic en iwevents al terminar el proceso hijo (#448)

### DIFF
--- a/agent/internal/iwevents/iwevents.go
+++ b/agent/internal/iwevents/iwevents.go
@@ -9,7 +9,6 @@ package iwevents
 import (
 	"bufio"
 	"context"
-	"io"
 	"log"
 	"os/exec"
 	"strings"
@@ -53,7 +52,6 @@ func Listen(ctx context.Context, onEvent func(Event)) error {
 		onEvent(ev)
 	}
 	_ = cmd.Wait()
-	_, _ = io.Copy(io.Discard, cmd.Stderr.(io.Reader))
 	return nil
 }
 

--- a/agent/internal/iwevents/iwevents_test.go
+++ b/agent/internal/iwevents/iwevents_test.go
@@ -1,0 +1,49 @@
+package iwevents
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestListenNoPanicOnExit regression para #448: el agente no debe hacer panic
+// cuando el proceso `iw event` termina y Listen vuelve de cmd.Wait.
+// Antes el código hacía una aserción de tipo inválida sobre cmd.Stderr.
+func TestListenNoPanicOnExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("iw no corre en Windows")
+	}
+
+	// Crear un `iw` falso que salga inmediatamente.
+	tmpDir := t.TempDir()
+	iwPath := filepath.Join(tmpDir, "iw")
+	if err := os.WriteFile(iwPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("escribir iw falso: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// Si vuelve a surgir el panic de #448, esta llamada lo lanzará y
+		// matará la goroutine de test en vez de propagarse al proceso.
+		if err := Listen(ctx, func(Event) {}); err != nil {
+			// Un error por ctx cancelado es aceptable; lo importante es no
+			// panicar.
+		}
+	}()
+
+	select {
+	case <-done:
+		// OK
+	case <-time.After(3 * time.Second):
+		t.Fatal("Listen no terminó a tiempo")
+	}
+}


### PR DESCRIPTION
## Qué arregla

Closes #448.

El agente de NetPulse moría con panic cuando el proceso `iw event` terminaba:

```
panic: interface conversion: *slog.handlerWriter is not io.Reader: missing method Read
```

La causa estaba en `agent/internal/iwevents/iwevents.go`:

```go
cmd.Stderr = log.Writer()
...
_, _ = io.Copy(io.Discard, cmd.Stderr.(io.Reader))
```

`log.Writer()` devuelve un `io.Writer`, no un `io.Reader`. La aserción de tipo forzada paniqueaba al cerrar el listener, matando todo el agente.

## Cambios

- Elimina la línea de `io.Copy` y la importación de `io`.
- Añade `TestListenNoPanicOnExit`, un test de regresión que crea un `iw` falso, llama a `Listen` y verifica que no haya panic.

## Cómo se ha probado

- `go test ./...` en `agent/` pasa.
- El test reproduce el escenario de salida del proceso `iw` sin depender de tener `iw` instalado.
