### PR TITLE
fix(updater): treat deferred-restart kill as success via pre-restart marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ server-go/netpulse-server
 collector/netpulse-collector
 bin/
 
+# Marcador pre-reinicio del updater (#444): lo escribe update.sh y lo lee el
+# updater al morir el script por el reinicio esperado
+.update-applied
+
 # Binarios de agente embebidos (construidos por CI)
 server-go/internal/agentbin/agents/netpulse-agent-*
 .worktrees/

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -140,6 +140,11 @@ if [ -f "$SERVER_BIN" ]; then
   rm -rf /opt/netpulse/server-go/pkg.new /tmp/netpulse-go.tgz "$RELEASE_JSON"
 
   echo "STEP:restart"
+  # Marcador de éxito pre-reinicio (#444): el reinicio vía systemd.path mata
+  # este script (hijo del servidor) y sin este fichero el updater registra
+  # "update_exit_-1" aunque el swap haya ido bien. El updater lo interpreta
+  # como el camino de éxito esperado y mantiene el pendingApply (#161).
+  echo "$SHA" > "$REPO_ROOT/.update-applied"
   # Reinicio vía unidad systemd.path del CT (netpulse-go-restart.path vigila
   # este flag y ejecuta systemctl restart netpulse-go.service como root).
   # El dir puede no existir (DATA_DIR real vive en /opt/netpulse/server-go/data):

