### PR TITLE
fix: forum feedback batch - password change, clipboard, install group, real luci apk, release assets

### DIFF
--- a/.github/workflows/openwrt-package.yml
+++ b/.github/workflows/openwrt-package.yml
@@ -197,7 +197,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "push" ]; then
             echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=${{ github.release.tag_name }}" >> "$GITHUB_OUTPUT"
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Wait for server tarball on the release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,12 @@ jobs:
           npm run build --prefix app
           rm -rf server-go/internal/staticspa/dist && cp -r app/dist server-go/internal/staticspa/dist
 
-      - name: Tests Go (ambos módulos)
-        run: |
-          (cd server-go && go test ./...)
-          (cd collector && go test ./...)
-
+      # Antes de los tests: TestOpenArmVariants abre los binarios embebidos
+      # (mismo orden que go.yml desde #459; aquí faltó aplicarlo y las
+      # releases v2.25.0+ se quedaron sin assets). OJO los nombres: Open()
+      # resuelve "agents/netpulse-agent-" + normalizeArch(arch) y esta mapea
+      # armv7/armv7l/armhf -> arm, asi que el fichero se llama
+      # netpulse-agent-arm (con GOARM=7), NO netpulse-agent-armv7 (#458).
       - name: Build agent binaries para embed (todas las arquitecturas)
         env:
           CGO_ENABLED: 0
@@ -68,8 +69,13 @@ jobs:
           (cd agent && GOARCH=amd64 go build -trimpath -ldflags "-s -w -X main.Version=${{ steps.version.outputs.agent }}" -o ../server-go/internal/agentbin/agents/netpulse-agent-amd64 ./cmd/netpulse-agent)
           # arm64
           (cd agent && GOARCH=arm64 go build -trimpath -ldflags "-s -w -X main.Version=${{ steps.version.outputs.agent }}" -o ../server-go/internal/agentbin/agents/netpulse-agent-arm64 ./cmd/netpulse-agent)
-          # armv7
-          (cd agent && GOARCH=arm GOARM=7 go build -trimpath -ldflags "-s -w -X main.Version=${{ steps.version.outputs.agent }}" -o ../server-go/internal/agentbin/agents/netpulse-agent-armv7 ./cmd/netpulse-agent)
+          # armv7 (fichero "arm": el nombre que busca normalizeArch)
+          (cd agent && GOARCH=arm GOARM=7 go build -trimpath -ldflags "-s -w -X main.Version=${{ steps.version.outputs.agent }}" -o ../server-go/internal/agentbin/agents/netpulse-agent-arm ./cmd/netpulse-agent)
+
+      - name: Tests Go (ambos módulos)
+        run: |
+          (cd server-go && go test ./...)
+          (cd collector && go test ./...)
 
       - name: Valida config goreleaser
         uses: goreleaser/goreleaser-action@v6

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ the router (LuCI System > Software, or over SSH):
 opkg install ./netpulse-agent_*.ipk ./luci-app-netpulse_*.ipk
 
 # OpenWrt 25.12 (apk)
