### PR TITLE
fix(agent): discover wired clients behind non-standard bridge ports (#506)

### DIFF
--- a/agent/probe/probe.go
+++ b/agent/probe/probe.go
@@ -92,11 +92,15 @@ const (
 	// No asume `br-lan` ni `brctl`: detecta el bridge real (br-lan o br0) y usa
 	// `bridge fdb show` como fallback cuando brctl no está (OpenWrt/GLuON
 	// modernos usan iproute2). Issue #253.
+	// La vía bridge excluye las entradas LOCALES (flag "permanent": la MAC del
+	// propio bridge registrada en cada puerto) para paridad con brctl ($3=="no"
+	// allí); sin esto el server ve la MAC propia aprendida en el puerto y lo
+	// clasifica como uplink, descartando TODOS sus clientes cableados (#506).
 	CmdBridgeFDB = `BR=br-lan; [ -d /sys/class/net/$BR ] || BR=br0; ` +
 		`echo "==PORTS=="; for d in /sys/class/net/$BR/brif/*; do [ -r "$d/port_no" ] && echo "$(cat $d/port_no) $(basename $d)"; done; ` +
 		`echo "==MACS=="; if command -v brctl >/dev/null 2>&1; then ` +
 		`brctl showmacs $BR 2>/dev/null | awk 'NR>1 && $3=="no" {print $1, $2}'; ` +
-		`else bridge fdb show br $BR 2>/dev/null | awk 'NF>=3 && $1!="01:" && $1!="33:33:" && $1!="ff:ff:" && $1!="00:00:00:00:00:00" {for(i=1;i<=NF;i++) if($i=="dev"){print $(i+1), $1}}'; fi`
+		`else bridge fdb show br $BR 2>/dev/null | awk 'NF>=3 && $1!="01:" && $1!="33:33:" && $1!="ff:ff:" && $1!="00:00:00:00:00:00" && $0 !~ /permanent/ {for(i=1;i<=NF;i++) if($i=="dev"){print $(i+1), $1}}'; fi`
 	CmdBridgeMAC       = "cat /sys/class/net/br-lan/address 2>/dev/null || cat /sys/class/net/br0/address 2>/dev/null"
 	CmdUbusSystemBoard = "ubus call system board"
 	CmdUbusSystemInfo  = "ubus call system info"

--- a/agent/probe/probe.go
+++ b/agent/probe/probe.go
@@ -814,7 +814,28 @@ func NaturalLess(a, b string) bool {
 	return a < b
 }
 
-var fdbPortRe = regexp.MustCompile(`^(lan\d+|wan|eth\d+|swp\d+|en[a-z0-9]+)$`)
+// Filtro de puertos del FDB (#506): DENYLIST, no allowlist. El allowlist
+// histórico (lan\d+|wan|eth\d+|swp\d+|en...) descartaba en silencio MACs
+// aprendidas en puertos con nombres no enumerados: las jaulas SFP del BPI-R4
+// se llaman "sfp-lan"/"sfp-wan" (openwrt,netdev-name, 25.12+) y sus
+// dispositivos cableados jamás llegaban a descubrirse. Ahora vale cualquier
+// puerto MIEMBRO del bridge (los no-miembros ya no resuelven en ==PORTS==)
+// salvo los wireless (clientes que llegan por la sección wireless) y las
+// interfaces virtuales.
+var (
+	fdbWirelessRe = regexp.MustCompile(`^(phy\d+-ap|wlan)`)
+	fdbVirtualRe  = regexp.MustCompile(`^(br|lo|veth|wg|tun|tap|ppp|sit|ip6|gre|erspan|dummy|macv|ifb)`)
+)
+
+// fdbPortWired: ¿cuenta este puerto como cableado para el mapa MAC→puerto?
+// Las subinterfaces VLAN (lan1.10, eth0.100) tampoco cuentan: el FDB de un
+// bridge con VLAN filtering reporta el puerto físico.
+func fdbPortWired(port string) bool {
+	if port == "" || strings.ContainsAny(port, ".@") {
+		return false
+	}
+	return !fdbWirelessRe.MatchString(port) && !fdbVirtualRe.MatchString(port)
+}
 
 // ParseBridgeFdb parsea la salida ==PORTS==/==MACS== → MAC aprendida → puerto.
 // Acepta dos formatos en ==MACS==: brctl (`<port_no> <mac>`) y
@@ -849,7 +870,7 @@ func ParseBridgeFdb(out string) map[string]string {
 			portNames[name] = name // puerto también localizable por nombre (bridge fdb)
 		case 'm':
 			no, mac := p[0], p[1]
-			if port, ok := portNames[no]; ok && mac != "" && fdbPortRe.MatchString(port) {
+			if port, ok := portNames[no]; ok && mac != "" && fdbPortWired(port) {
 				m[strings.ToUpper(mac)] = port
 			}
 		}

--- a/agent/probe/probe_test.go
+++ b/agent/probe/probe_test.go
@@ -371,6 +371,46 @@ func TestParseFdbExcluyeWireless(t *testing.T) {
 	}
 }
 
+// TestParseFdbDenylistPuertos — #506: el allowlist histórico descartaba en
+// silencio puertos físicos con nombres no enumerados (las jaulas SFP del
+// BPI-R4 se llaman sfp-lan/sfp-wan; también "lan" suelto o usb0). El filtro
+// invertido conserva cualquier miembro físico del bridge y solo excluye
+// wireless (phy*-ap*, wlan*) y virtuales (br*, lo, veth*, wg*, túneles,
+// subinterfaces VLAN).
+func TestParseFdbDenylistPuertos(t *testing.T) {
+	out := "==PORTS==\n" +
+		"1 sfp-lan\n2 sfp-wan\n3 eth1\n4 lan\n5 usb0\n6 swp1\n7 enp2s0\n" +
+		"8 phy0-ap0\n9 phy1-ap1\n10 wlan0\n11 br-lan\n12 br0\n13 lo\n" +
+		"14 veth0\n15 wg0\n16 tunl0\n17 tap0\n18 pppoe-wan\n19 lan1.10\n" +
+		"==MACS==\n" +
+		// sfp-lan resuelto por port_no (vía brctl); el resto por nombre.
+		"1 aa:00:00:00:00:01\n" +
+		"sfp-wan aa:00:00:00:00:02\neth1 aa:00:00:00:00:03\nlan aa:00:00:00:00:04\n" +
+		"usb0 aa:00:00:00:00:05\nswp1 aa:00:00:00:00:06\nenp2s0 aa:00:00:00:00:07\n" +
+		"phy0-ap0 bb:00:00:00:00:01\nphy1-ap1 bb:00:00:00:00:02\nwlan0 bb:00:00:00:00:03\n" +
+		"br-lan bb:00:00:00:00:04\nbr0 bb:00:00:00:00:05\nlo bb:00:00:00:00:06\nveth0 bb:00:00:00:00:07\n" +
+		"wg0 bb:00:00:00:00:08\ntunl0 bb:00:00:00:00:09\ntap0 bb:00:00:00:00:0a\n" +
+		"pppoe-wan bb:00:00:00:00:0b\nlan1.10 bb:00:00:00:00:0c\n"
+	fdb := ParseBridgeFdb(out)
+	want := map[string]string{
+		"AA:00:00:00:00:01": "sfp-lan",
+		"AA:00:00:00:00:02": "sfp-wan",
+		"AA:00:00:00:00:03": "eth1",
+		"AA:00:00:00:00:04": "lan",
+		"AA:00:00:00:00:05": "usb0",
+		"AA:00:00:00:00:06": "swp1",
+		"AA:00:00:00:00:07": "enp2s0",
+	}
+	if len(fdb) != len(want) {
+		t.Fatalf("esperaba %d MACs (solo puertos físicos), tengo %d: %+v", len(want), len(fdb), fdb)
+	}
+	for mac, port := range want {
+		if fdb[mac] != port {
+			t.Fatalf("MAC %s: esperaba puerto %s, tengo %q", mac, port, fdb[mac])
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Prober local con runner fake
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Two fixes in the wired discovery path, both verified end to end against a lab
repro of the reported BPI-R4 scenario (static-IP hosts behind a switch
uplinked to the SFP-LAN cage):

1. `ParseBridgeFdb` used a hardcoded port-name allowlist
   (`lan\d+|wan|eth\d+|swp\d+|en...`) meant to skip wireless bridge members.
   OpenWrt names the BPI-R4 SFP cages `sfp-lan`/`sfp-wan`
   (`openwrt,netdev-name`, since Dec 2024; the device only ships in
   25.12/snapshot), so every MAC learned on those ports was silently dropped
   and the hosts behind them never appeared as clients. The filter is now a
   denylist: any bridge-member port counts as wired except wireless members
   (`phy*-ap*`, `wlan*`), virtual interfaces (bridges, tunnels, veth, wg,
   ppp, ...) and VLAN subinterfaces (`.`/`@`).

2. The `bridge fdb show` fallback (used when brctl is absent) leaked LOCAL
   entries (the bridge's own MAC registered on every port, flag
   `permanent`). Server-side, a router's own bridge MAC learned on a port
   marks that port as an uplink, which dropped ALL its wired clients. The
   brctl path already filtered these (`$3=="no"`); the bridge path now skips
   `permanent` entries for parity.

## Evidence

- New `TestParseFdbDenylistPuertos`: keeps `sfp-lan` (resolved by port_no,
  brctl style), `sfp-wan`, `eth1`, `lan`, `usb0`, `swp1`, `enp2s0`; drops
  `phy0-ap0`, `wlan0`, `br-lan`, `lo`, `veth0`, `wg0`, `tunl0`, `tap0`,
  `pppoe-wan`, `lan1.10`.
- Full suites green (agent + server-go 36/36).
- Lab repro (bridge + veth named `sfp-lan`, static-IP host, no DHCP): agent
  built from main = device absent (bug reproduced); agent built from this
  branch = device present as a wired client of port `sfp-lan`.
- Regression on the real fleet: one router upgraded to the new agent; 91
  devices, same MACs, same attribution before/after.

Closes #506