### PR TITLE
feat(agent): ship mipsle and mips softfloat builds for MIPS devices

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -83,6 +83,10 @@ jobs:
           (cd agent && GOARCH=arm64 go build -trimpath -ldflags "-s -w -X main.Version=$AGENT_VERSION" -o ../server-go/internal/agentbin/agents/netpulse-agent-arm64 ./cmd/netpulse-agent)
           # armv7 (fichero "arm": el nombre que busca normalizeArch)
           (cd agent && GOARCH=arm GOARM=7 go build -trimpath -ldflags "-s -w -X main.Version=$AGENT_VERSION" -o ../server-go/internal/agentbin/agents/netpulse-agent-arm ./cmd/netpulse-agent)
+          # mipsle softfloat (MT7621 y resto de MIPS little-endian) y mips
+          # softfloat (big-endian, ath79): sin FPU en ambos (#488)
+          (cd agent && GOARCH=mipsle GOMIPS=softfloat go build -trimpath -ldflags "-s -w -X main.Version=$AGENT_VERSION" -o ../server-go/internal/agentbin/agents/netpulse-agent-mipsle ./cmd/netpulse-agent)
+          (cd agent && GOARCH=mips GOMIPS=softfloat go build -trimpath -ldflags "-s -w -X main.Version=$AGENT_VERSION" -o ../server-go/internal/agentbin/agents/netpulse-agent-mips ./cmd/netpulse-agent)
 
       - name: Tests Go
         working-directory: server-go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,9 @@ jobs:
           (cd agent && GOARCH=arm64 go build -trimpath -ldflags "-s -w -X main.Version=${{ steps.version.outputs.agent }}" -o ../server-go/internal/agentbin/agents/netpulse-agent-arm64 ./cmd/netpulse-agent)
           # armv7 (fichero "arm": el nombre que busca normalizeArch)
           (cd agent && GOARCH=arm GOARM=7 go build -trimpath -ldflags "-s -w -X main.Version=${{ steps.version.outputs.agent }}" -o ../server-go/internal/agentbin/agents/netpulse-agent-arm ./cmd/netpulse-agent)
+          # mipsle/mips softfloat (#488): MIPS sin FPU, ambos endianness
+          (cd agent && GOARCH=mipsle GOMIPS=softfloat go build -trimpath -ldflags "-s -w -X main.Version=${{ steps.version.outputs.agent }}" -o ../server-go/internal/agentbin/agents/netpulse-agent-mipsle ./cmd/netpulse-agent)
+          (cd agent && GOARCH=mips GOMIPS=softfloat go build -trimpath -ldflags "-s -w -X main.Version=${{ steps.version.outputs.agent }}" -o ../server-go/internal/agentbin/agents/netpulse-agent-mips ./cmd/netpulse-agent)
 
       - name: Tests Go (ambos módulos)
         run: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,7 +50,8 @@ builds:
 
   # Agente nativo OpenWrt (Fase 6): binario stateless que empuja al servidor.
   # arm64 = GL-MT6000 + APs (Cortex-A53); armv7 por si aparece un AP más
-  # viejo; amd64 para pilotos locales.
+  # viejo; amd64 para pilotos locales; mipsle (softfloat) = MT7621 y resto
+  # de ramips/lantiq LE; mips (softfloat) = ath79 y targets BE (#488).
   - id: netpulse-agent
     dir: agent
     main: ./cmd/netpulse-agent
@@ -58,8 +59,11 @@ builds:
     env:
       - CGO_ENABLED=0
     goos: [linux]
-    goarch: [amd64, arm64, arm]
+    goarch: [amd64, arm64, arm, mipsle, mips]
     goarm: [7]
+    # Los SoC MIPS de OpenWrt (MT7621, AR7xxx/AR9xxx...) no llevan FPU:
+    # softfloat para ambos endianness.
+    gomips: [softfloat]
     flags: [-trimpath]
     # -X main.Version: sin esto el agente reporta "0.1.0" para siempre
     # (main.go declara var Version con fallback para builds locales).

--- a/install-agent.sh
+++ b/install-agent.sh
@@ -3,8 +3,8 @@
 # NetPulse Agent — one-liner installer (OpenWrt, vía SSH desde esta máquina)
 #
 #   Instala el agente nativo netpulse-agent en un router/AP OpenWrt: copia el