--- a/server-go/internal/updater/updater.go
+++ b/server-go/internal/updater/updater.go
@@ -503,6 +503,8 @@ func (u *Updater) ApplyBy(initiatedBy string) bool {
 	if err == nil {
 		err = os.WriteFile(tmpScript, src, 0o755)
 	}
+	// Marcador de un apply previo: fuera antes de empezar (#444).
+	_ = os.Remove(u.appliedMarkerPath())
 	if err != nil {
 		u.mu.Lock()
 		u.updatingStep = nil
@@ -558,6 +560,17 @@ func (u *Updater) ApplyBy(initiatedBy string) bool {
 			u.lastLog = &log
 			u.updateAvail = false
 			u.finishHistory(historyID, "success", "", dur)
+		} else if marker := readAppliedMarker(u.appliedMarkerPath()); marker != "" && to != nil && marker == strings.TrimSpace(*to) {
+			// #444: el reinicio diferido (systemd.path) mata el script justo
+			// después del swap. Si el marcador pre-reinicio lleva el SHA
+			// objetivo, esto es el camino de éxito, no un fallo: se registra
+			// success y se MANTIENE el pendingApply para la confirmación
+			// post-reinicio (#161).
+			u.setStepLocked("done")
+			log := u.updatingLog
+			u.lastLog = &log
+			u.updateAvail = false
+			u.finishHistory(historyID, "success", "restarted_by_update", dur)
 		} else {
 			code := "update_exit_-1"
 			if ee, ok := waitErr.(*exec.ExitError); ok {
@@ -711,4 +724,20 @@ func (u *Updater) Stop() {
 		close(u.stopCh)
 	}
 	u.wg.Wait()
+}
+
+// appliedMarkerPath: fichero que update.sh escribe justo antes de tocar el
+// flag de reinicio diferido (#444). Vive en la raíz del repo (gitignored).
+func (u *Updater) appliedMarkerPath() string {
+	return filepath.Join(u.repoRoot, ".update-applied")
+}
+
+// readAppliedMarker devuelve el SHA objetivo escrito por update.sh ("" si no
+// existe o no es legible).
+func readAppliedMarker(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
 }

--- a/server-go/internal/updater/updater_restart_test.go
+++ b/server-go/internal/updater/updater_restart_test.go
@@ -1,0 +1,105 @@
+// updater_restart_test.go — #444: cuando el reinicio diferido mata a
+// update.sh después del swap, el marcador pre-reinicio convierte la muerte
+// por señal en el camino de éxito (historial success + pendingApply vivo).
+package updater
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestApplyKilledAfterMarkerIsSuccess(t *testing.T) {
+	if !gitAvailable() {
+		t.Skip("git no disponible")
+	}
+	root := t.TempDir()
+	writeGitHead(t, root)
+	if err := os.MkdirAll(filepath.Join(root, "deploy"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Simula el final real de update.sh: escribe el marcador con el SHA
+	// objetivo y muere por señal (lo que hace el restart del systemd.path).
+	script := "#!/bin/bash\necho STEP:install\necho abc1234 > '" + root + "/.update-applied'\nkill -9 $$\n"
+	if err := os.WriteFile(filepath.Join(root, "deploy", "update.sh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"sha":"abc1234deadbeef","commit":{"message":"feat: algo"}}`)
+	})
+	dbh := openDB(t)
+	u := New(root, "owner/netpulse", "", "2.0.0", dbh)
+	u.Check(context.Background()) // fija latest = abc1234
+	if !u.Apply() {
+		t.Fatal("apply debería arrancar")
+	}
+	waitDone(t, u)
+
+	st := u.Status()
+	if st.Error != nil {
+		t.Fatalf("no debería haber error (fue el reinicio esperado): %v", *st.Error)
+	}
+	// El marcador en BD debe seguir vivo para la confirmación post-reinicio
+	// (#161); PendingApply en memoria solo se expone tras el arranque.
+	if _, ok := readPendingApply(dbh); !ok {
+		t.Fatal("el marcador pendingApply debe persistirse para el post-reinicio")
+	}
+	hist, err := ListHistory(dbh, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hist) == 0 || hist[0].Status != "success" {
+		t.Fatalf("historial: esperaba success, got %+v", hist)
+	}
+}
+
+func TestApplyKilledWithoutMarkerIsFailure(t *testing.T) {
+	if !gitAvailable() {
+		t.Skip("git no disponible")
+	}
+	root := t.TempDir()
+	writeGitHead(t, root)
+	if err := os.MkdirAll(filepath.Join(root, "deploy"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Muere por señal SIN marcador: fallo real (crash del script).
+	script := "#!/bin/bash\nkill -9 $$\n"
+	if err := os.WriteFile(filepath.Join(root, "deploy", "update.sh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"sha":"abc1234deadbeef","commit":{"message":"feat: algo"}}`)
+	})
+	dbh := openDB(t)
+	u := New(root, "owner/netpulse", "", "2.0.0", dbh)
+	u.Check(context.Background())
+	if !u.Apply() {
+		t.Fatal("apply debería arrancar")
+	}
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		if u.Status().Error != nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timeout esperando el fallo")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if u.Status().PendingApply != nil {
+		t.Fatal("pendingApply debe limpiarse en un fallo real (#161)")
+	}
+	hist, err := ListHistory(dbh, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hist) == 0 || hist[0].Status != "failed" {
+		t.Fatalf("historial: esperaba failed, got %+v", hist)
+	}
+}


### PR DESCRIPTION
Closes #444

## Problem

The deferred restart (systemd.path unit watching `.restart-me`) kills `update.sh`, which is a child of the server process itself. `cmd.Wait()` then sees a signal death and the updater records `update_exit_-1` and clears the pending confirmation, even though the swap succeeded. Every recent apply in the history showed failed, inviting pointless retries.

## Fix

- `deploy/update.sh` writes `.update-applied` (the target SHA) right before touching the restart flag.
- The updater removes any stale marker when an apply starts, and on script death checks it: if it matches the target SHA, this is the expected restart path, so history is recorded as `success` (with a `restarted_by_update` note), the error is not set, and the pending-apply marker is kept so the post-restart confirmation toast (#161) still works.
- A script death without the marker is still a genuine failure (cleared pending, failed row), covered by a second test.

## Tests

Two new tests simulating the real script endings (marker + self-kill, and bare self-kill); full `go test ./...` green.

Note: the script-side healthcheck/rollback after STEP:restart is effectively unreachable today (the restart kills the script); that redesign is out of scope here, the recording is what this fixes.