### PR TITLE
feat(agent): collect LLDP neighbours in the agent payload

### DIFF
--- a/agent/probe/lldp.go
+++ b/agent/probe/lldp.go
@@ -1,0 +1,185 @@
+// lldp.go — vecinos LLDP del equipo (issue #489). El comando y el parser
+// viven aquí (patrón Cmd*/Parse* de probe) para que los use TANTO el agente
+// local (sección lldp del payload) como el sondeo SSH del server, que hasta
+// ahora tenía su propia copia en adapters/lldp.go.
+//
+// Contrato de disponibilidad (#247/#489):
+//   - lldpd NO instalado → LldpData{Available:false} (hint "instala lldpd").
+//   - instalado pero la sonda falla esta ronda → Available:true con
+//     Neighbors nil (el server conserva el último dato bueno).
+//   - instalado y sin vecinos → Available:true con Neighbors [] (vacío
+//     honesto: cero vecinos escuchados).
+package probe
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+// CmdLldpCheck: ¿está lldpcli instalado? (exit != 0 → no instalado).
+const CmdLldpCheck = "command -v lldpcli"
+
+// CmdLldpNeighbors: vecinos LLDP en JSON (lldpd). Igual que la sonda SSH.
+const CmdLldpNeighbors = "lldpcli -f json show neighbors"
+
+// LldpData: sección lldp del payload del agente (#489).
+type LldpData struct {
+	// Available: false cuando lldpd no está instalado en el equipo.
+	Available bool `json:"available"`
+	// Neighbors: vecinos anunciados. nil = sonda fallida esta ronda (el
+	// server conserva el último dato bueno); [] = cero vecinos honesto.
+	// SIN omitempty a propósito: hay que distinguir nil de vacío en el
+	// wire format.
+	Neighbors []LldpNeighbor `json:"neighbors"`
+}
+
+// LldpNeighbor: un vecino LLDP anunciado en un puerto local. Todos los
+// campos son opcionales en el anuncio; vacío = no anunciado. Mismos campos
+// que adapters.LldpNeighbor (conversión directa por campos idénticos).
+type LldpNeighbor struct {
+	Port       string   `json:"port"`                 // puerto local que recibe el anuncio ("lan3"…)
+	ChassisMac string   `json:"chassisMac,omitempty"` // id del chasis tipo mac (mayúsculas)
+	Chassis    string   `json:"chassis,omitempty"`    // nombre del chasis (o id si no hay nombre)
+	Mgmt       string   `json:"mgmt,omitempty"`       // primera mgmt-ip anunciada
+	Caps       []string `json:"caps,omitempty"`       // capacidades enabled ("Bridge", "Router", "Wlan"…)
+	PortDesc   string   `json:"portDesc,omitempty"`   // descripción del puerto remoto
+}
+
+// ParseLldpNeighbors parsea `lldpcli -f json show neighbors`:
+//
+//	{"lldp":{"interface":[{"name","chassis":{<nombre>:{id{type,value},descr,
+//	  mgmt-ip,capability[]}},"port":{id{type,value},descr}}]}}
+//
+// Defensivo: campos ausentes o de tipo inesperado se ignoran (best-effort de
+// encoding/json rellena lo compatible); interface también se acepta como
+// mapa nombre→objeto (versiones viejas de lldpd). Error solo si la raíz no
+// es JSON válido.
+func ParseLldpNeighbors(data []byte) ([]LldpNeighbor, error) {
+	var root struct {
+		Lldp struct {
+			Ifaces json.RawMessage `json:"interface"`
+		} `json:"lldp"`
+	}
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, err
+	}
+	if len(root.Lldp.Ifaces) == 0 || string(root.Lldp.Ifaces) == "null" {
+		return []LldpNeighbor{}, nil
+	}
+	var entries []json.RawMessage
+	if err := json.Unmarshal(root.Lldp.Ifaces, &entries); err != nil {
+		// Forma mapa: {"lan3": {...}, "lan1": {...}} (lldpd viejo)
+		var byName map[string]json.RawMessage
+		if err2 := json.Unmarshal(root.Lldp.Ifaces, &byName); err2 != nil {
+			// Ni array ni mapa: forma desconocida → sin datos, no error
+			return []LldpNeighbor{}, nil
+		}
+		names := make([]string, 0, len(byName))
+		for name := range byName {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		neighbors := make([]LldpNeighbor, 0, len(names))
+		for _, name := range names {
+			// En la forma mapa el nombre de la interfaz es la CLAVE
+			neighbors = append(neighbors, parseLldpEntry(byName[name], name))
+		}
+		return neighbors, nil
+	}
+	neighbors := make([]LldpNeighbor, 0, len(entries))
+	for _, raw := range entries {
+		neighbors = append(neighbors, parseLldpEntry(raw, ""))
+	}
+	return neighbors, nil
+}
+
+// parseLldpEntry parsea una entrada de interface (nunca entra en pánico:
+// los Unmarshal secundarios ignoran el error a propósito — best-effort).
+// fallbackName es la clave de la forma mapa (lldpd viejo, sin campo "name").
+func parseLldpEntry(raw json.RawMessage, fallbackName string) LldpNeighbor {
+	var e struct {
+		Name    string                     `json:"name"`
+		Chassis map[string]json.RawMessage `json:"chassis"`
+		Port    json.RawMessage            `json:"port"`
+	}
+	// Best-effort: un campo de tipo inesperado (chassis como cadena, port
+	// como número…) no invalida el resto de la entrada.
+	_ = json.Unmarshal(raw, &e)
+	n := LldpNeighbor{Port: e.Name}
+	if n.Port == "" {
+		n.Port = fallbackName
+	}
+
+	// Chassis: mapa nombre→datos (normalmente uno; el primero ordenado)
+	keys := make([]string, 0, len(e.Chassis))
+	for k := range e.Chassis {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	if len(keys) > 0 {
+		n.Chassis = keys[0]
+		var ch struct {
+			ID struct {
+				Type  string `json:"type"`
+				Value string `json:"value"`
+			} `json:"id"`
+			MgmtIP json.RawMessage `json:"mgmt-ip"`
+			Caps   []struct {
+				Type    string `json:"type"`
+				Enabled bool   `json:"enabled"`
+			} `json:"capability"`
+		}
+		_ = json.Unmarshal(e.Chassis[keys[0]], &ch) // best-effort (ver cabecera)
+		if ch.ID.Type == "mac" {
+			n.ChassisMac = strings.ToUpper(ch.ID.Value)
+		}
+		if n.Chassis == "" {
+			n.Chassis = ch.ID.Value
+		}
+		n.Mgmt = firstMgmtIP(ch.MgmtIP)
+		for _, cap := range ch.Caps {
+			if cap.Enabled && cap.Type != "" {
+				n.Caps = append(n.Caps, cap.Type)
+			}
+		}
+	}
+
+	// Puerto remoto: descr; si no, el id
+	if len(e.Port) > 0 {
+		var p struct {
+			ID struct {
+				Value string `json:"value"`
+			} `json:"id"`
+			Descr string `json:"descr"`
+		}
+		if json.Unmarshal(e.Port, &p) == nil {
+			n.PortDesc = p.Descr
+			if n.PortDesc == "" {
+				n.PortDesc = p.ID.Value
+			}
+		}
+	}
+	return n
+}
+
+// firstMgmtIP: mgmt-ip viene como array (lldpd actual) o string suelto.
+func firstMgmtIP(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var list []string
+	if err := json.Unmarshal(raw, &list); err == nil {
+		for _, ip := range list {
+			if ip != "" {
+				return ip
+			}
+		}
+		return ""
+	}
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		return single
+	}
+	return ""
+}