-#   binario (arm64/armv7), escribe /etc/netpulse-agent.env (chmod 600) e
-#   instala el servicio procd (respawn) habilitado y arrancado.
+#   binario (arm64/armv7/mipsle/mips), escribe /etc/netpulse-agent.env (chmod
+#   600) e instala el servicio procd (respawn) habilitado y arrancado.
 #
 # Uso (el token lo genera POST /api/agents y se muestra UNA sola vez):
 #   sh install-agent.sh --host 192.168.8.3 \
@@ -206,7 +206,18 @@ else
     case "$ARCH" in
         aarch64|arm64) GOARCH=arm64 ;;
         armv7l|armv7)  GOARCH=armv7 ;;
-        *) fatal 20 "arquitectura no soportada: $ARCH (release: arm64, armv7)" ;;
+        mips)
+            # uname -m dice "mips" para AMBOS endianness. El byte EI_DATA
+            # (5º del ELF del sistema) decide: 0x01 = little (mipsle,
+            # MT7621/ramips), 0x02 = big (mips, ath79). head|tail|tr en vez
+            # de "od -t": busybox od no garantiza -t/-j/-N (#488).
+            END=$(ssh "$SSH" 'head -c 6 /bin/sh | tail -c 1 | tr "\001\002" "12"')
+            case "$END" in
+                1) GOARCH=mipsle ;;
+                2) GOARCH=mips ;;
+                *) fatal 20 "no pude detectar el endianness MIPS de $HOST" ;;
+            esac ;;
+        *) fatal 20 "arquitectura no soportada: $ARCH (release: arm64, armv7, mipsle, mips)" ;;
     esac
     if command -v curl >/dev/null 2>&1; then FETCH="curl -fsSL --retry 3 --connect-timeout 10"
     elif command -v wget >/dev/null 2>&1; then FETCH="wget -q -O-"

--- a/server-go/internal/agentbin/arch_test.go
+++ b/server-go/internal/agentbin/arch_test.go
@@ -3,7 +3,7 @@ package agentbin
 import "testing"
 
 func TestOpenArmVariants(t *testing.T) {
-	for _, arch := range []string{"amd64", "arm64", "arm", "armv7", "armv7l", "aarch64", "x86_64"} {
+	for _, arch := range []string{"amd64", "arm64", "arm", "armv7", "armv7l", "aarch64", "x86_64", "mipsle", "mips"} {
 		f, err := Open(arch)
 		if err != nil {
 			t.Fatalf("Open(%q) failed: %v", arch, err)

--- a/server-go/internal/reinstall/reinstall.go
+++ b/server-go/internal/reinstall/reinstall.go
@@ -29,6 +29,14 @@ case "$ARCH" in
 	aarch64|arm64)  GOARCH=arm64; SHA256="` + digests["arm64"] + `" ;;
 	armv7l|armv7|armhf|arm) GOARCH=arm; SHA256="` + digests["arm"] + `" ;;
 	x86_64|amd64)   GOARCH=amd64; SHA256="` + digests["amd64"] + `" ;;
+	mips)
+		# uname -m dice "mips" para AMBOS endianness: el byte EI_DATA (5º del
+		# ELF) decide. head|tail|tr en vez de "od -t": busybox no lo garantiza.
+		case "$(head -c 6 /bin/sh | tail -c 1 | tr '\001\002' '12')" in
+			1) GOARCH=mipsle; SHA256="` + digests["mipsle"] + `" ;;
+			2) GOARCH=mips;  SHA256="` + digests["mips"] + `" ;;
+			*) echo "no pude detectar el endianness de $ARCH"; exit 20 ;;
+		esac ;;
 	*) echo "arch no soportado: $ARCH"; exit 20 ;;
 esac
 
@@ -82,6 +90,12 @@ selfheal_binary() {
 		aarch64|arm64) local ARCH=arm64 ;;
 		armv7l|armv7|armhf|arm) local ARCH=arm ;;
 		x86_64|amd64) local ARCH=amd64 ;;
+		mips)
+			case "$(head -c 6 /bin/sh | tail -c 1 | tr '\001\002' '12')" in
+				1) local ARCH=mipsle ;;
+				2) local ARCH=mips ;;
+				*) return 1 ;;
+			esac ;;
 		*) return 1 ;;
 	esac
 	local url tmp
