### PR TITLE
fix: channel plan end to end (store wiring, freq parse, dedup, router id resolution)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,9 @@ legacy/server-node/.env
 .DS_Store
 
 # Binarios compilados
-# (solo el binario local de `go build` en el módulo agent; el patrón `netpulse-agent*`
-# coincidía con el directorio fuente agent/cmd/netpulse-agent/ e ignoraba su código)
-netpulse
+# (ancla los patrones a su ruta: el patrón libre `netpulse` ignoraba el
+# directorio FUENTE server-go/cmd/netpulse/ y bloqueaba `git add` de main.go,
+# igual que `netpulse-agent*` hizo con agent/cmd/netpulse-agent/)
 # anclado a la raíz: el patrón libre `netpulse-agent` también ignoraba el
 # directorio deploy/openwrt/netpulse-agent/ (ficheros del paquete)
 /netpulse-agent

--- a/agent/probe/probe.go
+++ b/agent/probe/probe.go
@@ -1137,8 +1137,12 @@ func ParseScan(out string) []ScanResult {
 			continue
 		}
 		if strings.HasPrefix(line, "freq:") {
-			v, _ := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(line, "freq:")))
-			current.Freq = v
+			// iw imprime la frecuencia como float ("freq: 5260.0"): Atoi
+			// fallaba en silencio, Freq quedaba 0 y el flush descartaba TODOS
+			// los BSS (scans siempre vacíos, #475).
+			if f, err := strconv.ParseFloat(strings.TrimSpace(strings.TrimPrefix(line, "freq:")), 64); err == nil {
+				current.Freq = int(f)
+			}
 			continue
 		}
 		if strings.HasPrefix(line, "signal:") {

--- a/agent/probe/probe_test.go
+++ b/agent/probe/probe_test.go
@@ -873,6 +873,33 @@ BSS 11:22:33:44:55:66(on wlan1)
 	}
 }
 
+// TestParseScanFreqFloat (#475): iw real imprime "freq: 5260.0"; con Atoi el
+// error se tragaba, Freq quedaba 0 y el flush descartaba todos los BSS.
+func TestParseScanFreqFloat(t *testing.T) {
+	out := `==IFACE==wlan1
+BSS 9c:9d:7e:1b:ea:b3(on wlan1)
+	last seen: 945720.058s [boottime]
+	TSF: 419753678847 usec (4d, 20:35:53)
+	freq: 5260.0
+	signal: -61.00 dBm
+	SSID: vecino-dfs
+BSS 8c:de:f9:33:71:59(on wlan1)
+	freq: 5180.0
+	signal: -72.00 dBm
+	SSID: 
+`
+	got := ParseScan(out)
+	if len(got) != 2 {
+		t.Fatalf("esperaba 2 resultados, got %d: %+v", len(got), got)
+	}
+	if got[0].Freq != 5260 || got[0].Channel != 52 || got[0].Signal != -61 {
+		t.Errorf("primer scan incorrecto: %+v", got[0])
+	}
+	if got[1].Freq != 5180 || got[1].Channel != 36 || got[1].SSID != "" {
+		t.Errorf("segundo scan incorrecto: %+v", got[1])
+	}
+}
+
 func TestParseScanVacio(t *testing.T) {
 	if got := ParseScan(""); len(got) != 0 {
 		t.Fatalf("esperaba [] vacío, got %d", len(got))

--- a/app/src/pages/ChannelPlan.tsx
+++ b/app/src/pages/ChannelPlan.tsx
@@ -64,7 +64,7 @@ export default function ChannelPlan() {
         if (!res.ok) throw new Error(await res.text())
         return res.json()
       })
-      .then((d) => setData(d))
+      .then((d) => setData({ ...d, radios: d.radios ?? [], scans: d.scans ?? [] }))
       .catch((e) => setError(String(e)))
       .finally(() => setLoading(false))
   }, [routerId])

--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/gnacho/netpulse/server-go/internal/adapters"
 	"github.com/gnacho/netpulse/server-go/internal/agentbin"