--- a/agent/probe/lldp_test.go
+++ b/agent/probe/lldp_test.go
@@ -1,0 +1,219 @@
+// lldp_test.go — parser de `lldpcli -f json show neighbors` (fixture
+// portado de adapters/lldp_test.go al mover el parser a probe, #489) y
+// comportamiento de la sonda probeLldp con runner fake.
+package probe
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Fixture realista (lldpd 1.0.x en OpenWrt): switch gestionado GS308E con
+// mgmt-ip (array) y caps Bridge, un AP anunciándose (mgmt-ip como string
+// suelto), un equipo sin mgmt-ip ni descr de puerto.
+const lldpcliFixture = `{
+  "lldp": {
+    "interface": [
+      {
+        "name": "lan3",
+        "via": "LLDP",
+        "rid": "2",
+        "age": "0 day, 00:01:12",
+        "chassis": {
+          "GS308E": {
+            "id": {"type": "mac", "value": "28:c6:8e:1d:90:44"},
+            "descr": "Netgear GS308E 8-Port Gigabit Smart Managed Plus Switch",
+            "mgmt-ip": ["192.168.8.13", "fe80::2ac6:8eff:fe1d:9044"],
+            "capability": [
+              {"type": "Bridge", "enabled": true},
+              {"type": "Router", "enabled": false}
+            ]
+          }
+        },
+        "port": {
+          "id": {"type": "ifname", "value": "ge5"},
+          "descr": "ge5",
+          "ttl": "120"
+        }
+      },
+      {
+        "name": "lan1",
+        "chassis": {
+          "AP-patio": {
+            "id": {"type": "mac", "value": "aa:bb:cc:dd:ee:ff"},
+            "mgmt-ip": "192.168.8.20"
+          }
+        },
+        "port": {"id": {"type": "local", "value": "0.2"}}
+      },
+      {
+        "name": "lan4",
+        "chassis": {
+          " Equipo-sin-nombre ": {
+            "id": {"type": "mac", "value": "11:22:33:44:55:66"}
+          }
+        }
+      }
+    ]
+  }
+}`
+
+func TestParseLldpNeighborsFixture(t *testing.T) {
+	nbs, err := ParseLldpNeighbors([]byte(lldpcliFixture))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(nbs) != 3 {
+		t.Fatalf("vecinos: %d", len(nbs))
+	}
+	// Orden estable: el array llega lan3, lan1, lan4
+	got := nbs[0]
+	if got.Port != "lan3" || got.Chassis != "GS308E" || got.ChassisMac != "28:C6:8E:1D:90:44" {
+		t.Fatalf("n[0]: %+v", got)
+	}
+	if got.Mgmt != "192.168.8.13" {
+		t.Fatalf("mgmt: %q", got.Mgmt)
+	}
+	if !reflect.DeepEqual(got.Caps, []string{"Bridge"}) {
+		t.Fatalf("caps: %v", got.Caps)
+	}
+	if got.PortDesc != "ge5" {
+		t.Fatalf("portDesc: %q", got.PortDesc)
+	}
+	// mgmt-ip como string suelto + port descr ausente → id del puerto
+	if nbs[1].Mgmt != "192.168.8.20" || nbs[1].PortDesc != "0.2" {
+		t.Fatalf("n[1]: %+v", nbs[1])
+	}
+	// sin mgmt-ip ni port
+	if nbs[2].Mgmt != "" || nbs[2].PortDesc != "" {
+		t.Fatalf("n[2]: %+v", nbs[2])
+	}
+}
+
+func TestParseLldpNeighborsDefensivo(t *testing.T) {
+	// Raíz no JSON → error (el caller reintenta; NO es lldpd ausente)
+	if _, err := ParseLldpNeighbors([]byte("lldpd is not running")); err == nil {
+		t.Fatal("no JSON debería dar error")
+	}
+	// Formas vacías → sin vecinos, sin error
+	for _, in := range []string{`{}`, `{"lldp":{}}`, `{"lldp":{"interface":null}}`, `{"lldp":{"interface":[]}}`, `null`} {
+		neighbors, err := ParseLldpNeighbors([]byte(in))
+		if err != nil || len(neighbors) != 0 {
+			t.Fatalf("%s → %v %v", in, neighbors, err)
+		}
+	}
+	// Forma mapa (lldpd viejo): {"interface": {"lan3": {...}}}; la CLAVE es
+	// el puerto local.
+	mapForm := `{"lldp":{"interface":{"lan3":{"chassis":{"sw1":{"id":{"type":"mac","value":"AA:BB:CC:DD:EE:FF"}}}}}}}`
+	neighbors, err := ParseLldpNeighbors([]byte(mapForm))
+	if err != nil || len(neighbors) != 1 {
+		t.Fatalf("forma mapa: %v %v", neighbors, err)
+	}
+	if neighbors[0].Port != "lan3" || neighbors[0].ChassisMac != "AA:BB:CC:DD:EE:FF" || neighbors[0].Chassis != "sw1" {
+		t.Fatalf("forma mapa parseada: %+v", neighbors[0])
+	}
+	// Tipos inesperados por todas partes: nunca panic, campos vacíos
+	weird := `{"lldp":{"interface":[
+		{"name":"lan1","chassis":"una cadena","port":123},
+		{"name":"lan2","chassis":{"x":{"id":"no-objeto","mgmt-ip":42,"capability":"no-array"}},"port":{"id":{}}},
+		42,
+		null
+	]}}`
+	neighbors, err = ParseLldpNeighbors([]byte(weird))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(neighbors) != 4 {
+		t.Fatalf("entradas raras: %d", len(neighbors))
+	}
+	if neighbors[0].Port != "lan1" || neighbors[0].Chassis != "" || neighbors[0].PortDesc != "" {
+		t.Fatalf("chassis cadena: %+v", neighbors[0])
+	}
+	if neighbors[1].Port != "lan2" || neighbors[1].ChassisMac != "" || neighbors[1].Mgmt != "" {
+		t.Fatalf("subcampos raros: %+v", neighbors[1])
+	}
+	if neighbors[2].Port != "" || neighbors[2].Chassis != "" || neighbors[2].Caps != nil {
+		t.Fatalf("entrada no-objeto: %+v", neighbors[2])
+	}
+	if neighbors[3].Port != "" || neighbors[3].ChassisMac != "" {
+		t.Fatalf("entrada null: %+v", neighbors[3])
+	}
+	// interface con forma ni array ni mapa → sin datos, no error
+	neighbors, err = ParseLldpNeighbors([]byte(`{"lldp":{"interface":42}}`))
+	if err != nil || len(neighbors) != 0 {
+		t.Fatalf("interface escalar: %v %v", neighbors, err)
+	}
+}
+
+// TestProberLldp: contrato de disponibilidad de la sonda (#489).
+func TestProberLldp(t *testing.T) {
+	ctx := context.Background()
+
+	// lldpd NO instalado: command -v falla → Available=false.
+	p := NewProber(fakeRunner{outs: map[string]string{}}, Options{})
+	ld := p.probeLldp(ctx)
+	if ld == nil || ld.Available || ld.Neighbors != nil {
+		t.Fatalf("sin lldpd: %+v", ld)
+	}
+
+	// Instalado con vecinos: fixture completo.
+	p = NewProber(fakeRunner{outs: map[string]string{
+		CmdLldpCheck:     "/usr/sbin/lldpcli\n",
+		CmdLldpNeighbors: lldpcliFixture,
+	}}, Options{})
+	ld = p.probeLldp(ctx)
+	if ld == nil || !ld.Available || len(ld.Neighbors) != 3 {
+		t.Fatalf("con vecinos: %+v", ld)
+	}
+
+	// Instalado, lldpd parado: check OK pero lldpcli sin salida →
+	// Available=true con Neighbors nil (sonda fallida, no "no instalado").
+	p = NewProber(fakeRunner{outs: map[string]string{
+		CmdLldpCheck: "/usr/sbin/lldpcli\n",
+	}}, Options{})
+	ld = p.probeLldp(ctx)
+	if ld == nil || !ld.Available || ld.Neighbors != nil {
+		t.Fatalf("parado: %+v", ld)
+	}
+
+	// Instalado, cero vecinos: interface [] → vacío honesto, no nil.
+	p = NewProber(fakeRunner{outs: map[string]string{
+		CmdLldpCheck:     "/usr/sbin/lldpcli\n",
+		CmdLldpNeighbors: `{"lldp":{"interface":[]}}`,
+	}}, Options{})
+	ld = p.probeLldp(ctx)
+	if ld == nil || !ld.Available || ld.Neighbors == nil || len(ld.Neighbors) != 0 {
+		t.Fatalf("cero vecinos: %+v", ld)
+	}
+}
+
+// TestPayloadLldpWire: nil vs vacío viaja distinto en el JSON (contrato del
+// anti-parpadeo del server). Sin omitempty en Neighbors a propósito.
+func TestPayloadLldpWire(t *testing.T) {
+	mustJSON := func(v any) string {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return string(b)
+	}
+	// Sección presente con vecinos
+	if s := mustJSON(PayloadData{Lldp: &LldpData{Available: true, Neighbors: []LldpNeighbor{{Port: "lan3"}}}}); !strings.Contains(s, `"neighbors":[{`) {
+		t.Fatalf("wire con vecinos: %s", s)
+	}
+	// Sección presente, sonda fallida: neighbors null (no ausente)
+	if s := mustJSON(PayloadData{Lldp: &LldpData{Available: true}}); !strings.Contains(s, `"neighbors":null`) {
+		t.Fatalf("wire sonda fallida: %s", s)
+	}
+	// Sección ausente (push event-driven): nada de lldp en el JSON
+	if s := mustJSON(PayloadData{}); strings.Contains(s, "lldp") {
+		t.Fatalf("wire sin sección: %s", s)
+	}
+	// Disponible sin vecinos (vacío honesto): "neighbors":[]
+	if s := mustJSON(PayloadData{Lldp: &LldpData{Available: true, Neighbors: []LldpNeighbor{}}}); !strings.Contains(s, `"neighbors":[]`) {
+		t.Fatalf("wire vacío honesto: %s", s)
+	}
+}

