### PR TITLE
fix(ci): build agent binaries before tests and name arm output correctly

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -65,10 +65,11 @@ jobs:
       - name: Copia dist al embed del binario
         run: rm -rf server-go/internal/staticspa/dist && cp -r app/dist server-go/internal/staticspa/dist
 
-      - name: Tests Go
-        working-directory: server-go
-        run: go test ./...
-
+      # Antes de los tests: TestOpenArmVariants abre los binarios embebidos
+      # y además go:embed los necesita presentes para compilar el servidor.
+      # OJO los nombres: Open() resuelve "agents/netpulse-agent-" + normalizeArch(arch)
+      # y normalizeArch mapea armv7/armv7l/armhf -> arm, así que el fichero se
+      # llama netpulse-agent-arm (con GOARM=7), NO netpulse-agent-armv7 (#458).
       - name: Build agent binaries para embed (todas las arquitecturas)
         env:
           CGO_ENABLED: 0
@@ -79,8 +80,12 @@ jobs:
           (cd agent && GOARCH=amd64 go build -trimpath -ldflags "-s -w -X main.Version=$AGENT_VERSION" -o ../server-go/internal/agentbin/agents/netpulse-agent-amd64 ./cmd/netpulse-agent)
           # arm64
           (cd agent && GOARCH=arm64 go build -trimpath -ldflags "-s -w -X main.Version=$AGENT_VERSION" -o ../server-go/internal/agentbin/agents/netpulse-agent-arm64 ./cmd/netpulse-agent)
-          # armv7
-          (cd agent && GOARCH=arm GOARM=7 go build -trimpath -ldflags "-s -w -X main.Version=$AGENT_VERSION" -o ../server-go/internal/agentbin/agents/netpulse-agent-armv7 ./cmd/netpulse-agent)
+          # armv7 (fichero "arm": el nombre que busca normalizeArch)
+          (cd agent && GOARCH=arm GOARM=7 go build -trimpath -ldflags "-s -w -X main.Version=$AGENT_VERSION" -o ../server-go/internal/agentbin/agents/netpulse-agent-arm ./cmd/netpulse-agent)
+
+      - name: Tests Go
+        working-directory: server-go
+        run: go test ./...
 
       - name: Build binario (linux/${{ matrix.arch }})
         working-directory: server-go


### PR DESCRIPTION
Closes #458

- Moves the "Build agent binaries" step before "Tests Go": TestOpenArmVariants opens the embedded binaries, so they must exist.
- Renames the arm output to netpulse-agent-arm (what normalizeArch resolves for armv7/armv7l/armhf); the previous netpulse-agent-armv7 name could never be served by GET /api/agents/{slug}/binary.

Verified locally with the exact CI commands (three archs built, then full go test ./... in server-go): no failures, TestOpenArmVariants passes for every variant.