+	"github.com/gnacho/netpulse/server-go/internal/channelplan"
 	"github.com/gnacho/netpulse/server-go/internal/alerts"
 	"github.com/gnacho/netpulse/server-go/internal/apitoken"
 	"github.com/gnacho/netpulse/server-go/internal/auth"
@@ -223,6 +224,14 @@ func run() error {
 		return fmt.Errorf("config backup schema: %w", err)
 	}
 	fwStore := firmware.NewStore(dbHandle.DB)
+
+	// Channel plan (#452/#475): la tabla wifi_scans la crea db.Open; el store
+	// la envuelve. Sin esto la ruta /api/wifi/channel-plan nunca se registra
+	// (not_found en la UI) y la ingesta descarta los scans en silencio.
+	chPlan := channelplan.NewStore(dbHandle.DB)
+	// Los scans llegan con cada push de cada agente y las consultas miran
+	// 24h: sin purga la tabla crecería sin límite. Retención 48h, barrido 6h.
+	go pruneWifiScans(chPlan)
 
 	// Clave SSH propia para sondear routers (se genera la primera vez)
 	if err := sshkey.EnsureKeypair(cfg.SSHKeyPath); err != nil {
@@ -447,6 +456,7 @@ func run() error {
 		PathAnalysis:    pathStore,
 		ConfigBackup:    cfgBackup,
 		Firmware:        fwStore,
+		ChannelPlan:     chPlan,
 		LastOverview: func() *adapters.Overview {
 			return p.LastOverview()
 		},
@@ -601,4 +611,20 @@ func (a *mainKVAdapter) Set(key, value string) error {
 		`INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
 		key, value)
 	return err
+}
+
+// pruneWifiScans purga los scans de vecinos más allá de la retención (#475).
+// Corre en su propia goroutine: un barrido al arrancar y luego cada 6h.
+func pruneWifiScans(store *channelplan.Store) {
+	const retention = 48 * time.Hour
+	if err := store.Prune(retention); err != nil {
+		log.Printf("[netpulse] aviso: purge inicial de wifi_scans: %v", err)
+	}
+	ticker := time.NewTicker(6 * time.Hour)
+	defer ticker.Stop()
+	for range ticker.C {
+		if err := store.Prune(retention); err != nil {
+			log.Printf("[netpulse] aviso: purge de wifi_scans: %v", err)
+		}
+	}
 }

--- a/server-go/internal/channelplan/store.go
+++ b/server-go/internal/channelplan/store.go
@@ -59,25 +59,32 @@ type ScanRow struct {
 	RouterID string `json:"routerId"`
 }
 
-// RecentScans devuelve los scans recientes de todos los routers (opcionalmente
-// filtrado por routerID) dentro de la ventana de frescura.
+// RecentScans devuelve los vecinos vistos recientemente (opcionalmente
+// filtrado por routerID) dentro de la ventana de fresividad, DEDUPLICADOS por
+// BSSID: cada push del agente reinserta los mismos vecinos, y sin dedup el
+// mismo AP contaba una vez por push (decenas de miles de filas al día),
+// reventaba el score (overflow) y la tabla de vecinos era puro ruido.
+// SQLite: con un único agregado MAX(ts), las columnas "bare" salen de la
+// fila del máximo (https://sqlite.org/lang_select.html#bareagg).
 func (s *Store) RecentScans(routerID string, within time.Duration) ([]ScanRow, error) {
 	cutoff := time.Now().Add(-within).Unix()
 	var rows *sql.Rows
 	var err error
 	if routerID != "" {
 		rows, err = s.db.Query(`
-			SELECT router_id, iface, bssid, ssid, channel, freq, signal_dbm, ts
+			SELECT router_id, iface, bssid, ssid, channel, freq, signal_dbm, MAX(ts)
 			FROM wifi_scans
 			WHERE router_id = ? AND ts >= ?
-			ORDER BY ts DESC, signal_dbm ASC
+			GROUP BY bssid
+			ORDER BY signal_dbm ASC, bssid
 		`, routerID, cutoff)
 	} else {
 		rows, err = s.db.Query(`
-			SELECT router_id, iface, bssid, ssid, channel, freq, signal_dbm, ts
+			SELECT router_id, iface, bssid, ssid, channel, freq, signal_dbm, MAX(ts)
 			FROM wifi_scans
 			WHERE ts >= ?
-			ORDER BY ts DESC, signal_dbm ASC
+			GROUP BY router_id, bssid
+			ORDER BY signal_dbm ASC, bssid
 		`, cutoff)
 	}
 	if err != nil {

--- a/server-go/internal/channelplan/store_test.go
+++ b/server-go/internal/channelplan/store_test.go
@@ -36,6 +36,46 @@ func TestSaveAndRecentScans(t *testing.T) {
 	}
 }
 
+// TestRecentScansDedupBSSID (#475): cada push reinserta los vecinos; la
+// lectura debe devolver UNA fila por BSSID (la observación más reciente).
+func TestRecentScansDedupBSSID(t *testing.T) {
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	defer d.Close()
+
+	st := channelplan.NewStore(d.DB)
+	now := time.Now().Unix()
+	// Push 1: vecino A (-70) y vecino B (-50).
+	if err := st.SaveScan("rt1", now-60, []probe.ScanResult{
+		{Iface: "wlan0", BSSID: "AA:AA:AA:AA:AA:01", SSID: "a", Channel: 1, Freq: 2412, Signal: -70},
+		{Iface: "wlan0", BSSID: "BB:BB:BB:BB:BB:02", SSID: "b", Channel: 6, Freq: 2437, Signal: -50},
+	}); err != nil {
+		t.Fatalf("save1: %v", err)
+	}
+	// Push 2 (30 s después): el vecino A ahora se oye más fuerte (-55).
+	if err := st.SaveScan("rt1", now-30, []probe.ScanResult{
+		{Iface: "wlan0", BSSID: "AA:AA:AA:AA:AA:01", SSID: "a", Channel: 1, Freq: 2412, Signal: -55},
+		{Iface: "wlan0", BSSID: "BB:BB:BB:BB:BB:02", SSID: "b", Channel: 6, Freq: 2437, Signal: -50},
+	}); err != nil {
+		t.Fatalf("save2: %v", err)
+	}
+
+	got, err := st.RecentScans("rt1", time.Hour)
+	if err != nil {
+		t.Fatalf("recent: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("esperaba 2 vecinos dedup, got %d: %+v", len(got), got)
+	}
+	for _, r := range got {
+		if r.BSSID == "AA:AA:AA:AA:AA:01" && r.Signal != -55 {
+			t.Errorf("el vecino A debe reportar la señal MÁS RECIENTE (-55), got %d", r.Signal)
+		}
+	}
+}
+
 func TestRecommendPrefiereCanalLibre(t *testing.T) {
 	d, err := db.Open(t.TempDir())
 	if err != nil {

--- a/server-go/internal/httpapi/wifi_channelplan.go
+++ b/server-go/internal/httpapi/wifi_channelplan.go
@@ -2,6 +2,7 @@ package httpapi
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gnacho/netpulse/agent/probe"
@@ -14,26 +15,82 @@ func (s *server) registerChannelPlanRoutes(mux *http.ServeMux) {
 		return
 	}
 
+	// agentSlugForRouter resuelve la clave que usa la UI (el id del router
+	// en el overview: hostname o nombre amigable) al slug del agente bajo el
+	// que viven Fresh() y wifi_scans (#475): la flota manda flint2/rt2 y los
+	// agentes se llaman gateway/redmi-ax6. Tres capas: slug directo,
+	// hostname del board del último payload, e id/nombre de la tabla routers
+	// resuelto con resolveAgentRouter.
+	agentSlugForRouter := func(routerID string) string {
+		norm := func(v string) string { return strings.ToLower(strings.TrimSpace(v)) }
+		routerByID := map[string]routerIdentity{}
+		slugs := []string{}
+		if s.db != nil {
+			if rows, err := s.db.Query("SELECT id, type, name, host, COALESCE(mac,'') FROM routers"); err == nil {
+				for rows.Next() {
+					var id, typ, name, host, mac string
+					if rows.Scan(&id, &typ, &name, &host, &mac) == nil {
+						routerByID[id] = routerIdentity{ID: id, Type: typ, Name: name, Host: host, Mac: mac}
+					}
+				}
+				rows.Close()
+			}
+			if rows, err := s.db.Query("SELECT key FROM kv WHERE key LIKE ?", agentTokenKeyPrefix+"%"); err == nil {
+				for rows.Next() {
+					var key string
+					if rows.Scan(&key) == nil {
+						slugs = append(slugs, strings.TrimPrefix(key, agentTokenKeyPrefix))
+					}
+				}
+				rows.Close()
+			}
+		}
+		want := norm(routerID)
+		for _, slug := range slugs {
+			if slug == routerID {
+				return slug
+			}
+			var payload *probe.Payload
+			if s.agents != nil {
+				if st := s.agents.Snapshot(slug); st != nil {
+					payload = st.Payload
+				}
+			}
+			if payload != nil && payload.Data.System != nil && payload.Data.System.Board != nil {
+				if norm(payload.Data.System.Board.Hostname) == want {
+					return slug
+				}
+			}
+			if id := resolveAgentRouter(slug, payload, routerByID); id != "" {
+				if id == routerID || norm(routerByID[id].Name) == want || norm(routerByID[id].Host) == want {
+					return slug
+				}
+			}
+		}
+		return routerID
+	}
+
 	mux.Handle("GET /api/wifi/channel-plan", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		routerID := r.URL.Query().Get("routerId")
 		if routerID == "" {
 			writeError(w, http.StatusBadRequest, "invalid_body", "routerId requerido")
 			return
 		}
+		slug := agentSlugForRouter(routerID)
 
 		var radios []probe.Radio
 		if s.agents != nil {
-			if payload, ok := s.agents.Fresh(routerID); ok && payload.Data.Wireless != nil {
+			if payload, ok := s.agents.Fresh(slug); ok && payload.Data.Wireless != nil {
 				radios = payload.Data.Wireless.Radios
 			}
 		}
 
-		recommendations, err := s.channelPlan.Recommend(routerID, radios, 24*time.Hour)
+		recommendations, err := s.channelPlan.Recommend(slug, radios, 24*time.Hour)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "channel_plan_error")
 			return
 		}
-		scans, err := s.channelPlan.RecentScans(routerID, 24*time.Hour)
+		scans, err := s.channelPlan.RecentScans(slug, 24*time.Hour)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "channel_plan_error")
 			return


### PR DESCRIPTION
The channel plan page never worked in production, and it turned out to be four defects stacked, one per layer.

The server never wired the channelplan store in main, so the route was never registered and the page got a plain `not_found`. The ingest had the same hole silently: every scan the agents pushed was discarded, and `wifi_scans` stayed empty.

With the store wired, the scans still did not arrive: real `iw` output prints `freq: 5260.0`, ParseScan fed that to Atoi, the error was dropped, Freq stayed 0 and the flush discarded every BSS. Verified against a live router: pushes went from scans: [] to 8 real neighbors.

Then the scoring went absurd on routers with history: each push reinserts the same neighbors, and RecentScans returned one row per push, so every AP counted hundreds of times until the int overflowed (MaxInt64 recommendations). The read now groups by BSSID keeping the most recent observation.

Last one: the page sends the overview router id (flint2, rt2) while scans and fresh payloads live under the agent slug (gateway, redmi-ax6), so every lookup came back empty. The endpoint now resolves the slug through the board hostname and the routers table.

End-to-end on the live network: 31 raw scans persisted, 15 unique neighbors in the response, the 2.4 GHz radio on the gateway gets a real recommendation (channel 1, score 562, move to 6, score 260), no JS errors on the page, and routers without wireless data show the empty states instead of a TypeError. The wifi_scans table gets a 48h prune on a 6h ticker so it cannot grow unbounded.

Closes #475