### PR TITLE
docs: actualizar roadmap con v2.25.0 y v2.26.0

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -147,14 +147,14 @@ OpenWrt deberían funcionar, pero el tuyo sería el primero en contarlo.
 | **7 — Agente a fondo** | ✅ | Eventos wifi en tiempo real (`iw event`), SSE bidireccional, paquete `.ipk`, profiling (RSS 11-12 MB, CPU <1%) |
 | **8 — Consolidación** | ✅ | Métricas operativas en `/api/health`, registry de agentes persistente, escalera de retención (raw 7d → buckets 5min 1año → daily ∞), recharts v3, webhooks salientes |
 | **9 — On-box** | ✅ | Config UCI, bootstrap AUTH_PASS, TLS autofirmado + SPKI pinning, token de pairing, paquete server OpenWrt |
-| **10 — Orquestación** | 🔄 | Motor plan→apply→state + executor sandboxeado en el agente (10.1), módulo AdGuard (10.2), módulo DAWN (10.9). WireGuard aplazado a la Fase 17 |
+| **10 — Orquestación** | ✅ | Motor plan→apply→state + executor sandboxeado (10.1), módulos AdGuard (10.2), WiFi guest, DDNS, SQM y usteer. WireGuard aplazado a la Fase 17 |
 | **11 — Paquete LuCI** | ✅ | `luci-app-netpulse`: estado local del agente (procd, UCI, logs, restart/rearm) + test connection + puente a la webapp |
 | **12 — Auditoría de seguridad** | ✅ | TRUST_PROXY, anti-replay en ingesta, body cap, password mínima 10 |
 | **13 — Auditoría de robustez** | ✅ | Single-flight GetOverview, SSE write deadline, race en sshpool.dial, %w wrapping |
 | **14 — Visibilidad WiFi/roaming** | ✅ | Matriz de señal DAWN, estado 802.11r por SSID, utilización por canal survey, feed persistente de eventos de roaming (30 días) |
 | **15 — Informes** | 🔄 | Disponibilidad día/semana/mes. Pendiente: tráfico, actividad, resumen de alertas, exportación |
 | **16 — Alertas avanzadas** | 🔮 | Reglas custom por umbral, tipos nuevos (fallo de roaming, congestión de canal), silencio programado, email |
