### PR TITLE
fix(package): uci-defaults banner with pending config steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,9 @@ legacy/server-node/.env
 # (solo el binario local de `go build` en el módulo agent; el patrón `netpulse-agent*`
 # coincidía con el directorio fuente agent/cmd/netpulse-agent/ e ignoraba su código)
 netpulse
-netpulse-agent
+# anclado a la raíz: el patrón libre `netpulse-agent` también ignoraba el
+# directorio deploy/openwrt/netpulse-agent/ (ficheros del paquete)
+/netpulse-agent
 agent/netpulse-agent
 server-go/netpulse
 server-go/netpulse-server

--- a/deploy/openwrt/netpulse-agent/files/netpulse-agent.defaults
+++ b/deploy/openwrt/netpulse-agent/files/netpulse-agent.defaults
@@ -77,4 +77,24 @@ fi
 /etc/init.d/netpulse-agent enable
 /etc/init.d/netpulse-agent restart
 
+# Config vacía (#462): el servicio NO arrancará hasta definir server, token
+# y slug. Banner claro en consola y syslog en vez de un fallo silencioso.
+SERVER_CFG=$(uci -q get netpulse-agent.main.server)
+TOKEN_CFG=$(uci -q get netpulse-agent.main.token)
+SLUG_CFG=$(uci -q get netpulse-agent.main.slug)
+if [ -z "$SERVER_CFG" ] || [ -z "$TOKEN_CFG" ] || [ -z "$SLUG_CFG" ]; then
+	logger -t netpulse-agent "config vacía: define server, token y slug; el servicio no arrancará hasta completarla"
+	echo ""
+	echo "netpulse-agent: PENDIENTE DE CONFIGURAR: el servicio no arrancará hasta completarla."
+	echo "  1. Crea el agente en el servidor NetPulse (Ajustes → Agents) y copia su token (se muestra una sola vez)."
+	echo "  2. En este router:"
+	echo "       uci set netpulse-agent.main.server='http://<netpulse-server-ip>:3000'"
+	echo "       uci set netpulse-agent.main.slug='<slug>'"
+	echo "       uci set netpulse-agent.main.token='<token-64-hex>'"
+	echo "       uci commit netpulse-agent"
+	echo "       /etc/init.d/netpulse-agent enable && /etc/init.d/netpulse-agent restart"
+	echo "  (Si el servidor ya puede entrar por SSH a este router, usa el botón Reinstalar de la web y se configura solo.)"
+	echo ""
+fi
+
 exit 0


### PR DESCRIPTION
Closes #462

When the package installs with an empty config (the common case: it cannot know the server URL or the agent token), the service refuses to start by design and the user is left with a silent inactive service. This adds a banner to the uci-defaults post-install output (and syslog) with the exact steps: create the agent in the web UI, then the uci set commands, plus a pointer to the Reinstall button when the server already has SSH access.

Also anchors the `netpulse-agent` .gitignore rule to the repo root: the unanchored pattern silently ignored the whole `deploy/openwrt/netpulse-agent/` package directory (new files there would never be tracked).

Together with the README post-install docs from #464 this closes the reported dead end. The LuCI status-page guidance stays as an optional follow-up.