--- a/agent/probe/local.go
+++ b/agent/probe/local.go
@@ -113,6 +113,9 @@ func (p *Prober) Build(ctx context.Context, router, version string) *Payload {
 	pl.Data.Dawn = p.probeDawn(ctx)
 	pl.Data.Usteer = p.probeUsteer(ctx)
 	pl.Data.LuCI = p.probeLuCI(ctx)
+	// LLDP (#489): vecinos de lldpd en el payload del agente (antes solo
+	// llegaban por la sonda SSH del server, muerta para routers con agente).
+	pl.Data.Lldp = p.probeLldp(ctx)
 	// Discovery (#338): mDNS services + randomized MAC detection.
 	pl.Data.Discovery = p.probeDiscovery(ctx, pl.Data.Wireless)
 	// NetIf (#305): contadores por iface desde el MISMO /proc/net/dev que
@@ -380,6 +383,26 @@ func (p *Prober) probeFDB(ctx context.Context) *FDBData {
 		fd.Ports = []EthPort{}
 	}
 	return fd
+}
+
+// probeLldp: vecinos LLDP de lldpd (#489). Contrato: Available=false cuando
+// lldpcli no existe (hint "instala lldpd"); Available=true con Neighbors
+// nil si la sonda falla esta ronda (lldpd parado, salida no JSON); [] vacío
+// honesto cuando no hay vecinos. Solo en el sondeo completo (Build): los
+// pushes event-driven no re-sondean y el server conserva el último bueno.
+func (p *Prober) probeLldp(ctx context.Context) *LldpData {
+	if p.runBest(ctx, CmdLldpCheck, 0) == "" {
+		return &LldpData{Available: false}
+	}
+	out := p.runBest(ctx, CmdLldpNeighbors, 5*time.Second)
+	if out == "" {
+		return &LldpData{Available: true}
+	}
+	neighbors, err := ParseLldpNeighbors([]byte(out))
+	if err != nil {
+		return &LldpData{Available: true}
+	}
+	return &LldpData{Available: true, Neighbors: neighbors}
 }
 
 // probeLuCI: etiquetas de puertos/VLANs de LuCI (issue #258), si el router

