### PR TITLE
docs(changelog): cover firmware upgrades page in 2.26.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 - **Vecinos LLDP en el payload del agente (#489)**: el agente sondea `lldpcli` en su ciclo completo e incluye los vecinos (puerto, chasis, IP de gestión, capacidades, puerto remoto) en el push. Hasta ahora la recolección LLDP solo existía en la vía SSH del server, muerta para routers sondeados por agente (el camino recomendado de instalación), de modo que la topología nunca promovía switches gestionados ni identificaba vecinos en esas flotas. El contrato es explícito: `available:false` cuando lldpd no está instalado (alimenta el hint de la UI), vecinos ausentes si la sonda falla esa ronda (anti-parpadeo como las vitales) y lista vacía honesta cuando no hay vecinos. El parser de `lldpcli` pasa a vivir en `agent/probe` compartido por ambas vías. Nota de red: un switch conforme 802.1D filtra el multicast LLDP, así que los vecinos solo aparecen entre equipos directamente cableados o a través de switches no gestionados.
 
+### Changed
+
+- **Página de actualizaciones de firmware más segura (#477, con #494 aplazado)**: la lista solo incluye routers OpenWrt/GL.iNet con agente (los switches gestionados y los dispositivos solo-beacon desaparecen de la página), el formulario se prefiere con el modelo y target detectados por el propio agente y arrancar un upgrade exige confirmar el objetivo (versión actual a objetivo, URL de la imagen, verificación sha256 y aviso de reinicio). Los errores de upgrade antiguos de la tarjeta llevan marca de tiempo relativa para que un fallo viejo no se lea como agente caído. Las actualizaciones programadas quedan como seguimiento (#494).
+
 ## [2.26.4] - 2026-09-03
 
 ### Added


### PR DESCRIPTION
The 2.26.5 entry only covered #489 (LLDP); this documents the firmware upgrades page from #495 (OpenWrt-only list, target confirmation, board autodetect, relative timestamps on stale errors) and notes #494 as the scheduled-upgrades follow-up.