-| **17 — Escribir en routers (esqueleto)** | 🔮 | Motor común de despliegue + índice de 10 módulos (AdGuard full, WiFi guest, DDNS, QoS, WireGuard, OpenVPN, Tailscale, Batman, DPI) |
+| **17 — Escribir en routers** | 🔄 | Ownership UCI + apply seguro con rollback (#451), planificación de canales (#452), firmware upgrades (#453); índice completo de módulos (AdGuard full, WiFi guest, DDNS, QoS, WireGuard, OpenVPN, Tailscale, Batman, DPI) |
 | **18-20 — Programa de beta-testing** | 🔮 | Grupos de módulos por riesgo (bajo / medio / alto) con canales stable + unstable y beta-testers externos |
 
 Detalle completo en [docs/ROADMAP.md](docs/ROADMAP.md).

--- a/README.md
+++ b/README.md
@@ -145,14 +145,14 @@ Other OpenWrt devices should work, but yours would be the first to tell.
 | **7 — Agent deep dive** | ✅ | Real-time wifi events (`iw event`), bidirectional SSE, `.ipk` packaging (11-12 MB RSS, <1% CPU) |
 | **8 — Consolidation** | ✅ | `/api/health` metrics, persistent agent registry, retention ladder (raw 7d → 5min buckets 1y → daily ∞), recharts v3, outgoing alert webhooks |
 | **9 — On-box** | ✅ | UCI config, AUTH_PASS bootstrap, TLS self-signed + SPKI pinning, pairing token, OpenWrt server package |
-| **10 — Orchestration** | 🔄 | Plan→apply→state engine + sandboxed agent executor (10.1), AdGuard module (10.2), DAWN module (10.9). WireGuard deferred to Phase 17 |
+| **10 — Orchestration** | ✅ | Plan→apply→state engine + sandboxed executor (10.1), AdGuard (10.2), WiFi guest, DDNS, SQM, usteer modules. WireGuard moved to Phase 17 |
 | **11 — LuCI package** | ✅ | `luci-app-netpulse` shipped as `.ipk`/`.apk` on every release: local agent status/view (procd, UCI, logs, restart/rearm) + bridge to the web app |
 | **12 — Security audit** | ✅ | TRUST_PROXY, anti-replay on ingest, body cap, password min 10 |
 | **13 — Robustness audit** | ✅ | Single-flight GetOverview, SSE write deadline, sshpool dial race, error wrapping |
 | **14 — WiFi/roaming visibility** | ✅ | DAWN signal matrix, 802.11r status per SSID, channel utilization survey, persistent roaming events feed (30d) |
 | **15 — Reports** | 🔄 | Daily/week/month availability. Pending: traffic, activity, alert summary, export |
 | **16 — Advanced alerts** | 🔮 | Custom threshold rules, new alert types (roaming failure, channel congestion), scheduled silence, email |
-| **17 — Write to routers (skeleton)** | 🔮 | Common deploy engine + 10 modules index (AdGuard full, WiFi guest, DDNS, QoS, WireGuard, OpenVPN, Tailscale, Batman, DPI) |
+| **17 — Write to routers** | 🔄 | UCI ownership + safe apply with rollback (#451), channel planning (#452), firmware upgrades (#453); full module index (AdGuard full, WiFi guest, DDNS, QoS, WireGuard, OpenVPN, Tailscale, Batman, DPI) |
 | **18-20 — Beta-testing program** | 🔮 | Module groups by risk (low / medium / high) with stable + unstable release channels and external beta-testers |
 
 Full detail in [docs/ROADMAP.md](docs/ROADMAP.md).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,8 +1,6 @@
 # NetPulse — Hoja de ruta
 
-> Actualizada: 2026-08-08 (**v2.8.0**: Fase 14 completa + Fase 15 parcial;
-> Fases 15-16 pendientes; **Fase 17 "escribir en routers"** + programa de
-> beta-testing Fases 18-20 esqueleto acordado).
+> Actualizada: 2026-09-02 (**v2.25.0** publicado: acciones de router en tabla, vitales condicionales, timeline compacta de upgrades, comparación de builds; **v2.26.0** planificado: #448 bugfix, #451 apply seguro con ownership UCI, #452 channel planning, #453 firmware upgrades).
 
 ## Estado actual ✅
 
@@ -599,21 +597,19 @@ E2E. Pendiente:
 
 ---
 
-## Fase 17 — Escribir en los routers (esqueleto, por rellenar)
+## Fase 17 — Escribir en los routers (en progreso, v2.26.0)
 
-> **Por definir**. Esqueleto acordado 8-Ago-2026; el detalle de cada módulo
-> vivirá en su propio issue cuando se arranque (Fases 18-20).
+> **En desarrollo**: [#451](https://github.com/gnacho/netpulse/issues/451), [#452](https://github.com/gnacho/netpulse/issues/452), [#453](https://github.com/gnacho/netpulse/issues/453). Esqueleto acordado 8-Ago-2026; el detalle de cada módulo vive en su propio issue.
 
-Objetivo: NetPulse pasa de **monitor** a **gestor completo** de la red
-OpenWrt. Cada módulo no solo configura UCI sino que **despliega el servicio
-enterero**: instala paquetes, escribe scripts de soporte, configura
-firewall/dnsmasq/network, activa el servicio y deja todo revertible.
+### v2.26.0 — Fundación segura de escritura
 
-Continúa la Fase 10 (motor plan→apply→state ✅) ampliándola a despliegues
-completos (instalador unificado + provisioner de scripts + healthcheck con
-auto-rollback). Los módulos concretos se agrupan por riesgo en Fases 18-20.
+Antes de desplegar módulos completos se estabilizan tres primitivas de seguridad:
 
-**índice de módulos** (cada uno es un issue independiente):
+1. **Ownership UCI + apply seguro con rollback (#451)**: las secciones gestionadas por NetPulse se marcan con `np_managed`, el executor rechaza tocar secciones ajenas y el apply usa el rollback nativo de OpenWrt (o snapshot+revert) con healthcheck post-cambio.
+2. **Channel planning (#452)**: el agente recoge scan de vecinos (`iwinfo scan`) y la UI recomienda canal óptimo por radio, aplicable vía #451.
+3. **Firmware upgrades (#453)**: descarga de imagen oficial, verificación, `sysupgrade` vía agente y recuperación si se pierde conectividad. Reutiliza el motor de #451.
+
+Estos tres issues cierran los prerrequisitos comunes listados más abajo y desbloquean los módulos de bajo riesgo (Fase 18).
 
 | # | Módulo | Fase | Riesgo |
 |---|---|---|---|


### PR DESCRIPTION
## Qué cambia

Actualiza el roadmap del README (EN/ES) y `docs/ROADMAP.md` para reflejar el estado tras v2.25.0 y el trabajo planificado en v2.26.0.

## Cambios concretos

- **README.md / README.es.md**:
  - Fase 10 "Orchestration/Orquestación" pasa a ✅ (motor + módulos AdGuard, WiFi guest, DDNS, SQM, usteer).
  - Fase 17 pasa a 🔄 y menciona los issues #451, #452 y #453.

- **docs/ROADMAP.md**:
  - Fecha de actualización y nota de v2.25.0 / v2.26.0.
  - Nueva sección "v2.26.0 — Fundación segura de escritura" con #451 (ownership UCI + apply seguro), #452 (channel planning) y #453 (firmware upgrades).

## Checklist

- [x] Texto revisado en ambos idiomas.
- [x] Sin em-dashes.
- [x] Issues referenciados correctamente.

closes nothing (solo docs)