--- a/agent/probe/payload.go
+++ b/agent/probe/payload.go
@@ -46,6 +46,10 @@ type PayloadData struct {
 	// Vlans: VLANs del bridge (issue #315, bridge vlan show). nil = sonda
 	// fallida o router sin bridge vlan filtering.
 	Vlans []VlanPort `json:"vlans,omitempty"`
+	// Lldp (#489): vecinos LLDP de lldpd. nil = sonda fallida en este push
+	// (el server conserva el último dato bueno); Available=false = lldpd
+	// no instalado (hint de UI).
+	Lldp *LldpData `json:"lldp,omitempty"`
 	// Discovery: mDNS services and randomized MAC detection (#338).
 	Discovery *DiscoveryData `json:"discovery,omitempty"`
 }

--- a/server-go/internal/adapters/agent.go
+++ b/server-go/internal/adapters/agent.go
@@ -574,6 +574,29 @@ func (l *Live) polledFromAgent(cfg RouterConfig, p *probe.Payload) *routerPolled
 	if p.Data.LuCI != nil {
 		out.luci = p.Data.LuCI
 	}
+	// LLDP (#489): vecinos del payload del agente (antes solo llegaban por
+	// la sonda SSH, muerta para routers con agente fresco). Resolución con
+	// anti-parpadeo: manda la sección buena del payload; una sección
+	// fallida (Available=true con Neighbors nil) o ausente (push
+	// event-driven) recicla la última cacheada. Available=false explícito =
+	// lldpd no instalado (hint de UI), y eso SÍ pisa lo cacheado.
+	resolveLldp := func() (nbs []LldpNeighbor, unavailable bool) {
+		ld := p.Data.Lldp
+		if ld == nil || (ld.Available && ld.Neighbors == nil) {
+			ld = nil
+			if cached != nil {
+				ld = cached.lldp
+			}
+		}
+		if ld == nil {
+			return nil, false
+		}
+		if !ld.Available {
+			return nil, true
+		}
+		return lldpFromProbe(ld.Neighbors), false
+	}
+	out.lldp, out.lldpUnavailable = resolveLldp()
 	// Discovery (#338): mDNS services + randomized MACs. Best-effort.
 	if p.Data.Discovery != nil {
 		out.discovery = p.Data.Discovery
@@ -629,8 +652,12 @@ func (l *Live) polledFromAgent(cfg RouterConfig, p *probe.Payload) *routerPolled
 	if sysSnap == nil && cached != nil {
 		sysSnap = cached.system
 	}
+	lldpSnap := p.Data.Lldp
+	if (lldpSnap == nil || (lldpSnap.Available && lldpSnap.Neighbors == nil)) && cached != nil {
+		lldpSnap = cached.lldp // conserva la última sección buena (#489)
+	}
 	l.extrasCache[cfg.ID] = &extrasSnapshot{ports: out.ports, radios: out.radios,
-		wireless: out.wireless, fdb: out.fdb, luci: out.luci, system: sysSnap}
+		wireless: out.wireless, fdb: out.fdb, luci: out.luci, system: sysSnap, lldp: lldpSnap}
 	l.mu.Unlock()
 
 	// Solo con un payload NUEVO alimentamos las series y el monitor de

