### PR TITLE
chore(release): v2.26.10

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,7 +39,7 @@ jobs:
       # (agentbin.EmbeddedAgentVersion): el campo updateAvailable de
       # GET /api/agents compara la versión reportada del agente contra esa
       # versión. Bumpear aquí y en agentbin.md el valor único de verdad.
-      AGENT_VERSION: "0.2.0"
+      AGENT_VERSION: "2.26.10"
     strategy:
       matrix:
         arch: [amd64, arm64]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.26.10] - 2026-09-04
+
+### Fixed
+
+- **Descubrimiento de clientes cableados tras puertos con nombres no estándar (#506)**: el agente filtraba las MACs aprendidas en el FDB del bridge con una lista cerrada de nombres de puerto (`lan1`, `wan`, `eth0`...), pensada para excluir los puertos wireless; cualquier puerto físico fuera de esa lista se descartaba en silencio. En el Banana Pi BPI-R4 las jaulas SFP se llaman `sfp-lan`/`sfp-wan` (naming de OpenWrt 25.12+), así que los dispositivos cableados tras el SFP-LAN (p. ej. detrás de un switch no gestionado, con IP estática y sin lease DHCP) jamás aparecían como clientes. El filtro pasa a ser una lista de exclusión: vale cualquier puerto miembro del bridge salvo wireless (`phy*-ap*`, `wlan*`), interfaces virtuales (bridges, túneles, veth, wg, ppp...) y subinterfaces VLAN.
+- **La vía `bridge fdb show` filtraba mal las entradas locales (#506)**: cuando el router no tiene `brctl`, el fallback dejaba pasar las entradas locales del bridge (su propia MAC registrada en cada puerto, flag `permanent`); el servidor interpretaba esa MAC propia como un uplink y descartaba TODOS los clientes cableados de ese puerto. Ahora se excluyen las entradas `permanent`, en paridad con la vía brctl.
+- **AGENT_VERSION alineada con la release (2.26.10)**: los agentes embebidos en el servidor reportaban 0.2.0, menor que los agentes de la flota instalados desde tarball (2.26.x), por lo que nunca se ofrecía su actualización; a partir de aquí el agente embebido ofrece update a toda la flota anterior.
+
 ## [2.26.9] - 2026-09-03
 
 ### Fixed

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.26.9",
+  "version": "2.26.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.26.9",
+      "version": "2.26.10",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.26.9",
+  "version": "2.26.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -51,7 +51,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.26.9"
+var Version = "2.26.10"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Bump de versión (server, app, lock), CHANGELOG y AGENT_VERSION alineada con la release para que la flota 2.26.x reciba la actualización del agente con el fix #506.