-apk add --allow-untrusted ./netpulse-agent_*.apk ./luci-app-netpulse_*.apk
+apk add --allow-untrusted ./netpulse-agent-*.apk ./luci-app-netpulse-*.apk
 ```
 
 `luci-app-netpulse` depends on `netpulse-agent` and `luci-base`; installing

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1194,6 +1194,7 @@
       "nameSaved": "Name saved",
       "pwCurrent": "Current password",
       "pwNew": "New password",
+      "pwMinLength": "At least 10 characters",
       "pwConfirm": "Repeat password",
       "pwMismatch": "Passwords do not match",
       "pwSubmit": "Change password",

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -204,6 +204,7 @@
       "tv": "TV & consoles"
     },
     "ipCopied": "IP copied",
+    "ipCopyFailed": "Could not copy the IP",
     "listView": "List view",
     "nameUpdated": "Name updated",
     "colLease": "Lease time",
@@ -1099,6 +1100,7 @@
       "sshKeyCaption": "Authorize it on each router (System → Administration → SSH keys, or /etc/dropbear/authorized_keys). NetPulse is read-only: status, clients and traffic.",
       "copy": "Copy",
       "copied": "Copied",
+      "copyFailed": "Copy failed; select the key manually",
       "agentOnly": "Agent only (no SSH)",
       "agentOnlyBadge": "Agent only",
       "edit": "Edit",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1194,6 +1194,7 @@
       "nameSaved": "Nombre guardado",
       "pwCurrent": "Contraseña actual",
       "pwNew": "Nueva contraseña",
+      "pwMinLength": "Al menos 10 caracteres",
       "pwConfirm": "Repite la contraseña",
       "pwMismatch": "Las contraseñas no coinciden",
       "pwSubmit": "Cambiar contraseña",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -204,6 +204,7 @@
       "tv": "TV y consolas"
     },
     "ipCopied": "IP copiada",
+    "ipCopyFailed": "No se pudo copiar la IP",
     "listView": "Vista de lista",
     "nameUpdated": "Nombre actualizado",
     "colLease": "Tiempo restante",
@@ -1099,6 +1100,7 @@
       "sshKeyCaption": "Autorízala en cada router (Sistema → Administración → claves SSH, o /etc/dropbear/authorized_keys). NetPulse solo lee: estado, clientes y tráfico.",
       "copy": "Copiar",
       "copied": "Copiada",
+      "copyFailed": "No se pudo copiar; selecciona la clave a mano",
       "agentOnly": "Solo agente (sin SSH)",
       "agentOnlyBadge": "Solo agente",
       "edit": "Editar",

--- a/app/src/components/TokensManager.tsx
+++ b/app/src/components/TokensManager.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Copy, KeyRound, Plus, Trash2 } from 'lucide-react'
+import { copyToClipboard } from '@/lib/utils'
 
 type TokenItem = {
   id: string
@@ -85,12 +86,10 @@ export function TokensManager() {
   )
 
   const copyToken = useCallback(async (raw: string) => {
-    try {
-      await navigator.clipboard.writeText(raw)
-      setCopied(true)
+    const ok = await copyToClipboard(raw)
+    setCopied(ok)
+    if (ok) {
       setTimeout(() => setCopied(false), 2000)
-    } catch {
-      /* ignore */
     }
   }, [])
 

--- a/app/src/components/routers/AgentsSection.tsx
+++ b/app/src/components/routers/AgentsSection.tsx
@@ -9,7 +9,7 @@ import type { AgentInfo, Router } from '@/data/types'
 import { relTimeFromTs } from '@/i18n'
 import { AgentRearmButton } from '@/components/routers/AgentRearmButton'
 import { AgentUpgradeButton, activeUpgrade, upgradeStepText } from '@/components/routers/AgentUpgradeButton'
-import { cn } from '@/lib/utils'
+import { cn, copyToClipboard } from '@/lib/utils'
 
 /**
  * Sección de agentes nativos (issue #245, reubicada en /routers por #284):
@@ -29,30 +29,9 @@ function isOpenWrtType(t: string | undefined): boolean {
   return t === undefined || t === '' || t === 'glinet' || t === 'openwrt'
 }
 
-async function copyText(text: string): Promise<boolean> {
-  try {
-    if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(text)
-      return true
-    }
-  } catch {
-    /* fallback abajo */
-  }
-  try {
-    const ta = document.createElement('textarea')
-    ta.value = text
-    ta.setAttribute('readonly', '')
-    ta.style.position = 'fixed'
-    ta.style.opacity = '0'
-    document.body.appendChild(ta)
-    ta.select()
-    const ok = document.execCommand('copy')
-    document.body.removeChild(ta)
-    return ok
-  } catch {
-    return false
-  }
-}
+// copyText: alias del helper compartido con fallback para orígenes no
+// seguros (#466); antes vivía inline aquí y en RouterInfo duplicado.
+const copyText = copyToClipboard
 
 type ReinstallState = 'idle' | 'busy' | 'done' | 'fail'
 type CopyState = 'idle' | 'busy' | 'done' | 'fail'

--- a/app/src/components/routers/RouterInfo.tsx
+++ b/app/src/components/routers/RouterInfo.tsx
@@ -10,6 +10,7 @@ import { getRouterExtras } from '@/components/routers/routerExtras'
 import type { RouterExtras } from '@/components/routers/routerExtras'
 import { EMPTY_EXTRAS, useNetPulse } from '@/data/DataProvider'
 import { useAgentFor } from '@/hooks/useAgentFor'
+import { copyToClipboard } from '@/lib/utils'
 
 function Row({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -37,34 +38,8 @@ export function RouterInfo({ router, extras }: { router: Router; extras?: Router
   }, [])
 
   async function copySsh() {
-    const text = `ssh root@${router.ip}`
-    let ok = false
-    try {
-      // Clipboard API solo funciona en contexto seguro (HTTPS/localhost);
-      // en la LAN HTTP lanza → fallback abajo.
-      if (navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(text)
-        ok = true
-      }
-    } catch {
-      ok = false
-    }
-    if (!ok) {
-      // Fallback para HTTP: textarea oculta + execCommand('copy').
-      try {
-        const ta = document.createElement('textarea')
-        ta.value = text
-        ta.setAttribute('readonly', '')
-        ta.style.position = 'fixed'
-        ta.style.opacity = '0'
-        document.body.appendChild(ta)
-        ta.select()
-        ok = document.execCommand('copy')
-        document.body.removeChild(ta)
-      } catch {
-        ok = false
-      }
-    }
+    // Clipboard con fallback HTTP (#466); el helper vive en lib/utils.
+    const ok = await copyToClipboard(`ssh root@${router.ip}`)
     setToast(ok)
     if (timer.current) window.clearTimeout(timer.current)
     timer.current = window.setTimeout(() => setToast(false), 1800)

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -29,6 +29,9 @@ export async function copyToClipboard(text: string): Promise<boolean> {
     ta.style.position = 'fixed'
     ta.style.opacity = '0'
     document.body.appendChild(ta)
+    // focus() antes de select(): con el foco aún en el botón, Chromium
+    // devuelve false en execCommand aunque la selección exista.
+    ta.focus()
     ta.select()
     ta.setSelectionRange(0, text.length)
     const ok = document.execCommand('copy')

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -6,6 +6,40 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
+ * Copiar al portapapeles con fallback para orígenes no seguros (#466).
+ * La API async clipboard (navigator.clipboard) solo existe en contexto
+ * seguro (HTTPS/localhost); NetPulse se suele servir por http://<ip>:3000
+ * en la LAN, así que se cae a textarea + execCommand, que sigue
+ * funcionando dentro de un gesto de usuario. Devuelve false si ambas
+ * vías fallan.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+  } catch {
+    /* sin permiso o contexto no seguro: probar el fallback */
+  }
+  try {
+    const ta = document.createElement('textarea')
+    ta.value = text
+    ta.setAttribute('readonly', '')
+    ta.style.position = 'fixed'
+    ta.style.opacity = '0'
+    document.body.appendChild(ta)
+    ta.select()
+    ta.setSelectionRange(0, text.length)
+    const ok = document.execCommand('copy')
+    document.body.removeChild(ta)
+    return ok
+  } catch {
+    return false
+  }
+}
+
+/**
  * Salir del modo demo (frontend estático sin backend): aquí no hay sesión ni
  * login al que volver. Se intenta cerrar la ventana (la demo se abre en una
  * pestaña propia desde la landing); si el navegador bloquea window.close()

--- a/app/src/pages/Devices.tsx
+++ b/app/src/pages/Devices.tsx
@@ -41,7 +41,7 @@ import { fmtEs, signalLevel } from '@/data/mock'
 import { useNetPulse } from '@/data/DataProvider'
 import { useDashboard } from '@/hooks/useDashboard'
 import { DeviceEditSheet } from '@/components/DeviceEditSheet'
-import { cn, fetchJson } from '@/lib/utils'
+import { cn, copyToClipboard, fetchJson } from '@/lib/utils'
 import type { ClientDevice, FilterGroup } from '@/pages/devices-data'
 import { buildClientDevices, GROUP_ORDER } from '@/pages/devices-data'
 import type { DeviceType } from '@/data/mock'
@@ -1176,8 +1176,9 @@ export default function Devices() {
 
   const copyIp = useCallback(
     (ip: string) => {
-      void navigator.clipboard?.writeText(ip).catch(() => undefined)
-      showToast(t('devices.ipCopied'))
+      void copyToClipboard(ip).then((ok) => {
+        showToast(t(ok ? 'devices.ipCopied' : 'devices.ipCopyFailed'))
+      })
     },
     [showToast, t],
   )

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -2972,7 +2972,7 @@ export default function Settings() {
   const [pwChanged, setPwChanged] = useState(false)
 
   const submitOwnPassword = useCallback(async () => {
-    if (pwBusy || !pwCurrent || pwNew.length < 6 || pwNew !== pwConfirm) return
+    if (pwBusy || !pwCurrent || pwNew.length < 10 || pwNew !== pwConfirm) return
     setPwBusy(true)
     setPwError(null)
     setPwChanged(false)
@@ -3922,6 +3922,7 @@ export default function Settings() {
                   aria-label={t('settings.session.pwNew')}
                   className="h-10 rounded-lg border border-border bg-elevated px-3 text-sm text-text-primary"
                 />
+                <p className="-mt-1 text-caption text-text-muted">{t('settings.session.pwMinLength')}</p>
                 <input
                   type="password"
                   autoComplete="new-password"
@@ -3943,7 +3944,7 @@ export default function Settings() {
                 )}
                 <button
                   type="submit"
-                  disabled={pwBusy || !pwCurrent || pwNew.length < 6 || pwNew !== pwConfirm}
+                  disabled={pwBusy || !pwCurrent || pwNew.length < 10 || pwNew !== pwConfirm}
                   className="flex h-10 items-center justify-center rounded-lg bg-accent px-4 text-sm font-semibold text-canvas transition-opacity hover:opacity-90 disabled:opacity-50"
                 >
                   {pwBusy ? t('settings.session.pwSubmitting') : t('settings.session.pwSubmit')}

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -59,7 +59,7 @@ import { getVapidKey, postPushSubscribe, postPushUnsubscribe, pushContext, urlBa
 import { useServicesVisibility } from '@/hooks/useServicesVisibility'
 import type { ServicesVisibility } from '@/hooks/useServicesVisibility'
 import { relTimeFromTs } from '@/i18n'
-import { cn, exitDemo } from '@/lib/utils'
+import { cn, copyToClipboard, exitDemo } from '@/lib/utils'
 import { notifyBanner } from '@/lib/update-check'
 import { ACCENTS, PALETTES, type AccentId, type PaletteId, type ThemeMode } from '@/lib/theme-boot'
 import TelegramCard from '@/components/TelegramCard'
@@ -317,6 +317,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
   const [editSubmitting, setEditSubmitting] = useState(false)
   const [pubkey, setPubkey] = useState<{ publicKey: string; fingerprint: string } | null>(null)
   const [copied, setCopied] = useState(false)
+  const [copyFailed, setCopyFailed] = useState(false)
   const [rotating, setRotating] = useState(false)
   const [rotateConfirmOpen, setRotateConfirmOpen] = useState(false)
   const [rotateError, setRotateError] = useState<string | null>(null)
@@ -387,13 +388,15 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
 
   const copyKey = async () => {
     if (!pubkey) return
-    try {
-      await navigator.clipboard.writeText(pubkey.publicKey)
-      setCopied(true)
-      window.setTimeout(() => setCopied(false), 1500)
-    } catch {
-      /* portapapeles no disponible */
-    }
+    // Helper con fallback para orígenes no seguros (http://<ip> de la LAN):
+    // navigator.clipboard no existe ahí y el botón no copiaba nada (#466).
+    const ok = await copyToClipboard(pubkey.publicKey)
+    setCopyFailed(!ok)
+    setCopied(ok)
+    window.setTimeout(() => {
+      setCopied(false)
+      setCopyFailed(false)
+    }, 1500)
   }
 
   const rotateKey = async () => {
@@ -935,7 +938,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
               className="flex shrink-0 items-center gap-1.5 rounded-lg border border-border bg-elevated px-3 py-2 text-xs font-medium text-text-secondary transition-colors duration-150 hover:border-accent/40 hover:text-accent"
             >
               {copied ? <Check className="h-3.5 w-3.5 text-ok" strokeWidth={2} /> : <Copy className="h-3.5 w-3.5" strokeWidth={1.75} />}
-              {copied ? t('settings.routers.copied') : t('settings.routers.copy')}
+              {copied ? t('settings.routers.copied') : copyFailed ? t('settings.routers.copyFailed') : t('settings.routers.copy')}
             </button>
             <button
               type="button"
@@ -2430,9 +2433,12 @@ function AdoptionCard() {
   }
 
   const copy = (val: string, label: string) => {
-    navigator.clipboard?.writeText(val)
-    setCopied(label)
-    setTimeout(() => setCopied(null), 2000)
+    void copyToClipboard(val).then((ok) => {
+      if (ok) {
+        setCopied(label)
+        setTimeout(() => setCopied(null), 2000)
+      }
+    })
   }
 
   if (!data?.token) return null
@@ -2675,12 +2681,10 @@ function ExternalDevicesManager({ onSaved }: { onSaved: () => void }) {
   }
 
   const copy = async (text: string, label: string) => {
-    try {
-      await navigator.clipboard.writeText(text)
+    const ok = await copyToClipboard(text)
+    if (ok) {
       setCopied(label)
       window.setTimeout(() => setCopied(null), 1500)
-    } catch {
-      /* clipboard unavailable */
     }
   }
 

--- a/deploy/openwrt/package-luci.sh
+++ b/deploy/openwrt/package-luci.sh
@@ -101,52 +101,75 @@ POSTRM
   echo "  IPK: $(ls "$OUT_DIR"/luci-app-netpulse_*.ipk)"
 
 elif [ "$FORMAT" = "apk" ]; then
-  echo "  Building .apk (arch all via ipkg-build)..."
-  # El .apk real del luci arrastra luci-base/lucihttp desde el feed, que no
-  # compilan en CI headless (descarga de source falla) y no aporta nada sobre
-  # el .ipk arch-all: el contenido es el mismo (solo ficheros, sin binario).
-  # Se genera el paquete con ipkg-build y se renombra a .apk para que el job
-  # CI lo suba con la extensión que espera.
-  PKG_DIR="$WORK_DIR/luci-app-netpulse-pkg"
-  mkdir -p "$PKG_DIR/CONTROL"
-  cp -r "$APP_DIR/files/." "$PKG_DIR/"
-  chmod 755 "$PKG_DIR/usr/libexec/rpcd/luci.netpulse"
+  echo "  Building .apk (real apk v3 via 25.12 SDK)..."
+  # #468: renaming an ipk to .apk does NOT work: apk-tools v3 on the router
+  # refuses the ipk bytes with "v2 package format error". Build a real v3
+  # package with the SDK, same source-less Makefile pattern package.sh uses
+  # for netpulse-agent: files staged under files/, no-op Build/Compile, and
+  # the SDK's own `apk mkpkg` produces the signed-v3 tarball. Dependencies
+  # are recorded as metadata; the SDK does not need them present.
+  PKG_DIR_SDK="$SDK_DIR/package/utils/luci-app-netpulse"
+  mkdir -p "$PKG_DIR_SDK/files"
+  cp -r "$APP_DIR/files/." "$PKG_DIR_SDK/files/"
+  chmod 755 "$PKG_DIR_SDK/files/usr/libexec/rpcd/luci.netpulse"
+  cat > "$PKG_DIR_SDK/Makefile" << 'MAKE'
+include $(TOPDIR)/rules.mk
 
-  cat > "$PKG_DIR/CONTROL/control" << CTRL
-Package: luci-app-netpulse
-Version: ${PKG_VERSION:-0.0.0}-${PKG_RELEASE:-1}
-Depends: luci-base, netpulse-agent
-License: AGPL-3.0-only
-Section: luci
-Architecture: all
-Maintainer: Nacho <netpulse@cloudless.club>
-Description: Node-local NetPulse agent view for LuCI
- LuCI pages for the NetPulse agent on THIS router: procd status, binary
- version, RSS, heartbeat, recent syslog lines, restart button and
- editable UCI configuration, plus a link to the NetPulse web app.
-CTRL
+PKG_NAME:=luci-app-netpulse
+PKG_VERSION:=@PKG_VERSION@
+PKG_RELEASE:=@PKG_RELEASE@
 
-  cat > "$PKG_DIR/CONTROL/postinst" << 'POSTINST'
+PKG_LICENSE:=AGPL-3.0-only
+PKG_MAINTAINER:=Nacho <netpulse@cloudless.club>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/luci-app-netpulse
+	SECTION:=luci
+	CATEGORY:=LuCI
+	TITLE:=Node-local NetPulse agent view for LuCI
+	URL:=https://github.com/gnacho/netpulse
+	DEPENDS:=+luci-base +netpulse-agent
+	PKGARCH:=all
+endef
+
+define Package/luci-app-netpulse/description
+	LuCI pages for the NetPulse agent on this router: procd status,
+	binary version, RSS, heartbeat, recent syslog lines, restart button
+	and editable UCI configuration, plus a link to the NetPulse web app.
+endef
+
+define Build/Compile
+endef
+
+define Package/luci-app-netpulse/install
+	$(INSTALL_DIR) $(1)/usr/share/luci/menu.d
+	$(INSTALL_DATA) ./files/usr/share/luci/menu.d/luci-app-netpulse.json $(1)/usr/share/luci/menu.d/
+	$(INSTALL_DIR) $(1)/usr/share/rpcd/acl.d
+	$(INSTALL_DATA) ./files/usr/share/rpcd/acl.d/luci-app-netpulse.json $(1)/usr/share/rpcd/acl.d/
+	$(INSTALL_DIR) $(1)/usr/libexec/rpcd
+	$(INSTALL_BIN) ./files/usr/libexec/rpcd/luci.netpulse $(1)/usr/libexec/rpcd/
+	$(INSTALL_DIR) $(1)/www/luci-static/resources/view/netpulse
+	$(INSTALL_DATA) ./files/www/luci-static/resources/view/netpulse/*.js $(1)/www/luci-static/resources/view/netpulse/
+endef
+
+define Package/luci-app-netpulse/postinst
 #!/bin/sh
-[ -n "$IPKG_INSTROOT" ] && exit 0
+[ -n "$${IPKG_INSTROOT}" ] && exit 0
 /etc/init.d/rpcd restart 2>/dev/null || true
 rm -f /tmp/luci-indexcache* 2>/dev/null || true
 exit 0
-POSTINST
-  chmod 755 "$PKG_DIR/CONTROL/postinst"
+endef
 
-  cat > "$PKG_DIR/CONTROL/postrm" << 'POSTRM'
-#!/bin/sh
-[ -n "$IPKG_INSTROOT" ] && exit 0
-/etc/init.d/rpcd restart 2>/dev/null || true
-rm -f /tmp/luci-indexcache* 2>/dev/null || true
-exit 0
-POSTRM
-  chmod 755 "$PKG_DIR/CONTROL/postrm"
+$(eval $(call BuildPackage,luci-app-netpulse))
+MAKE
+  sed -i "s/@PKG_VERSION@/${PKG_VERSION:-0.0.0}/; s/@PKG_RELEASE@/${PKG_RELEASE:-1}/" "$PKG_DIR_SDK/Makefile"
 
-  "$SDK_DIR/scripts/ipkg-build" "$PKG_DIR" "$OUT_DIR"
-  # Renombra el .ipk arch-all a .apk para el upload del job CI.
-  cp "$OUT_DIR"/luci-app-netpulse_*.ipk "$OUT_DIR/luci-app-netpulse_${PKG_VERSION:-0.0.0}-${PKG_RELEASE:-1}_all.apk"
+  cd "$SDK_DIR"
+  # .config válido sin terminal (menuconfig muere en CI headless).
+  make defconfig >/dev/null 2>&1 || true
+  make package/luci-app-netpulse/compile V=s 2>&1 | tail -20
+  find bin/packages -name "luci-app-netpulse*.apk" -exec cp {} "$OUT_DIR/" \;
   echo "  APK: $(ls "$OUT_DIR"/luci-app-netpulse*.apk 2>/dev/null || echo 'NOT FOUND')"
 
 else

--- a/install-collector.sh
+++ b/install-collector.sh
@@ -97,6 +97,11 @@ if [ "$UNINSTALL" -eq 1 ]; then
         run $SUDO userdel "$APP_NAME" 2>/dev/null || warn "could not delete user $APP_NAME"
         ok "system user removed"
     fi
+    # Same as install.sh: a leftover login group breaks the next install (#467).
+    if getent group "$APP_NAME" >/dev/null 2>&1; then
+        run $SUDO groupdel "$APP_NAME" 2>/dev/null || warn "could not delete group $APP_NAME (still in use?)"
+        ok "system group removed"
+    fi
     if [ "$PURGE" -eq 1 ]; then
         run $SUDO rm -rf "$STATE_DIR"
         ok "data removed (--purge)"
@@ -247,7 +252,12 @@ run $SUDO install -T -m 0755 "$TMP/$BIN_NAME" "$INSTALL_DIR/$BIN_NAME"
 ok "binary installed at $INSTALL_DIR/$BIN_NAME"
 
 if ! id "$APP_NAME" >/dev/null 2>&1; then
-    run $SUDO useradd --system --home-dir "$STATE_DIR" --shell /usr/sbin/nologin "$APP_NAME"
+    # Reuse a leftover login group from a previous uninstall (#467).
+    if getent group "$APP_NAME" >/dev/null 2>&1; then
+        run $SUDO useradd --system -g "$APP_NAME" --home-dir "$STATE_DIR" --shell /usr/sbin/nologin "$APP_NAME"
+    else
+        run $SUDO useradd --system --home-dir "$STATE_DIR" --shell /usr/sbin/nologin "$APP_NAME"
+    fi
     ok "system user $APP_NAME created"
 fi
 run $SUDO install -d -m 0750 -o "$APP_NAME" -g "$APP_NAME" "$STATE_DIR"

--- a/install.sh
+++ b/install.sh
@@ -127,6 +127,13 @@ if [ "$UNINSTALL" -eq 1 ]; then
         run $SUDO userdel "$APP_NAME" 2>/dev/null || warn "could not delete user $APP_NAME"
         ok "system user removed"
     fi
+    # userdel leaves the login group behind whenever it has other members
+    # (the collector user joins it) or the distro keeps it; the leftover
+    # group breaks the next install (#467).
+    if getent group "$APP_NAME" >/dev/null 2>&1; then
+        run $SUDO groupdel "$APP_NAME" 2>/dev/null || warn "could not delete group $APP_NAME (still in use?)"
+        ok "system group removed"
+    fi
     if [ "$PURGE" -eq 1 ]; then
         run $SUDO rm -rf "$STATE_DIR"
         ok "data and configuration removed (--purge)"
@@ -293,7 +300,14 @@ run $SUDO install -T -m 0755 "$TMP/$BIN_NAME" "$INSTALL_DIR/$BIN_NAME"
 ok "binary installed at $INSTALL_DIR/$BIN_NAME"
 
 if ! id "$APP_NAME" >/dev/null 2>&1; then
-    run $SUDO useradd --system --home-dir "$STATE_DIR" --shell /usr/sbin/nologin "$APP_NAME"
+    # Reinstall on a box where the group survived a previous uninstall
+    # (#467): reuse the existing group instead of dying with
+    # "useradd: group netpulse exists".
+    if getent group "$APP_NAME" >/dev/null 2>&1; then
+        run $SUDO useradd --system -g "$APP_NAME" --home-dir "$STATE_DIR" --shell /usr/sbin/nologin "$APP_NAME"
+    else
+        run $SUDO useradd --system --home-dir "$STATE_DIR" --shell /usr/sbin/nologin "$APP_NAME"
+    fi
     ok "system user $APP_NAME created"
 fi
 run $SUDO install -d -m 0750 -o "$APP_NAME" -g "$APP_NAME" "$STATE_DIR"

--- a/server-go/internal/httpapi/httpapi_test.go
+++ b/server-go/internal/httpapi/httpapi_test.go
@@ -259,6 +259,82 @@ func TestLogoutRevocaSesion(t *testing.T) {
 	}
 }
 
+func TestMyPasswordChange(t *testing.T) {
+	srv := makeTestServer(t)
+	_, adminCookie, _ := loginCookie(t, srv.URL, "admin", "test123456")
+
+	// Alta de ana (rol user)
+	req, _ := http.NewRequest("POST", srv.URL+"/api/users",
+		strings.NewReader(`{"username":"ana","password":"secreto12345","role":"user"}`))
+	req.Header.Set("Cookie", "session="+adminCookie)
+	res, _ := http.DefaultClient.Do(req)
+	res.Body.Close()
+	if res.StatusCode != 201 {
+		t.Fatalf("create ana: got %d want 201", res.StatusCode)
+	}
+
+	// Dos sesiones de ana: la que pide el cambio y otra que debe morir.
+	_, c1, _ := loginCookie(t, srv.URL, "ana", "secreto12345")
+	_, c2, _ := loginCookie(t, srv.URL, "ana", "secreto12345")
+
+	put := func(cookie, jsonBody string) *http.Response {
+		t.Helper()
+		r, _ := http.NewRequest("PUT", srv.URL+"/api/auth/password", strings.NewReader(jsonBody))
+		r.Header.Set("Cookie", "session="+cookie)
+		rq, err := http.DefaultClient.Do(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return rq
+	}
+
+	// Current incorrecto → 401 y la sesión no se toca
+	res = put(c1, `{"current":"no-es-la-clave","password":"nueva-clave-99"}`)
+	res.Body.Close()
+	if res.StatusCode != 401 {
+		t.Fatalf("current malo: got %d want 401", res.StatusCode)
+	}
+	res = get(t, srv.URL, "/api/auth/me", c1)
+	res.Body.Close()
+	if res.StatusCode != 200 {
+		t.Fatalf("sesión tras 401: got %d want 200", res.StatusCode)
+	}
+
+	// Password corto → 400
+	res = put(c1, `{"current":"secreto12345","password":"corta"}`)
+	res.Body.Close()
+	if res.StatusCode != 400 {
+		t.Fatalf("password corto: got %d want 400", res.StatusCode)
+	}
+
+	// Cambio correcto → 204
+	res = put(c1, `{"current":"secreto12345","password":"nueva-clave-99"}`)
+	res.Body.Close()
+	if res.StatusCode != 204 {
+		t.Fatalf("cambio: got %d want 204", res.StatusCode)
+	}
+
+	// La sesión que pidió el cambio sigue viva; la otra muere.
+	res = get(t, srv.URL, "/api/auth/me", c1)
+	res.Body.Close()
+	if res.StatusCode != 200 {
+		t.Fatalf("sesión actual: got %d want 200", res.StatusCode)
+	}
+	res = get(t, srv.URL, "/api/auth/me", c2)
+	res.Body.Close()
+	if res.StatusCode != 401 {
+		t.Fatalf("sesión hermana: got %d want 401", res.StatusCode)
+	}
+
+	// Login con la clave nueva OK; con la vieja, 401.
+	if st, _, _ := loginCookie(t, srv.URL, "ana", "nueva-clave-99"); st != 204 {
+		t.Fatalf("login clave nueva: got %d want 204", st)
+	}
+	if st, _, _ := loginCookie(t, srv.URL, "ana", "secreto12345"); st != 401 {
+		t.Fatalf("login clave vieja: got %d want 401", st)
+	}
+}
+
 func TestMutationsCrossOriginRejected(t *testing.T) {
 	// Issue #213: una mutación con Origin cruzado → 403 cross_origin antes
 	// incluso de la autenticación; el login legítimo con Origin propio pasa.

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -249,6 +249,9 @@ func NewHandler(d Deps) http.Handler {
 	mux.HandleFunc("POST /api/auth/login", s.handleLogin)
 	mux.HandleFunc("POST /api/auth/logout", s.handleLogout)
 	mux.HandleFunc("GET /api/auth/me", s.handleMe(mode))
+	// Cambio de la PROPIA contraseña (Settings > Mi sesión, #465): va tras el
+	// RequireAuth global, sin gate admin; cualquier rol puede cambiar la suya.
+	mux.HandleFunc("PUT /api/auth/password", s.handleMyPassword)
 
 	// --- Datos (sesión; con no-store) ---
 	mux.HandleFunc("GET /api/overview", s.handleOverview)

--- a/server-go/internal/httpapi/users.go
+++ b/server-go/internal/httpapi/users.go
@@ -1,5 +1,6 @@
 // users.go — CRUD de usuarios (paridad routes/users.js).
 //
+//	PUT  /api/auth/password      (autenticado — cambia la PROPIA contraseña)
 //	PUT  /api/users/me/language   (cualquier rol — fuera del gate admin)
 //	PUT  /api/users/me/display-name (cualquier rol — fuera del gate admin)
 //	GET  /api/users               (admin)
@@ -220,6 +221,48 @@ func (s *server) handleCreateUser(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, map[string]any{
 		"user": map[string]any{"id": id, "username": username, "role": role, "language": language},
 	})
+}
+
+// handleMyPassword (#465): PUT /api/auth/password {current, password} → 204.
+// Verifica la contraseña actual contra el hash almacenado, aplica la misma
+// política que el alta (10..128) e invalida las demás sesiones del usuario;
+// la sesión que pide el cambio sigue viva (no se desloguea a sí mismo).
+func (s *server) handleMyPassword(w http.ResponseWriter, r *http.Request) {
+	me := auth.UserFromContext(r.Context())
+	var body struct {
+		Current  *string `json:"current"`
+		Password *string `json:"password"`
+	}
+	if st := readJSONBody(w, r, &body); st != 0 {
+		writeBodyError(w, st, "invalid_input", "current y password son obligatorios")
+		return
+	}
+	if body.Current == nil || body.Password == nil {
+		writeError(w, http.StatusBadRequest, "invalid_input", "current y password son obligatorios")
+		return
+	}
+	if len(*body.Password) < 10 || len(*body.Password) > 128 {
+		writeError(w, http.StatusBadRequest, "invalid_input", "password mínimo 10 caracteres")
+		return
+	}
+	var hash string
+	err := s.db.QueryRow("SELECT pass_hash FROM users WHERE id = ?", me.ID).Scan(&hash)
+	if err != nil || !auth.CheckPassword(*body.Current, hash) {
+		writeError(w, http.StatusUnauthorized, "invalid_credentials", "la contraseña actual no es correcta")
+		return
+	}
+	newHash, err := auth.HashPassword(*body.Password)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error")
+		return
+	}
+	_, _ = s.db.Exec("UPDATE users SET pass_hash = ? WHERE id = ?", newHash, me.ID)
+	if current := auth.SessionIDFromRequest(s.db, s.secret, r); current != "" {
+		_, _ = s.db.Exec("DELETE FROM sessions WHERE user_id = ? AND id <> ?", me.ID, current)
+	} else {
+		auth.DestroyUserSessions(s.db, me.ID)
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // handleSetPassword: {password 6..128} → 204 + destroyUserSessions.


### PR DESCRIPTION
Five fixes from the first round of external user feedback.

The own-password change in Settings called an endpoint that did not exist, so it never worked. This adds `PUT /api/auth/password`: it checks the current password, enforces the 10..128 policy, drops the user's other sessions and keeps the one making the request. The form now enforces the same minimum and says so. Verified against the live server: change, wrong current password, short password, old password rejected, sessions split as expected (9/9).

Copy buttons did nothing over plain HTTP because `navigator.clipboard` only exists on secure origins, and the catch swallowed the error. There is now one helper in `lib/utils` that tries the async API and falls back to a hidden textarea with `execCommand('copy')`, focused before selecting (Chromium refuses the copy otherwise). It replaces the two inline copies of that fallback and covers the SSH key, tokens, pairing and IP copy buttons, with visible feedback when both paths fail. Headless check over `http://<lan-ip>:3000`: key copied, copied state shown (5/5).

Uninstall left the `netpulse` group behind (userdel keeps it when it has other members) and the next install died with "useradd: group netpulse exists". Installers now reuse a leftover group with `-g` and uninstall tries `groupdel` afterwards, for the server and the collector.

The luci-app `.apk` asset was an ipk renamed, and apk-tools v3 rejects those bytes ("v2 package format error"). The 25.12 SDK now builds it as a real signed v3 package with the same source-less Makefile pattern the agent package uses; dependencies stay as metadata. Installed-parsed check on a 25.12.5 router passes (it only asks for the declared agent dependency). The README apk glob matches the new asset name.

And releases since v2.25.0 shipped zero assets: release.yml ran the Go tests before building the embedded agent binaries (the ordering bug fixed for go.yml in #459, missed here), so goreleaser never ran and openwrt-package timed out waiting for tarballs. Same reorder as go.yml, the arm binary named as normalizeArch expects, plus the package-server tag context fix (`github.release.tag_name` is always empty). Next tag publishes assets again.

Closes #465
Closes #466
Closes #467
Closes #468
Closes #469