### PR TITLE
feat(updater): human changelog from GitHub compare in the update dialog

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1347,6 +1347,9 @@
       "hideHint": "You can close this window: the update continues on the server",
       "progressLabel": "Update progress",
       "changelogTitle": "What's new",
+      "commitsCount_one": "1 change since your version",
+      "commitsCount_other": "{{count}} changes since your version",
+      "viewCompare": "View the full comparison on GitHub",
       "changelogFallback": "Could not load changelog.",
       "changelogLink": "View release notes on GitHub",
       "downNotice": "The service will be down while it restarts"

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1347,6 +1347,9 @@
       "hideHint": "Puedes cerrar esta ventana: la actualización continúa en el servidor",
       "progressLabel": "Progreso de la actualización",
       "changelogTitle": "Novedades",
+      "commitsCount_one": "1 cambio desde tu versión",
+      "commitsCount_other": "{{count}} cambios desde tu versión",
+      "viewCompare": "Ver la comparación completa en GitHub",
       "changelogFallback": "No se ha podido cargar el changelog.",
       "changelogLink": "Ver notas del release en GitHub",
       "downNotice": "El servicio estará caído mientras se reinicia"

--- a/app/src/components/UpdateBanner.tsx
+++ b/app/src/components/UpdateBanner.tsx
@@ -21,6 +21,8 @@ interface UpdateStatus {
   latest: string | null
   latestMsg: string | null
   latestBody?: string | null
+  commits?: { sha: string; subject: string }[] | null
+  compareUrl?: string | null
   updateAvailable: boolean
   canApply: boolean
   mode: string

--- a/app/src/components/UpdateDialog.tsx
+++ b/app/src/components/UpdateDialog.tsx
@@ -13,6 +13,7 @@ import {
   Check,
   Circle,
   DownloadCloud,
+  ExternalLink,
   Loader2,
 } from 'lucide-react'
 import {
@@ -28,12 +29,21 @@ import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { ReadinessPanel, type UpdateReadiness } from '@/components/UpdateReadiness'
 
+/** Commit entre current y latest (compare de GitHub, issue #490). */
+export interface UpdateCommit {
+  sha: string
+  subject: string
+}
+
 export interface UpdateStatusInfo {
   current: string
   latest: string | null
   latestMsg: string | null
   /** Cuerpo del commit (rolling) o notas del release (estable): changelog. */
   latestBody?: string | null
+  /** Commits current→latest (newest first) + enlace al compare (#490). */
+  commits?: UpdateCommit[] | null
+  compareUrl?: string | null
   updateAvailable: boolean
   canApply: boolean
   repo: string
@@ -309,10 +319,46 @@ export function UpdateDialog({ open, onOpenChange, initialStatus }: UpdateDialog
             {status?.latestMsg && (
               <p className="text-center text-caption text-text-muted">{status.latestMsg}</p>
             )}
-            {/* Changelog (issue #280): cuerpo del commit (rolling) o notas
-                del release (estable), línea a línea con scroll. Los trailers
-                de git (Co-authored-by, Signed-off-by…) son ruido: fuera. */}
-            {changelogLines.length > 0 && (
+            {/* Changelog humano (issue #490): commits current→latest del
+                compare de GitHub, newest first. Fallback (#280): cuerpo del
+                commit (rolling) o notas del release (estable), sin trailers. */}
+            {(status?.commits?.length ?? 0) > 0 && (
+              <p className="text-center text-caption text-text-muted">
+                {t('update.dialog.commitsCount', { count: status!.commits!.length })}
+              </p>
+            )}
+            {(status?.commits?.length ?? 0) > 0 && (
+              <div className="flex flex-col gap-1.5">
+                <p className="text-xs font-semibold uppercase tracking-wider text-text-muted">
+                  {t('update.dialog.changelogTitle')}
+                </p>
+                <div className="max-h-44 overflow-y-auto rounded-xl border border-border bg-surface px-3.5 py-2.5">
+                  <ul className="flex flex-col gap-1">
+                    {status!.commits!.map((c) => (
+                      <li
+                        key={c.sha + c.subject}
+                        className="flex items-start gap-2 text-caption leading-snug text-text-secondary"
+                      >
+                        <span className="shrink-0 font-mono text-text-muted">{c.sha}</span>
+                        <span className="min-w-0 break-words">{c.subject}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                {status?.compareUrl && (
+                  <a
+                    href={status.compareUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center gap-1 text-caption text-accent hover:underline"
+                  >
+                    <ExternalLink className="h-3 w-3" strokeWidth={1.75} aria-hidden="true" />
+                    {t('update.dialog.viewCompare')}
+                  </a>
+                )}
+              </div>
+            )}
+            {(status?.commits?.length ?? 0) === 0 && changelogLines.length > 0 && (
               <div className="flex flex-col gap-1.5">
                 <p className="text-xs font-semibold uppercase tracking-wider text-text-muted">
                   {t('update.dialog.changelogTitle')}
@@ -329,8 +375,9 @@ export function UpdateDialog({ open, onOpenChange, initialStatus }: UpdateDialog
                 </div>
               </div>
             )}
-            {/* Issue #404: fallback con enlace si no hay changelog. */}
-            {changelogLines.length === 0 && status?.latest && (
+            {/* Issue #404: fallback con enlace si no hay changelog
+                (ni commits del compare ni body). */}
+            {(status?.commits?.length ?? 0) === 0 && changelogLines.length === 0 && status?.latest && (
               <p className="text-caption text-text-muted">
                 {t('update.dialog.changelogFallback')}{' '}
                 <a

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -2226,6 +2226,8 @@ interface NetPulseUpdateStatus {
   latest: string | null
   latestMsg: string | null
   latestBody?: string | null
+  commits?: { sha: string; subject: string }[] | null
+  compareUrl?: string | null
   updateAvailable: boolean
   canApply: boolean
   repo: string

--- a/server-go/internal/updater/stable_test.go
+++ b/server-go/internal/updater/stable_test.go
@@ -67,6 +67,11 @@ func serveStableRelease(t *testing.T, tag, asset, tgzSum string, tgzBytes []byte
 		if r.URL.Path == "/" {
 			return // probe de readiness: solo comprueba conectividad
 		}
+		// Compare del changelog (issue #490): se tolera sin fallar el test.
+		if strings.Contains(r.URL.Path, "/compare/") {
+			fmt.Fprint(w, `{"commits":[]}`)
+			return
+		}
 		if r.URL.Path != "/repos/owner/netpulse/releases/latest" {
 			t.Errorf("API path inesperado: %s", r.URL.Path)
 			w.WriteHeader(404)

--- a/server-go/internal/updater/updater.go
+++ b/server-go/internal/updater/updater.go
@@ -27,6 +27,9 @@ const (
 	httpTimeout   = 8 * time.Second
 	logTail       = 4000
 	statusLogTail = 800
+	// maxChangelogCommits: tope de commits del compare que se exponen en el
+	// estado (issue #490); el enlace compareUrl lleva la lista completa.
+	maxChangelogCommits = 30
 )
 
 // APIBase es la base de la API de GitHub (inyectable en tests).
@@ -40,6 +43,13 @@ var BuildCommit string
 type progress struct {
 	Step     string `json:"step"`
 	Progress int    `json:"progress"` // 0-100
+}
+
+// CommitRef: un commit entre la versión actual y la disponible, para el
+// changelog humano del asistente de actualización (issue #490).
+type CommitRef struct {
+	SHA     string `json:"sha"`     // corto (7 chars), solo display
+	Subject string `json:"subject"` // primera línea del mensaje
 }
 
 // stepWeight: porcentaje mostrado MIENTRAS el paso está en ejecución
@@ -73,12 +83,18 @@ type Status struct {
 	LastCheck       *int64  `json:"lastCheck"`
 	// LatestBody: cuerpo del commit (rolling) o notas del release (estable)
 	// mostrado como changelog en el asistente (issue #280).
-	LatestBody    *string `json:"latestBody,omitempty"`
-	Updating      any     `json:"updating"` // false | {"step": ...}
-	Error         *string `json:"error"`
-	LastLog       *string `json:"lastLog"`
-	Repo          string  `json:"repo"`
-	HasToken      bool    `json:"hasToken"`
+	LatestBody *string `json:"latestBody,omitempty"`
+	// Commits: commits entre current y latest (compare de GitHub), newest
+	// first, cap maxChangelogCommits (issue #490). Vacío cuando no hay
+	// actualización o el compare falló: la UI cae a latestBody.
+	Commits []CommitRef `json:"commits,omitempty"`
+	// CompareURL: enlace web al compare completo current...latest (#490).
+	CompareURL string    `json:"compareUrl,omitempty"`
+	Updating   any       `json:"updating"` // false | {"step": ...}
+	Error      *string   `json:"error"`
+	LastLog    *string   `json:"lastLog"`
+	Repo       string    `json:"repo"`
+	HasToken   bool      `json:"hasToken"`
 	// Readiness: pre-flight checks del apply (issue #160). Null en layout
 	// estable (sin auto-apply) o hasta el primer Status().
 	Readiness *Readiness `json:"readiness,omitempty"`
@@ -107,6 +123,11 @@ type Updater struct {
 	latest       *string
 	latestMsg    *string
 	latestBody   *string // cuerpo del commit/notas del release (changelog #280)
+	// compare de GitHub cacheado (issue #490): commits current→latest y
+	// clave "current|latest" del último fetch para no repetir la consulta.
+	commits    []CommitRef
+	compareURL string
+	compareKey string
 	updateAvail  bool
 	lastCheck    *int64
 	updatingStep *string // nil = no actualizando
@@ -342,6 +363,71 @@ func (u *Updater) fetchReleaseBody(ctx context.Context, sha string) string {
 	return ""
 }
 
+// fetchCompare consulta los commits entre base y head (compare de GitHub,
+// issue #490). base/head aceptan SHAs (rolling) o tags (estable); GitHub
+// devuelve los commits oldest→newest y aquí se invierten para que el
+// changelog se lea newest-first. Cualquier error → (nil, ""): el changelog
+// no aparece y el flujo de actualización queda intacto.
+func (u *Updater) fetchCompare(ctx context.Context, base, head string) ([]CommitRef, string) {
+	req, err := http.NewRequestWithContext(ctx, "GET",
+		fmt.Sprintf("%s/repos/%s/compare/%s...%s", APIBase, u.repo, base, head), nil)
+	if err != nil {
+		return nil, ""
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "netpulse-updater")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if u.token != "" {
+		req.Header.Set("Authorization", "Bearer "+u.token)
+	}
+	client := &http.Client{Timeout: httpTimeout}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, ""
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		return nil, ""
+	}
+	var data struct {
+		Commits []struct {
+			SHA    string `json:"sha"`
+			Commit struct {
+				Message string `json:"message"`
+			} `json:"commit"`
+		} `json:"commits"`
+	}
+	if err := json.NewDecoder(io.LimitReader(res.Body, 4<<20)).Decode(&data); err != nil {
+		return nil, ""
+	}
+	out := make([]CommitRef, 0, len(data.Commits))
+	for i := len(data.Commits) - 1; i >= 0; i-- {
+		c := data.Commits[i]
+		subject := strings.Split(c.Commit.Message, "\n")[0]
+		if subject == "" {
+			continue
+		}
+		sha := c.SHA
+		if len(sha) > 7 {
+			sha = sha[:7]
+		}
+		out = append(out, CommitRef{SHA: sha, Subject: subject})
+		if len(out) >= maxChangelogCommits {
+			break
+		}
+	}
+	return out, fmt.Sprintf("https://github.com/%s/compare/%s...%s", u.repo, base, head)
+}
+
+// compareTagRef normaliza un semver a ref de tag ("2.26.2" → "v2.26.2")
+// para el compare en modo estable; los tags del repo llevan prefijo "v".
+func compareTagRef(s string) string {
+	if !strings.HasPrefix(s, "v") {
+		return "v" + s
+	}
+	return s
+}
+
 // compareSemver compara dos strings semver (con o sin prefijo "v").
 // Devuelve >0 si a > b, 0 si iguales, <0 si a < b. No-parseable → 0.
 func compareSemver(a, b string) int {
@@ -401,6 +487,31 @@ func (u *Updater) Check(ctx context.Context) Status {
 
 	now := time.Now().UnixMilli()
 
+	// Disponibilidad calculada fuera del lock (lógica pura de strings).
+	avail := false
+	if latest != "" && current != "desconocido" {
+		if u.mode == "stable" {
+			avail = compareSemver(latest, current) > 0
+		} else {
+			avail = latest != current
+		}
+	}
+
+	// Changelog humano (issue #490): commits current→latest vía compare,
+	// solo con novedades y solo si el par (current, latest) cambió desde el
+	// último fetch (el check corre cada 24 h; no repetir la misma consulta).
+	key := current + "|" + latest
+	var commits []CommitRef
+	var compareURL string
+	if avail && key != u.compareKey {
+		base, head := current, latestSHA
+		if u.mode == "stable" {
+			base = compareTagRef(current)
+			head = compareTagRef(latest)
+		}
+		commits, compareURL = u.fetchCompare(ctx, base, head)
+	}
+
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	u.current = current
@@ -413,10 +524,18 @@ func (u *Updater) Check(ctx context.Context) Status {
 	u.latest = &latest
 	u.latestMsg = &latestMsg
 	u.latestBody = &latestBody
-	if u.mode == "stable" {
-		u.updateAvail = latest != "" && current != "desconocido" && compareSemver(latest, current) > 0
+	u.updateAvail = avail
+	if avail {
+		if key != u.compareKey {
+			u.compareKey = key
+			u.commits = commits
+			u.compareURL = compareURL
+		}
 	} else {
-		u.updateAvail = latest != "" && current != "desconocido" && latest != current
+		// Sin novedades: caduca cualquier changelog anterior.
+		u.compareKey = ""
+		u.commits = nil
+		u.compareURL = ""
 	}
 	if u.updateAvail {
 		fmt.Printf("[netpulse] nueva versión disponible: %s → %s (%s)\n", current, latest, latestMsg)
@@ -712,6 +831,8 @@ func (u *Updater) statusLocked() Status {
 		Latest:          u.latest,
 		LatestMsg:       u.latestMsg,
 		LatestBody:      u.latestBody,
+		Commits:         u.commits,
+		CompareURL:      u.compareURL,
 		UpdateAvailable: u.updateAvail,
 		CanApply:        u.canApply,
 		Mode:            u.mode,
@@ -726,11 +847,12 @@ func (u *Updater) statusLocked() Status {
 }
 
 // Start lanza el chequeo inicial y el timer de 6 h (paridad start()).
+// El contexto cubre las llamadas de red del Check: latest + compare (#490).
 func (u *Updater) Start() {
 	u.wg.Add(1)
 	go func() {
 		defer u.wg.Done()
-		ctx, cancel := context.WithTimeout(context.Background(), httpTimeout+2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*httpTimeout+2*time.Second)
 		u.Check(ctx)
 		cancel()
 		t := time.NewTicker(checkInterval)
@@ -740,7 +862,7 @@ func (u *Updater) Start() {
 			case <-u.stopCh:
 				return
 			case <-t.C:
-				ctx, cancel := context.WithTimeout(context.Background(), httpTimeout+2*time.Second)
+				ctx, cancel := context.WithTimeout(context.Background(), 2*httpTimeout+2*time.Second)
 				u.Check(ctx)
 				cancel()
 			}

--- a/server-go/internal/updater/updater_compare_test.go
+++ b/server-go/internal/updater/updater_compare_test.go
@@ -1,0 +1,152 @@
+// updater_compare_test.go — changelog humano del asistente (issue #490):
+// el Check expone los commits current→latest (compare de GitHub) en ambos
+// modos, tolera fallos del compare y cachea por par (current, latest).
+package updater
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// mockCompare: respuesta del compare con 3 commits oldest→newest (GitHub los
+// devuelve en orden cronológico; el updater los invierte).
+const compareBody = `{
+  "commits": [
+    {"sha": "1111111111111111", "commit": {"message": "fix(wifi): parse freq as float (#475)\n\ncon cuerpo"}},
+    {"sha": "2222222222222222", "commit": {"message": "feat(routers): one-click agent install (#483)"}},
+    {"sha": "deadbee1234567890", "commit": {"message": "feat: newest\n\nlong body"}}
+  ]
+}`
+
+func TestCheckFetchesCompareCommits(t *testing.T) {
+	root := t.TempDir()
+	writeDeployScript(t, root)
+	short := writeGitHead(t, root)
+	withAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/netpulse/commits/main":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"sha":"deadbee1234567890","commit":{"message":"feat: newest\n\nlong body"}}`)
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/netpulse/compare/"):
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, compareBody)
+		default:
+			t.Errorf("path inesperado: %s", r.URL.Path)
+		}
+	})
+	u := New(root, "owner/netpulse", "", "2.0.0", nil)
+	st := u.Check(context.Background())
+	if st.Error != nil {
+		t.Fatalf("error: %v", *st.Error)
+	}
+	if !st.UpdateAvailable {
+		t.Fatal("debería haber update")
+	}
+	if len(st.Commits) != 3 {
+		t.Fatalf("commits: %+v", st.Commits)
+	}
+	// Newest first y subjects = primera línea del mensaje.
+	if st.Commits[0].SHA != "deadbee" || st.Commits[0].Subject != "feat: newest" {
+		t.Fatalf("commits[0]: %+v", st.Commits[0])
+	}
+	if st.Commits[2].SHA != "1111111" || st.Commits[2].Subject != "fix(wifi): parse freq as float (#475)" {
+		t.Fatalf("commits[2]: %+v", st.Commits[2])
+	}
+	want := "https://github.com/owner/netpulse/compare/" + short + "...deadbee1234567890"
+	if st.CompareURL != want {
+		t.Fatalf("compareUrl: %q, want %q", st.CompareURL, want)
+	}
+}
+
+func TestCheckCompareStableUsesTags(t *testing.T) {
+	withAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/netpulse/releases/latest":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"tag_name":"v2.1.0","name":"v2.1.0","body":"release notes"}`)
+		case r.URL.Path == "/repos/owner/netpulse/compare/v2.0.0...v2.1.0":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"commits":[{"sha":"abcdef0123456789","commit":{"message":"feat: uno"}}]}`)
+		default:
+			t.Errorf("path inesperado: %s", r.URL.Path)
+		}
+	})
+	// Sin deploy/update.sh → estable; version sin prefijo "v" (ldflags).
+	u := New(t.TempDir(), "owner/netpulse", "", "2.0.0", nil)
+	st := u.Check(context.Background())
+	if !st.UpdateAvailable {
+		t.Fatal("debería haber update 2.0.0 → 2.1.0")
+	}
+	if len(st.Commits) != 1 || st.Commits[0].Subject != "feat: uno" || st.Commits[0].SHA != "abcdef0" {
+		t.Fatalf("commits: %+v", st.Commits)
+	}
+	if st.CompareURL != "https://github.com/owner/netpulse/compare/v2.0.0...v2.1.0" {
+		t.Fatalf("compareUrl: %q", st.CompareURL)
+	}
+}
+
+func TestCheckCompareFailureTolerated(t *testing.T) {
+	root := t.TempDir()
+	writeDeployScript(t, root)
+	writeGitHead(t, root)
+	withAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/netpulse/commits/main":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"sha":"deadbee1234567890","commit":{"message":"feat: newest\n\nbody"}}`)
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/netpulse/compare/"):
+			http.Error(w, "boom", http.StatusInternalServerError)
+		case r.URL.Path == "/repos/owner/netpulse/releases":
+			// #404: body no vacío en el mock → no llega aquí, pero por si acaso.
+			fmt.Fprint(w, `[]`)
+		default:
+			t.Errorf("path inesperado: %s", r.URL.Path)
+		}
+	})
+	u := New(root, "owner/netpulse", "", "2.0.0", nil)
+	st := u.Check(context.Background())
+	if st.Error != nil {
+		t.Fatalf("el fallo del compare no debe ser error: %v", *st.Error)
+	}
+	if !st.UpdateAvailable {
+		t.Fatal("debería haber update pese al compare caído")
+	}
+	if st.Commits != nil || st.CompareURL != "" {
+		t.Fatalf("compare fallido: %+v %q", st.Commits, st.CompareURL)
+	}
+}
+
+func TestCheckCompareCachedPerPair(t *testing.T) {
+	root := t.TempDir()
+	writeDeployScript(t, root)
+	writeGitHead(t, root)
+	compareCalls := 0
+	withAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/netpulse/commits/main":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"sha":"deadbee1234567890","commit":{"message":"feat: newest\n\nbody"}}`)
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/netpulse/compare/"):
+			compareCalls++
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, compareBody)
+		default:
+			t.Errorf("path inesperado: %s", r.URL.Path)
+		}
+	})
+	u := New(root, "owner/netpulse", "", "2.0.0", nil)
+	st1 := u.Check(context.Background())
+	if len(st1.Commits) != 3 {
+		t.Fatalf("commits primer check: %+v", st1.Commits)
+	}
+	st2 := u.Check(context.Background())
+	if compareCalls != 1 {
+		t.Fatalf("el compare se reconsultó con el mismo par: %d llamadas", compareCalls)
+	}
+	if len(st2.Commits) != 3 {
+		t.Fatalf("commits cacheados: %+v", st2.Commits)
+	}
+}

--- a/server-go/internal/updater/updater_test.go
+++ b/server-go/internal/updater/updater_test.go
@@ -31,13 +31,19 @@ func TestCheckUpdateAvailable(t *testing.T) {
 		switch r.URL.Path {
 		case "/repos/owner/netpulse/commits/main":
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"sha":"abc1234deadbeef","commit":{"message":"feat: algo\n\nbody"}}`)
-		case "/repos/owner/netpulse/releases":
+		fmt.Fprint(w, `{"sha":"abc1234deadbeef","commit":{"message":"feat: algo\n\nbody"}}`)
+	case "/repos/owner/netpulse/releases":
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[]`)
+	default:
+		// Compare del changelog (issue #490): cualquier path /compare/.
+		if strings.Contains(r.URL.Path, "/compare/") {
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `[]`)
-		default:
-			t.Errorf("path: %s", r.URL.Path)
+			fmt.Fprint(w, `{"commits":[{"sha":"abc1234deadbeef","commit":{"message":"feat: algo"}}]}`)
+			return
 		}
+		t.Errorf("path: %s", r.URL.Path)
+	}
 	})
 	// repoRoot con git válido (commit distinto) para updateAvailable.
 	// deploy/update.sh → modo rolling (compara contra main HEAD).
@@ -85,6 +91,11 @@ func TestCheckUsesReleaseBodyWhenCommitBodyEmpty(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprint(w, `[{"body":"Release notes line 1\nRelease notes line 2","target_commitish":"deadbeefabc1234"}]`)
 		default:
+			// Compare del changelog (issue #490).
+			if strings.Contains(r.URL.Path, "/compare/") {
+				fmt.Fprint(w, `{"commits":[]}`)
+				return
+			}
 			t.Errorf("path: %s", r.URL.Path)
 		}
 	})
@@ -209,6 +220,11 @@ func TestApplyYaEnCursoYScript(t *testing.T) {
 
 func TestStableModeUpdateAvailable(t *testing.T) {
 	withAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		// Compare del changelog (issue #490).
+		if strings.Contains(r.URL.Path, "/compare/") {
+			fmt.Fprint(w, `{"commits":[]}`)
+			return
+		}
 		if r.URL.Path != "/repos/owner/netpulse/releases/latest" {
 			t.Errorf("path: %s (modo estable debe consultar releases/latest)", r.URL.Path)
 		}


### PR DESCRIPTION
## What

The update wizard's "What's new" section was almost always empty: in rolling mode `latestBody` is the body of the last commit on main (empty for one-line squashes), and in stable mode release bodies are CI-generated with a single commit. This adds a real changelog before applying.

## How

- **Server** (`internal/updater`): when a check finds `updateAvailable`, it queries GitHub's compare endpoint between current and latest (SHAs in rolling, tags in stable) and exposes `commits` (`{sha, subject}`, newest first, capped at 30) plus `compareUrl` in the status. The fetch is tolerant (any failure leaves it empty, the update flow is untouched) and cached per `(current, latest)` pair so the 24 h check loop does not repeat it. The `Start` context budget grows to cover the extra call. When up to date again, the cached changelog expires.
- **UI** (`UpdateDialog`, shared by banner and Settings): the confirm step renders the commit list with a count caption and a "view full comparison on GitHub" link. Falls back to the previous `latestBody` rendering and then to the #404 link fallback. New i18n keys in ES/EN (`commitsCount_one/_other`, `viewCompare`).

## Verification

- `go test ./...` green in server-go (36 pkgs) and agent; new `updater_compare_test.go` covers rolling, stable tags, failure tolerance and the per-pair cache; existing mocks updated to tolerate the new `/compare/` path.
- `npm run build` + lint clean (5 pre-existing warnings).
- Live E2E on a preview CT with a forced older `BuildCommit`: `POST /api/update/check` returned the 7 real commits between the two versions with correct subjects and compare URL; Playwright 11/11 PASS on banner + dialog (count, first row, compare link, apply button gated by the downtime ack), 0 JS errors.

Closes #490