--- a/server-go/internal/adapters/agent_lldp_test.go
+++ b/server-go/internal/adapters/agent_lldp_test.go
@@ -1,0 +1,73 @@
+// agent_lldp_test.go — #489: consumo de la sección lldp del payload del
+// agente en polledFromAgent, con el anti-parpadeo de pushes event-driven y
+// sondas fallidas (mismo patrón que system #441).
+package adapters
+
+import (
+	"testing"
+
+	"github.com/gnacho/netpulse/agent/probe"
+)
+
+func lldpAgentPayload(ts int64, lldp *probe.LldpData) *probe.Payload {
+	return &probe.Payload{
+		Router: "gateway", Ts: ts, Version: "test",
+		Data: probe.PayloadData{
+			System: &probe.SystemData{BridgeMAC: "94:83:c4:00:00:01"},
+			Lldp:   lldp,
+		},
+	}
+}
+
+var lldpGoodNeighbors = []probe.LldpNeighbor{
+	{Port: "lan3", Chassis: "GS308E", ChassisMac: "28:C6:8E:1D:90:44", Mgmt: "192.168.1.13", Caps: []string{"Bridge"}, PortDesc: "ge5"},
+}
+
+func TestPolledFromAgentLldp(t *testing.T) {
+	l := NewLive(nil, nil, []RouterConfig{{ID: "gateway", Host: "192.168.1.1", Name: "Gateway"}}, nil)
+	cfg := l.routers[0]
+
+	// 1. Push completo con vecinos: lldp poblado, disponible.
+	p := l.polledFromAgent(cfg, lldpAgentPayload(1, &probe.LldpData{Available: true, Neighbors: lldpGoodNeighbors}))
+	if len(p.lldp) != 1 || p.lldp[0].Chassis != "GS308E" || p.lldp[0].ChassisMac != "28:C6:8E:1D:90:44" {
+		t.Fatalf("lldp: %+v", p.lldp)
+	}
+	if p.lldpUnavailable {
+		t.Fatal("no debe marcar unavailable con vecinos")
+	}
+
+	// 2. Push event-driven SIN sección: conserva los vecinos (anti-parpadeo).
+	p = l.polledFromAgent(cfg, lldpAgentPayload(2, nil))
+	if len(p.lldp) != 1 || p.lldp[0].Chassis != "GS308E" {
+		t.Fatalf("event-driven perdió lldp: %+v", p.lldp)
+	}
+
+	// 3. Sonda fallida (Available=true, Neighbors nil): conserva el último bueno.
+	p = l.polledFromAgent(cfg, lldpAgentPayload(3, &probe.LldpData{Available: true}))
+	if len(p.lldp) != 1 {
+		t.Fatalf("sonda fallida perdió lldp: %+v", p.lldp)
+	}
+
+	// 4. Cero vecinos honesto (Available=true, []): pisa lo cacheado.
+	p = l.polledFromAgent(cfg, lldpAgentPayload(4, &probe.LldpData{Available: true, Neighbors: []probe.LldpNeighbor{}}))
+	if p.lldp == nil || len(p.lldp) != 0 {
+		t.Fatalf("vacío honesto: %+v", p.lldp)
+	}
+
+	// 5. lldpd desinstalado (Available=false): sin vecinos + hint de UI, y
+	// persiste en un push event-driven posterior.
+	p = l.polledFromAgent(cfg, lldpAgentPayload(5, &probe.LldpData{Available: false}))
+	if p.lldp != nil || !p.lldpUnavailable {
+		t.Fatalf("unavailable: lldp=%v flag=%v", p.lldp, p.lldpUnavailable)
+	}
+	p = l.polledFromAgent(cfg, lldpAgentPayload(6, nil))
+	if !p.lldpUnavailable {
+		t.Fatal("unavailable debe persistir sin sección")
+	}
+
+	// 6. Reinstalado con vecinos: vuelve a poblar.
+	p = l.polledFromAgent(cfg, lldpAgentPayload(7, &probe.LldpData{Available: true, Neighbors: lldpGoodNeighbors}))
+	if len(p.lldp) != 1 || p.lldpUnavailable {
+		t.Fatalf("reinstalado: %+v flag=%v", p.lldp, p.lldpUnavailable)
+	}
+}

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -156,8 +156,12 @@ type extrasSnapshot struct {
 	vlans    []VlanPort
 	// system (#441): última sección system BUENA del payload del agente.
 	// Los pushes event-driven (wireless-only) van sin ella; sin este cache
-	// las vitals del router parpadeaban a 0 entre pushes completos.
+	// las vitales del router parpadeaban a 0 entre pushes completos.
 	system *probe.SystemData
+	// lldp (#489): última sección lldp del payload. Mismo anti-parpadeo:
+	// los pushes event-driven van sin ella y la topología no debe perder
+	// los switches managed entre pushes completos.
+	lldp *probe.LldpData
 }
 
 // backhaulCacheTTL: el medio del uplink cambia muy raro; no se sondea cada 5 s.

