### PR TITLE
chore(release): v2.26.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 - **Vecinos LLDP en el payload del agente (#489)**: el agente sondea `lldpcli` en su ciclo completo e incluye los vecinos (puerto, chasis, IP de gestión, capacidades, puerto remoto) en el push. Hasta ahora la recolección LLDP solo existía en la vía SSH del server, muerta para routers sondeados por agente (el camino recomendado de instalación), de modo que la topología nunca promovía switches gestionados ni identificaba vecinos en esas flotas. El contrato es explícito: `available:false` cuando lldpd no está instalado (alimenta el hint de la UI), vecinos ausentes si la sonda falla esa ronda (anti-parpadeo como las vitales) y lista vacía honesta cuando no hay vecinos. El parser de `lldpcli` pasa a vivir en `agent/probe` compartido por ambas vías. Nota de red: un switch conforme 802.1D filtra el multicast LLDP, así que los vecinos solo aparecen entre equipos directamente cableados o a través de switches no gestionados.
 
+## [2.26.6] - 2026-09-03
+
 ### Changed
 
 - **Página de actualizaciones de firmware más segura (#477, con #494 aplazado)**: la lista solo incluye routers OpenWrt/GL.iNet con agente (los switches gestionados y los dispositivos solo-beacon desaparecen de la página), el formulario se prefiere con el modelo y target detectados por el propio agente y arrancar un upgrade exige confirmar el objetivo (versión actual a objetivo, URL de la imagen, verificación sha256 y aviso de reinicio). Los errores de upgrade antiguos de la tarjeta llevan marca de tiempo relativa para que un fallo viejo no se lea como agente caído. Las actualizaciones programadas quedan como seguimiento (#494).

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.26.5",
+  "version": "2.26.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.26.5",
+      "version": "2.26.6",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.26.5",
+  "version": "2.26.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -51,7 +51,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.26.5"
+var Version = "2.26.6"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Version bump to 2.26.6 and its changelog entry (firmware upgrades page, #495). v2.26.5 shipped with LLDP only; the firmware work merged after its tag. Replaces #497 (branched off a stale local main).