@@ -147,12 +161,14 @@ chmod 0755 "$WATCHDOG"
 `
 }
 
-// Digests devuelve los sha256 de los binarios de agente embebidos para las
-// tres arquitecturas (cadena vacía si el arch no tiene binario).
+// Digests devuelve los sha256 de los binarios de agente embebidos (cadena
+// vacía si el arch no tiene binario).
 func Digests() map[string]string {
 	return map[string]string{
-		"arm64": agentbin.Digest("arm64"),
-		"arm":   agentbin.Digest("arm"),
-		"amd64": agentbin.Digest("amd64"),
+		"arm64":  agentbin.Digest("arm64"),
+		"arm":    agentbin.Digest("arm"),
+		"amd64":  agentbin.Digest("amd64"),
+		"mipsle": agentbin.Digest("mipsle"),
+		"mips":   agentbin.Digest("mips"),
 	}
 }

--- a/server-go/internal/reinstall/script_test.go
+++ b/server-go/internal/reinstall/script_test.go
@@ -15,9 +15,11 @@ func scriptForTest() string {
 		strings.Repeat("a1", 32), // 64 hex como un token real
 		"http://192.168.1.226:3000",
 		map[string]string{
-			"arm64": "cafebabe",
-			"arm":   "deadbeef",
-			"amd64": "abcd1234",
+			"arm64":  "cafebabe",
+			"arm":    "deadbeef",
+			"amd64":  "abcd1234",
+			"mipsle": "0123feed",
+			"mips":   "4567beef",
 		},
 	)
 }
@@ -52,6 +54,21 @@ func TestScriptArchAndDigests(t *testing.T) {
 	}
 	if strings.Contains(s, "arch=armv7\"") {
 		t.Error("el script no debe pedir arch=armv7 (normalizeArch espera arm)")
+	}
+	// #488: uname -m "mips" no distingue endianness; el script lo detecta
+	// con el byte EI_DATA del ELF y mapea a mipsle/mips con su digest.
+	for _, want := range []string{
+		`1) GOARCH=mipsle; SHA256="0123feed"`,
+		`2) GOARCH=mips;  SHA256="4567beef"`,
+		`head -c 6 /bin/sh | tail -c 1 | tr '\001\002' '12'`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("script sin %q", want)
+		}
+	}
+	if strings.Count(s, "mipsle") < 2 {
+		t.Errorf("el self-heal del init también debe resolver mipsle (apariciones: %d)",
+			strings.Count(s, "mipsle"))
 	}
 	if !strings.Contains(s, `GOT=$(sha256sum /tmp/netpulse-agent.new | awk '{print $1}')`) {
 		t.Error("sin verificación sha256sum")


### PR DESCRIPTION
## What

The agent only shipped for amd64, arm64 and armv7, so a whole class of very common OpenWrt hardware (MT7621 and every other MIPS SoC) could not install it: the one-liner exited with `fatal 20` and the UI install button had nothing to serve.

## How

- **Builds**: `netpulse-agent` gains `mipsle` (little-endian, MT7621/ramips) and `mips` (big-endian, ath79) targets, both `GOMIPS=softfloat` since these SoCs have no FPU. Added to goreleaser (release tarballs), `go.yml` and `release.yml` (binaries embedded in the server for `GET /api/agents/{slug}/binary`). Server and collector stay on amd64/arm64/arm.
- **Installer** (`install-agent.sh`): `uname -m` reports `mips` for BOTH endiannesses, so the arch detection now reads the EI_DATA byte (offset 5) of the system ELF: `head -c 6 /bin/sh | tail -c 1 | tr '\001\002' '12'` yields `1` for little, `2` for big. Deliberately busybox-safe (no `od -t` dependency).
- **Reinstall script** (UI button, self-heal init): same endian detection in both places, with sha256 digests for `mipsle`/`mips` wired through `Digests()`.

Out of scope (follow-up noted on the issue): the OpenWrt agent .apk/.ipk packages remain aarch64-only; the one-liner and release tarballs cover MIPS.

## Verification

- `go test ./...` green in server-go (36 pkgs) and agent; extended `arch_test` and reinstall script contract tests (mips cases, digests, endian snippet, self-heal coverage); `sh -n` on the installer.
- **The binaries actually run**: `qemu-mipsel` / `qemu-mips` execute both builds (`--version` → exit 0), including the binaries downloaded live from a preview CT via `GET /binary?arch=mipsle|mips` (correct ELF32 LE/BE headers, unknown arch → 404, ephemeral test token created and revoked).
- Endianness detection validated against real ELFs: the snippet returns `1` on a little-endian image, `2` on a big-endian one.

Closes #488