--- a/server-go/internal/adapters/lldp.go
+++ b/server-go/internal/adapters/lldp.go
@@ -7,11 +7,11 @@ package adapters
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"sort"
 	"strings"
 	"time"
+
+	"github.com/gnacho/netpulse/agent/probe"
 )
 
 // lldpTimeout: timeout corto de la sonda (≤5 s, contrato C2).
@@ -76,7 +76,7 @@ func (c *OpenWrtClient) LldpNeighbors(ctx context.Context) ([]LldpNeighbor, erro
 	if c.lldpDownCached() {
 		return nil, ErrLldpUnavailable
 	}
-	out, err := c.pool.RunCtx(ctx, c.Host, "lldpcli -f json show neighbors", lldpTimeout)
+	out, err := c.pool.RunCtx(ctx, c.Host, probe.CmdLldpNeighbors, lldpTimeout)
 	if err != nil {
 		if isLldpUnavailable(err) {
 			c.cacheLldpDown()
@@ -84,13 +84,13 @@ func (c *OpenWrtClient) LldpNeighbors(ctx context.Context) ([]LldpNeighbor, erro
 		}
 		return nil, err
 	}
-	neighbors, perr := parseLldpNeighbors([]byte(out))
+	neighbors, perr := probe.ParseLldpNeighbors([]byte(out))
 	if perr != nil {
 		// Salida no JSON (p.ej. mensaje de error de lldpcli con exit 0):
 		// no es "no instalado", se reintenta en el próximo tick lento.
 		return nil, perr
 	}
-	return neighbors, nil
+	return lldpFromProbe(neighbors), nil
 }
 
 // isLldpUnavailable: el comando no existe en el router (exit 127 del shell,
@@ -104,142 +104,15 @@ func isLldpUnavailable(err error) bool {
 	return strings.Contains(msg, "status 127") || strings.Contains(msg, "not found")
 }
 
-// parseLldpNeighbors parsea `lldpcli -f json show neighbors`:
-//
-//	{"lldp":{"interface":[{"name","chassis":{<nombre>:{id{type,value},descr,
-//	  mgmt-ip,capability[]}},"port":{id{type,value},descr}}]}}
-//
-// Defensivo: campos ausentes o de tipo inesperado se ignoran (best-effort de
-// encoding/json rellena lo compatible); interface también se acepta como
-// mapa nombre→objeto (versiones viejas de lldpd). Error solo si la raíz no
-// es JSON válido.
-func parseLldpNeighbors(data []byte) ([]LldpNeighbor, error) {
-	var root struct {
-		Lldp struct {
-			Ifaces json.RawMessage `json:"interface"`
-		} `json:"lldp"`
+// lldpFromProbe: conversión probe.LldpNeighbor → LldpNeighbor (campos
+// idénticos; el parser vive en agent/probe desde #489 para compartirlo con
+// la sonda del agente).
+func lldpFromProbe(nbs []probe.LldpNeighbor) []LldpNeighbor {
+	out := make([]LldpNeighbor, len(nbs))
+	for i, n := range nbs {
+		out[i] = LldpNeighbor(n)
 	}
-	if err := json.Unmarshal(data, &root); err != nil {
-		return nil, err
-	}
-	if len(root.Lldp.Ifaces) == 0 || string(root.Lldp.Ifaces) == "null" {
-		return []LldpNeighbor{}, nil
-	}
-	var entries []json.RawMessage
-	if err := json.Unmarshal(root.Lldp.Ifaces, &entries); err != nil {
-		// Forma mapa: {"lan3": {...}, "lan1": {...}} (lldpd viejo)
-		var byName map[string]json.RawMessage
-		if err2 := json.Unmarshal(root.Lldp.Ifaces, &byName); err2 != nil {
-			// Ni array ni mapa: forma desconocida → sin datos, no error
-			return []LldpNeighbor{}, nil
-		}
-		names := make([]string, 0, len(byName))
-		for name := range byName {
-			names = append(names, name)
-		}
-		sort.Strings(names)
-		neighbors := make([]LldpNeighbor, 0, len(names))
-		for _, name := range names {
-			// En la forma mapa el nombre de la interfaz es la CLAVE
-			neighbors = append(neighbors, parseLldpEntry(byName[name], name))
-		}
-		return neighbors, nil
-	}
-	neighbors := make([]LldpNeighbor, 0, len(entries))
-	for _, raw := range entries {
-		neighbors = append(neighbors, parseLldpEntry(raw, ""))
-	}
-	return neighbors, nil
-}
-
-// parseLldpEntry parsea una entrada de interface (nunca entra en pánico:
-// los Unmarshal secundarios ignoran el error a propósito — best-effort).
-// fallbackName es la clave de la forma mapa (lldpd viejo, sin campo "name").
-func parseLldpEntry(raw json.RawMessage, fallbackName string) LldpNeighbor {
-	var e struct {
-		Name    string                     `json:"name"`
-		Chassis map[string]json.RawMessage `json:"chassis"`
-		Port    json.RawMessage            `json:"port"`
-	}
-	// Best-effort: un campo de tipo inesperado (chassis como cadena, port
-	// como número…) no invalida el resto de la entrada.
-	_ = json.Unmarshal(raw, &e)
-	n := LldpNeighbor{Port: e.Name}
-	if n.Port == "" {
-		n.Port = fallbackName
-	}
-
-	// Chassis: mapa nombre→datos (normalmente uno; el primero ordenado)
-	keys := make([]string, 0, len(e.Chassis))
-	for k := range e.Chassis {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	if len(keys) > 0 {
-		n.Chassis = keys[0]
-		var ch struct {
-			ID struct {
-				Type  string `json:"type"`
-				Value string `json:"value"`
-			} `json:"id"`
-			MgmtIP json.RawMessage `json:"mgmt-ip"`
-			Caps   []struct {
-				Type    string `json:"type"`
-				Enabled bool   `json:"enabled"`
-			} `json:"capability"`
-		}
-		_ = json.Unmarshal(e.Chassis[keys[0]], &ch) // best-effort (ver cabecera)
-		if ch.ID.Type == "mac" {
-			n.ChassisMac = strings.ToUpper(ch.ID.Value)
-		}
-		if n.Chassis == "" {
-			n.Chassis = ch.ID.Value
-		}
-		n.Mgmt = firstMgmtIP(ch.MgmtIP)
-		for _, cap := range ch.Caps {
-			if cap.Enabled && cap.Type != "" {
-				n.Caps = append(n.Caps, cap.Type)
-			}
-		}
-	}
-
-	// Puerto remoto: descr; si no, el id
-	if len(e.Port) > 0 {
-		var p struct {
-			ID struct {
-				Value string `json:"value"`
-			} `json:"id"`
-			Descr string `json:"descr"`
-		}
-		if json.Unmarshal(e.Port, &p) == nil {
-			n.PortDesc = p.Descr
-			if n.PortDesc == "" {
-				n.PortDesc = p.ID.Value
-			}
-		}
-	}
-	return n
-}
-
-// firstMgmtIP: mgmt-ip viene como array (lldpd actual) o string suelto.
-func firstMgmtIP(raw json.RawMessage) string {
-	if len(raw) == 0 || string(raw) == "null" {
-		return ""
-	}
-	var list []string
-	if err := json.Unmarshal(raw, &list); err == nil {
-		for _, ip := range list {
-			if ip != "" {
-				return ip
-			}
-		}
-		return ""
-	}
-	var single string
-	if err := json.Unmarshal(raw, &single); err == nil {
-		return single
-	}
-	return ""
+	return out
 }
 
 // lldpNeighborOnPort: vecino anunciado en un puerto local concreto (nil si

--- a/server-go/internal/adapters/lldp_test.go
+++ b/server-go/internal/adapters/lldp_test.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/gnacho/netpulse/agent/probe"
 )
 
 // Fixture realista (lldpd 1.0.x en OpenWrt).
@@ -83,106 +85,30 @@ const lldpcliFixture = `{
   }
 }`
 
-func TestParseLldpNeighborsFixture(t *testing.T) {
-	neighbors, err := parseLldpNeighbors([]byte(lldpcliFixture))
+// El parser vive en agent/probe desde #489 (mismo comando para la sonda del
+// agente y la SSH); aquí solo queda la conversión de tipos.
+func TestLldpFromProbe(t *testing.T) {
+	nbs, err := probe.ParseLldpNeighbors([]byte(lldpcliFixture))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(neighbors) != 3 {
-		t.Fatalf("neighbors: %d", len(neighbors))
+	got := lldpFromProbe(nbs)
+	if len(got) != len(nbs) {
+		t.Fatalf("longitud: %d vs %d", len(got), len(nbs))
 	}
-	// Switch GS308E en lan3: mgmt-ip array (se coge la primera), caps enabled
-	sw := neighbors[0]
-	if sw.Port != "lan3" || sw.Chassis != "GS308E" || sw.ChassisMac != "28:C6:8E:1D:90:44" {
-		t.Fatalf("gs308e: %+v", sw)
+	if got[0].Port != "lan3" || got[0].Chassis != "GS308E" || got[0].ChassisMac != "28:C6:8E:1D:90:44" {
+		t.Fatalf("conversión n[0]: %+v", got[0])
 	}
-	if sw.Mgmt != "192.168.8.13" {
-		t.Fatalf("mgmt: %q", sw.Mgmt)
+	// métodos del tipo adapters intactos tras la conversión
+	if info := got[0].info(); info.Chassis != "GS308E" {
+		t.Fatalf("info(): %+v", info)
 	}
-	if len(sw.Caps) != 1 || sw.Caps[0] != "Bridge" {
-		t.Fatalf("caps (Router disabled no cuenta): %v", sw.Caps)
+	if got[0].displayName() != "GS308E" {
+		t.Fatalf("displayName(): %q", got[0].displayName())
 	}
-	if sw.PortDesc != "ge5" {
-		t.Fatalf("portDesc: %q", sw.PortDesc)
-	}
-	if info := sw.info(); info.Chassis != "GS308E" || info.Mgmt != "192.168.8.13" || info.Caps != "Bridge" || info.PortDesc != "ge5" {
-		t.Fatalf("info: %+v", info)
-	}
-	// AP anunciándose: mgmt-ip como STRING suelto, dos caps enabled
-	ap := neighbors[1]
-	if ap.Port != "lan1" || ap.Chassis != "EAP225" || ap.ChassisMac != "B0:4A:39:2E:77:10" {
-		t.Fatalf("ap: %+v", ap)
-	}
-	if ap.Mgmt != "192.168.8.4" {
-		t.Fatalf("mgmt string suelto: %q", ap.Mgmt)
-	}
-	if len(ap.Caps) != 2 || ap.Caps[0] != "Bridge" || ap.Caps[1] != "Wlan" {
-		t.Fatalf("caps ap: %v", ap.Caps)
-	}
-	if ap.info().Caps != "Bridge, Wlan" {
-		t.Fatalf("caps unidas: %q", ap.info().Caps)
-	}
-	// Equipo sin mgmt-ip ni descr de puerto: PortDesc cae al id
-	pc := neighbors[2]
-	if pc.Port != "lan2" || pc.Mgmt != "" {
-		t.Fatalf("mini-pc: %+v", pc)
-	}
-	if pc.PortDesc != "eno1" {
-		t.Fatalf("portDesc fallback id: %q", pc.PortDesc)
-	}
-}
-
-func TestParseLldpNeighborsDefensivo(t *testing.T) {
-	// Raíz no JSON → error (el caller reintenta; NO es lldpd ausente)
-	if _, err := parseLldpNeighbors([]byte("lldpd is not running")); err == nil {
-		t.Fatal("no JSON debería dar error")
-	}
-	// Formas vacías → sin vecinos, sin error
-	for _, in := range []string{`{}`, `{"lldp":{}}`, `{"lldp":{"interface":null}}`, `{"lldp":{"interface":[]}}`, `null`} {
-		neighbors, err := parseLldpNeighbors([]byte(in))
-		if err != nil || len(neighbors) != 0 {
-			t.Fatalf("%s → %v %v", in, neighbors, err)
-		}
-	}
-	// Forma mapa (lldpd viejo): {"interface": {"lan3": {...}}}
-	mapForm := `{"lldp":{"interface":{"lan3":{"chassis":{"sw1":{"id":{"type":"mac","value":"AA:BB:CC:DD:EE:FF"}}}}}}}`
-	neighbors, err := parseLldpNeighbors([]byte(mapForm))
-	if err != nil || len(neighbors) != 1 {
-		t.Fatalf("forma mapa: %v %v", neighbors, err)
-	}
-	if neighbors[0].Port != "lan3" || neighbors[0].ChassisMac != "AA:BB:CC:DD:EE:FF" || neighbors[0].Chassis != "sw1" {
-		t.Fatalf("forma mapa parseada: %+v", neighbors[0])
-	}
-	// Tipos inesperados por todas partes: nunca panic, campos vacíos
-	weird := `{"lldp":{"interface":[
-		{"name":"lan1","chassis":"una cadena","port":123},
-		{"name":"lan2","chassis":{"x":{"id":"no-objeto","mgmt-ip":42,"capability":"no-array"}},"port":{"id":{}}},
-		42,
-		null
-	]}}`
-	neighbors, err = parseLldpNeighbors([]byte(weird))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(neighbors) != 4 {
-		t.Fatalf("entradas raras: %d", len(neighbors))
-	}
-	if neighbors[0].Port != "lan1" || neighbors[0].Chassis != "" || neighbors[0].PortDesc != "" {
-		t.Fatalf("chassis cadena: %+v", neighbors[0])
-	}
-	if neighbors[1].Port != "lan2" || neighbors[1].ChassisMac != "" || neighbors[1].Mgmt != "" {
-		t.Fatalf("subcampos raros: %+v", neighbors[1])
-	}
-	if neighbors[2].Port != "" || neighbors[2].Chassis != "" || neighbors[2].Caps != nil {
-		t.Fatalf("entrada no-objeto: %+v", neighbors[2])
-	}
-	if neighbors[3].Port != "" || neighbors[3].ChassisMac != "" {
-		t.Fatalf("entrada null: %+v", neighbors[3])
-	}
-	// interface con forma ni array ni mapa → sin datos, no error
-	neighbors, err = parseLldpNeighbors([]byte(`{"lldp":{"interface":42}}`))
-	if err != nil || len(neighbors) != 0 {
-		t.Fatalf("interface escalar: %v %v", neighbors, err)
+	// nil probe → slice vacío no nil (contrato: "sin datos", no panic)
+	if empty := lldpFromProbe(nil); empty == nil || len(empty) != 0 {
+		t.Fatalf("nil: %+v", empty)
 	}
 }
 


### PR DESCRIPTION
## What

LLDP neighbour collection only ran over SSH from the server, and only in the Tier-0 poll path. Since the agent is now the recommended install, routers reporting through it got zero LLDP: no managed-switch promotion in the topology map, no `Device.Lldp` identification, no "install lldpd" hint.

## How

- **Agent** (`agent/probe`): new `probeLldp` in the full probe cycle runs `command -v lldpcli` (installation check) and `lldpcli -f json show neighbors`. The payload gains an `lldp` section with an explicit contract: `available:false` = lldpd not installed (drives the UI hint); `neighbors:null` = probe failed this round; `neighbors:[]` = honest zero neighbours. Deliberately absent from event-driven pushes.
- **Shared parser**: the `lldpcli` parser moved from `adapters/lldp.go` to `agent/probe` following the codebase pattern (commands and parsers live in probe; adapters reuses them over SSH). The SSH path now calls the same `probe.ParseLldpNeighbors` and converts (struct conversion, identical fields).
- **Server** (`polledFromAgent`): resolves LLDP from the payload with the same anti-flicker pattern as system vitals (#441): a failed probe or an event-driven push without the section recycles the last good section from `extrasSnapshot`; an explicit `available:false` does override and persists.
- Backwards compatible: old agents send no `lldp` section and behave exactly as before.

## Verification

- Agent suite 9/9 and server suite 36/36 green; new tests cover the realistic lldpd fixture, degenerate JSON forms, the probe availability contract, the nil-vs-empty wire distinction, and six wiring cases (anti-flicker, honest empty, uninstall, reinstall).
- Live E2E on a preview CT: the amd64 agent running on a machine without lldpd produced `lldpAvailable: false` in `GET /api/overview` through the full chain (probe → payload → ingest → view-model), while an agent on a router with lldpd installed reported no flag. Test rig fully removed afterwards.
- Network reality check documented in the issue: a conformant 802.1D switch (like the test fleet's gateway) filters LLDP multicast, so neighbours only appear between directly cabled equipment or across unmanaged switches.

Closes #489