### PR TITLE
feat(speedtest): periodic WAN speed test for connection health

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -649,7 +649,14 @@
       "fiber": "Fiber {{plan}}",
       "publicIp": "Public IP",
       "title": "WAN network",
-      "totalToday": "Total today"
+      "totalToday": "Total today",
+      "speedtestTitle": "Measured speed",
+      "speedtestEmpty": "No measurements yet. Enable it in Settings or run a test.",
+      "speedtestRun": "Run test",
+      "speedtestRunning": "Measuring...",
+      "speedtestFailed": "Last test failed",
+      "planPct": "{{pct}} % of plan",
+      "speedtestServer": "server {{name}}"
     },
     "wireguard": {
       "lastIp": "Last IP",
@@ -1276,7 +1283,25 @@
     "paletteNetpulse": "NetPulse",
     "paletteNoc": "Warm NOC",
     "palettePhosphor": "Phosphor",
-    "paletteElectric": "Electric"
+    "paletteElectric": "Electric",
+    "speedtest": {
+      "title": "WAN speed test",
+      "caption": "Real periodic measurement from the server against speedtest.net",
+      "enabled": "Periodic test enabled",
+      "interval": "Interval",
+      "intervalH": "every {{hours}} h",
+      "alertPct": "Alert below {{pct}} % of the plan",
+      "alertPctHint": "0 = alert off. Uses the contracted plan declared above (download only).",
+      "serverId": "speedtest.net server (ID, 0 = automatic)",
+      "save": "Save",
+      "saving": "Saving...",
+      "saved": "Saved",
+      "saveError": "Could not save",
+      "invalid": "Invalid values",
+      "hint": "Each test saturates the link for a few seconds and consumes data: avoid short intervals on capped connections.",
+      "lastResult": "Last test: {{when}} · {{down}} Mbps ↓ / {{up}} Mbps ↑",
+      "unavailable": "Not available in this mode"
+    }
   },
   "statcard": {
     "vsPrevious": "vs previous"

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -649,7 +649,14 @@
       "fiber": "Fibra {{plan}}",
       "publicIp": "IP pública",
       "title": "Red WAN",
-      "totalToday": "Total hoy"
+      "totalToday": "Total hoy",
+      "speedtestTitle": "Velocidad medida",
+      "speedtestEmpty": "Sin mediciones todavía. Actívalo en Ajustes o lanza un test.",
+      "speedtestRun": "Ejecutar test",
+      "speedtestRunning": "Midiendo...",
+      "speedtestFailed": "El último test falló",
+      "planPct": "{{pct}} % del plan",
+      "speedtestServer": "servidor {{name}}"
     },
     "wireguard": {
       "lastIp": "Última IP",
@@ -1276,7 +1283,25 @@
     "paletteNetpulse": "NetPulse",
     "paletteNoc": "NOC Calido",
     "palettePhosphor": "Fosforo",
-    "paletteElectric": "Electrico"
+    "paletteElectric": "Electrico",
+    "speedtest": {
+      "title": "Test de velocidad WAN",
+      "caption": "Medición periódica real desde el servidor contra speedtest.net",
+      "enabled": "Test periódico activado",
+      "interval": "Intervalo",
+      "intervalH": "cada {{hours}} h",
+      "alertPct": "Alertar por debajo del {{pct}} % del plan",
+      "alertPctHint": "0 = alerta desactivada. Usa el plan contratado declarado arriba (solo bajada).",
+      "serverId": "Servidor speedtest.net (ID, 0 = automático)",
+      "save": "Guardar",
+      "saving": "Guardando...",
+      "saved": "Guardado",
+      "saveError": "No se pudo guardar",
+      "invalid": "Valores inválidos",
+      "hint": "Cada test satura el enlace durante unos segundos y consume datos: evita intervalos cortos en líneas con límite de datos.",
+      "lastResult": "Último test: {{when}} · {{down}} Mbps ↓ / {{up}} Mbps ↑",
+      "unavailable": "No disponible en este modo"
+    }
   },
   "statcard": {
     "vsPrevious": "vs anterior"

--- a/app/src/components/routers/WanLatency.tsx
+++ b/app/src/components/routers/WanLatency.tsx
@@ -133,7 +133,8 @@ export function WanLatency() {
 // ---------------------------------------------------------------------------
 
 type SpeedtestItem = {
-  ts: number
+  /** ISO 8601 (time.Time serializado por el API). */
+  ts: string
   downMbps: number
   upMbps: number
   pingMs?: number
@@ -207,7 +208,9 @@ function SpeedtestStrip({ contractDown }: { contractDown?: number }) {
   const { running, lastError, last, points, starting, run } = useSpeedtestState()
 
   const busy = running || starting
-  const when = last ? (relTimeFromTs(last.ts) ?? '') : ''
+  // El API serializa ts como ISO 8601; relTimeFromTs espera unix SEGUNDOS
+  // (SPEC-ALERTAS, igual que las alertas).
+  const when = last ? (relTimeFromTs(Math.floor(new Date(last.ts).getTime() / 1000)) ?? '') : ''
   const planPct =
     contractDown && contractDown > 0 && last ? Math.round((last.downMbps / contractDown) * 100) : null
 

--- a/app/src/components/routers/WanLatency.tsx
+++ b/app/src/components/routers/WanLatency.tsx
@@ -1,11 +1,14 @@
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis } from 'recharts'
 import { motion, useReducedMotion } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
+import { Activity, Loader2 } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
 import { fmtEs } from '@/data/mock'
 import { useNetPulse } from '@/data/DataProvider'
 import { SectionHeader } from '@/components/SectionHeader'
 import { Sparkline } from '@/components/Sparkline'
 import { LatencyGauge } from '@/components/routers/LatencyGauge'
+import { relTimeFromTs } from '@/i18n'
 import { WAN_LATENCY_24H, WAN_LATENCY_STATS } from '@/components/routers/routerExtras'
 
 function WanTooltip({
@@ -45,7 +48,6 @@ export function WanLatency() {
     { label: 'ISP', value: `${wan.isp} · ${t('routerDetail.wan.fiber', { plan: wan.plan.replace(' Mbps', '') })}` },
     { label: t('routerDetail.wan.totalToday'), value: wan.total24h },
   ] as const
-
   return (
     <div className="grid grid-cols-1 gap-4 md:gap-5 lg:col-span-12 lg:grid-cols-12">
       {/* 4a. WAN */}
@@ -94,6 +96,7 @@ export function WanLatency() {
             </div>
           ))}
         </div>
+        <SpeedtestStrip contractDown={wan.contractDownMbps} />
       </section>
 
       {/* 4b. Latencia */}
@@ -119,6 +122,180 @@ export function WanLatency() {
           </div>
         </div>
       </section>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Velocidad medida (issue #511): último speedtest real + histórico de 7 días
+// + % del plan contratado (#151) + botón de ejecución manual. Vive dentro de
+// la tarjeta WAN porque es la métrica que sustituye a las aproximaciones.
+// ---------------------------------------------------------------------------
+
+type SpeedtestItem = {
+  ts: number
+  downMbps: number
+  upMbps: number
+  pingMs?: number
+  serverName?: string
+}
+
+function useSpeedtestState() {
+  const [running, setRunning] = useState(false)
+  const [lastError, setLastError] = useState<string | null>(null)
+  const [last, setLast] = useState<SpeedtestItem | null>(null)
+  const [points, setPoints] = useState<{ t: string; down: number; up: number }[]>([])
+  const [starting, setStarting] = useState(false)
+
+  const load = useCallback(async () => {
+    try {
+      const [stRes, hRes] = await Promise.all([
+        fetch('/api/speedtest/status'),
+        fetch('/api/speedtest/history?hours=168'),
+      ])
+      if (stRes.ok) {
+        const st = await stRes.json()
+        setRunning(!!st.running)
+        setLastError(st.lastError || null)
+        setLast(st.last ?? null)
+      }
+      if (hRes.ok) {
+        const h = await hRes.json()
+        const fmt = new Intl.DateTimeFormat(undefined, { weekday: 'short', hour: '2-digit' })
+        setPoints(
+          (h.items ?? []).map((it: SpeedtestItem) => ({
+            t: fmt.format(new Date(it.ts)),
+            down: it.downMbps,
+            up: it.upMbps,
+          })),
+        )
+      }
+    } catch {
+      // Sin red / sesión caducada: se conserva el último estado pintado.
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  // Mientras corre un test, refresco cada 3 s hasta que termina.
+  useEffect(() => {
+    if (!running) return
+    const id = window.setInterval(() => void load(), 3000)
+    return () => window.clearInterval(id)
+  }, [running, load])
+
+  const run = useCallback(async () => {
+    setStarting(true)
+    try {
+      const res = await fetch('/api/speedtest/run', { method: 'POST' })
+      if (res.ok || res.status === 409) setRunning(true)
+      else if (res.status === 503) setLastError('unavailable')
+    } catch {
+      /* el siguiente poll reflejará el estado real */
+    } finally {
+      setStarting(false)
+    }
+  }, [])
+
+  return { running, lastError, last, points, starting, run, reload: load }
+}
+
+function SpeedtestStrip({ contractDown }: { contractDown?: number }) {
+  const { t } = useTranslation()
+  const { running, lastError, last, points, starting, run } = useSpeedtestState()
+
+  const busy = running || starting
+  const when = last ? (relTimeFromTs(last.ts) ?? '') : ''
+  const planPct =
+    contractDown && contractDown > 0 && last ? Math.round((last.downMbps / contractDown) * 100) : null
+
+  return (
+    <div className="mt-4 border-t border-border pt-4" aria-label={t('routerDetail.wan.speedtestTitle')}>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5">
+          <Activity className="h-4 w-4 text-accent" aria-hidden />
+          <span className="text-label uppercase text-text-muted">{t('routerDetail.wan.speedtestTitle')}</span>
+          {planPct !== null && (
+            <span
+              className={`ml-1 rounded-full border px-2 py-0.5 font-mono text-[11px] ${
+                planPct >= 80
+                  ? 'border-ok/40 bg-ok/10 text-ok'
+                  : planPct >= 50
+                    ? 'border-warn/40 bg-warn/10 text-warn'
+                    : 'border-danger/40 bg-danger/10 text-danger'
+              }`}
+            >
+              {t('routerDetail.wan.planPct', { pct: planPct })}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => void run()}
+          disabled={busy}
+          aria-label={t('routerDetail.wan.speedtestRun')}
+          className="inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-xl border border-border bg-canvas px-3 text-[13px] font-medium text-text-primary transition-colors hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {busy ? (
+            <>
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+              {t('routerDetail.wan.speedtestRunning')}
+            </>
+          ) : (
+            t('routerDetail.wan.speedtestRun')
+          )}
+        </button>
+      </div>
+
+      {lastError && lastError !== 'unavailable' && (
+        <p role="alert" className="mt-2 text-caption text-danger">
+          {t('routerDetail.wan.speedtestFailed')}
+        </p>
+      )}
+
+      {last ? (
+        <>
+          <div className="mt-2 flex flex-wrap items-baseline gap-x-3 gap-y-1 font-mono text-mono-sm text-text-primary">
+            <span>
+              <span className="text-accent">↓</span> {fmtEs(last.downMbps, 0)} Mbps
+            </span>
+            <span>
+              <span className="text-tunnel">↑</span> {fmtEs(last.upMbps, 0)} Mbps
+            </span>
+            {last.pingMs !== undefined && <span className="text-text-muted">{fmtEs(last.pingMs, 0)} ms</span>}
+            {when && <span className="text-text-muted">· {when}</span>}
+            {last.serverName && (
+              <span className="text-text-muted">· {t('routerDetail.wan.speedtestServer', { name: last.serverName })}</span>
+            )}
+          </div>
+          {points.length > 1 && (
+            <div className="mt-2 h-[64px]" role="img" aria-label={t('routerDetail.wan.speedtestTitle')}>
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={points} margin={{ top: 6, right: 4, bottom: 0, left: 4 }}>
+                  <CartesianGrid vertical={false} stroke="rgb(var(--border) / 0.4)" strokeDasharray="3 6" />
+                  <XAxis
+                    dataKey="t"
+                    tickLine={false}
+                    axisLine={false}
+                    interval="preserveStartEnd"
+                    minTickGap={48}
+                    tick={{ fill: 'rgb(var(--text-muted))', fontSize: 9, fontFamily: '"JetBrains Mono", monospace' }}
+                  />
+                  <Tooltip content={<WanTooltip />} cursor={{ stroke: 'rgb(var(--border-strong))', strokeWidth: 1 }} />
+                  <Area type="stepAfter" dataKey="down" stroke="#22D3EE" strokeWidth={1.5} fill="url(#wan-detail-down)" dot={false} />
+                  <Area type="stepAfter" dataKey="up" stroke="#A78BFA" strokeWidth={1.5} fill="url(#wan-detail-up)" dot={false} />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </>
+      ) : (
+        <p className="mt-2 text-caption text-text-muted">
+          {lastError === 'unavailable' ? t('settings.speedtest.unavailable') : t('routerDetail.wan.speedtestEmpty')}
+        </p>
+      )}
     </div>
   )
 }

--- a/app/src/data/types.ts
+++ b/app/src/data/types.ts
@@ -85,6 +85,12 @@ export interface WanInfo {
   /** Velocidad contratada declarada por el admin (Mbps, issue #151). Ausente si no configurada. */
   contractDownMbps?: number
   contractUpMbps?: number
+  /** Última medición real del speedtest (issue #511). Ausente sin tests. */
+  speedtestDownMbps?: number
+  speedtestUpMbps?: number
+  /** Unix ms de la última medición. */
+  speedtestTsMs?: number
+  speedtestServer?: string
 }
 
 export interface TrafficPoint {

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -1851,6 +1851,161 @@ function WanSpeedCard({ onSaved, disabled = false }: { onSaved: () => void; disa
 }
 
 // ---------------------------------------------------------------------------
+// Test de velocidad WAN (issue #511) — configuración del test periódico.
+// Sub-sección de «Datos y umbrales» junto a la velocidad contratada: el
+// umbral de alerta (% del plan) depende de ella.
+// ---------------------------------------------------------------------------
+
+function SpeedtestCard({ onSaved, disabled = false }: { onSaved: () => void; disabled?: boolean }) {
+  const { t } = useTranslation()
+  const [enabled, setEnabled] = useState(false)
+  const [intervalHours, setIntervalHours] = useState(12)
+  const [alertPct, setAlertPct] = useState(50)
+  const [serverId, setServerId] = useState('0')
+  const [busy, setBusy] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+  const loaded = useRef(false)
+
+  useEffect(() => {
+    let alive = true
+    void fetch('/api/settings/speedtest')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (!alive || !d || loaded.current) return
+        loaded.current = true
+        setEnabled(!!d.enabled)
+        if (typeof d.intervalHours === 'number') setIntervalHours(d.intervalHours)
+        if (typeof d.alertPct === 'number') setAlertPct(d.alertPct)
+        if (typeof d.serverId === 'number') setServerId(String(d.serverId))
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        if (alive) setLoading(false)
+      })
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  const save = useCallback(async () => {
+    const sid = Number(serverId)
+    if (![6, 12, 24].includes(intervalHours) || !Number.isInteger(sid) || sid < 0 || alertPct < 0 || alertPct > 90) {
+      setError(t('settings.speedtest.invalid'))
+      return
+    }
+    setError(null)
+    setBusy(true)
+    try {
+      const res = await fetch('/api/settings/speedtest', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled, intervalHours, serverId: sid, alertPct }),
+      })
+      if (!res.ok) {
+        setError(t('settings.speedtest.saveError'))
+        return
+      }
+      setSaved(true)
+      window.setTimeout(() => setSaved(false), 2000)
+      onSaved()
+    } finally {
+      setBusy(false)
+    }
+  }, [enabled, intervalHours, serverId, alertPct, onSaved, t])
+
+  return (
+    <div className="mt-4 space-y-3 border-t border-border pt-4">
+      <div>
+        <div className="text-sm font-medium text-text-primary">{t('settings.speedtest.title')}</div>
+        <div className="text-caption text-text-muted">{t('settings.speedtest.caption')}</div>
+      </div>
+      <label className="flex items-center justify-between gap-3">
+        <span className="text-label uppercase text-text-muted">{t('settings.speedtest.enabled')}</span>
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => setEnabled(e.target.checked)}
+          disabled={disabled || loading}
+          aria-label={t('settings.speedtest.enabled')}
+          className="h-4 w-4 accent-[rgb(var(--accent))]"
+        />
+      </label>
+      <div className="grid grid-cols-2 gap-3">
+        <label className="block">
+          <span className="text-label uppercase text-text-muted">{t('settings.speedtest.interval')}</span>
+          <select
+            value={intervalHours}
+            onChange={(e) => setIntervalHours(Number(e.target.value))}
+            disabled={disabled || loading}
+            aria-label={t('settings.speedtest.interval')}
+            className="mt-1 w-full rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
+          >
+            {[6, 12, 24].map((h) => (
+              <option key={h} value={h}>
+                {t('settings.speedtest.intervalH', { hours: h })}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-label uppercase text-text-muted">{t('settings.speedtest.alertPct', { pct: alertPct })}</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min="0"
+            max="90"
+            step="1"
+            value={alertPct}
+            onChange={(e) => setAlertPct(Number(e.target.value))}
+            disabled={disabled || loading}
+            aria-label={t('settings.speedtest.alertPct', { pct: alertPct })}
+            className="mt-1 w-full rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
+          />
+        </label>
+      </div>
+      <p className="text-caption text-text-muted">{t('settings.speedtest.alertPctHint')}</p>
+      <label className="block">
+        <span className="text-label uppercase text-text-muted">{t('settings.speedtest.serverId')}</span>
+        <input
+          type="number"
+          inputMode="numeric"
+          min="0"
+          step="1"
+          value={serverId}
+          onChange={(e) => setServerId(e.target.value)}
+          disabled={disabled || loading}
+          aria-label={t('settings.speedtest.serverId')}
+          className="mt-1 w-full rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
+        />
+      </label>
+      <p className="text-caption text-text-muted">{t('settings.speedtest.hint')}</p>
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => void save()}
+          disabled={disabled || busy || loading}
+          className="inline-flex h-9 shrink-0 cursor-pointer items-center gap-1.5 rounded-xl border border-accent bg-accent-soft px-3 text-[13px] font-medium text-accent transition-colors hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {busy ? t('settings.speedtest.saving') : t('settings.speedtest.save')}
+        </button>
+        {saved && (
+          <span role="status" className="text-caption text-ok">
+            {t('settings.speedtest.saved')}
+          </span>
+        )}
+        {error && (
+          <span role="alert" className="text-caption text-danger">
+            {error}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Página Ajustes `/settings` (settings.md)
 // ---------------------------------------------------------------------------
 
@@ -3403,6 +3558,9 @@ export default function Settings() {
 
             {/* Velocidad WAN contratada (issue #151) — sub-sección del mismo ámbito */}
             <WanSpeedCard onSaved={notify} disabled={isDemo} />
+
+            {/* Test de velocidad WAN periódico (issue #511) */}
+            <SpeedtestCard onSaved={notify} disabled={isDemo} />
           </Card>
         </div>
 

--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -468,6 +468,12 @@ func run() error {
 		stScheduler.SetContractDown(func() (float64, bool) {
 			return httpapi.WanContractDown(dbHandle.DB)
 		})
+		// El snapshot SSE debe llevar las mismas inyecciones kv que
+		// /api/overview (contratado #151, speedtest #511): sin esto el
+		// primer evento pisaría los campos en la UI.
+		p.SetEnrich(func(ov *adapters.Overview) {
+			httpapi.EnrichOverview(dbHandle.DB, stScheduler, ov)
+		})
 		go stScheduler.Start()
 	}
 

--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gnacho/netpulse/server-go/internal/configbackup"
 	"github.com/gnacho/netpulse/server-go/internal/db"
 	"github.com/gnacho/netpulse/server-go/internal/firmware"
+	"github.com/gnacho/netpulse/server-go/internal/speedtest"
 	"github.com/gnacho/netpulse/server-go/internal/httpapi"
 	"github.com/gnacho/netpulse/server-go/internal/orchestr"
 	"github.com/gnacho/netpulse/server-go/internal/pathanalysis"
@@ -450,6 +451,26 @@ func run() error {
 		}
 	}
 
+	// Speedtest WAN periódico (#511): store + runner + scheduler. Las
+	// alertas de "velocidad por debajo del plan" se emiten por el MISMO
+	// motor del adapter (la lista de eventos es por instancia). Solo en
+	// live: en demo no hay red real que medir y las rutas quedan en 503.
+	var stScheduler *speedtest.Scheduler
+	if !cfg.DemoMode {
+		stStore, err := speedtest.NewStore(dbHandle.DB)
+		if err != nil {
+			return fmt.Errorf("speedtest schema: %w", err)
+		}
+		stScheduler = speedtest.NewScheduler(stStore, dbHandle.DB, speedtest.SpeedtestNetRunner{})
+		if adapter != nil {
+			stScheduler.SetAlertEmitter(adapter.AlertsEngine())
+		}
+		stScheduler.SetContractDown(func() (float64, bool) {
+			return httpapi.WanContractDown(dbHandle.DB)
+		})
+		go stScheduler.Start()
+	}
+
 	handler := httpapi.NewHandler(httpapi.Deps{
 		Config:          cfg,
 		DB:              dbHandle,
@@ -470,6 +491,7 @@ func run() error {
 		PathAnalysis:    pathStore,
 		ConfigBackup:    cfgBackup,
 		Firmware:        fwStore,
+		Speedtest:       stScheduler,
 		ChannelPlan:     chPlan,
 		LastOverview: func() *adapters.Overview {
 			return p.LastOverview()

--- a/server-go/go.mod
+++ b/server-go/go.mod
@@ -1,10 +1,12 @@
 module github.com/gnacho/netpulse/server-go
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/SherClockHolmes/webpush-go v1.4.0
 	github.com/gnacho/netpulse/agent v0.0.0
+	github.com/gosnmp/gosnmp v1.44.0
+	github.com/showwin/speedtest-go v1.8.3
 	golang.org/x/crypto v0.54.0
 	golang.org/x/text v0.40.0
 	modernc.org/sqlite v1.56.0
@@ -18,7 +20,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gosnmp/gosnmp v1.44.0 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/server-go/go.sum
+++ b/server-go/go.sum
@@ -1,5 +1,7 @@
 github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1B1pULsf9i3s=
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
@@ -18,8 +20,14 @@ github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsRe
 github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/showwin/speedtest-go v1.8.3 h1:x988hyZFsa5V1EEwox84niAji632uxBTk8Clsc1itF8=
+github.com/showwin/speedtest-go v1.8.3/go.mod h1:N4bn2lgNNWmfJyC1AIHD4T5wYhU+9D21OfacVhJsxiU=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
@@ -97,6 +105,8 @@ golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxb
 golang.org/x/tools v0.47.0 h1:7Kn5x/d1svx/PzryTsqeoZN4TZwqeH5pGWjefhLi/1Q=
 golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 modernc.org/cc/v4 v4.29.1 h1:MKgdCV3WykTSPqpVrnxdEDS0HEd2FHpKZDzxzU5LyeI=
 modernc.org/cc/v4 v4.29.1/go.mod h1:OnovgIhbbMXMu1aISnJ0wvVD1KnW+cAUJkIrAWh+kVI=
 modernc.org/ccgo/v4 v4.34.6 h1:sBgfIwyN0TQ9C5hwIeuqyeAKyMWnbvj2fvpF4L11uzU=

--- a/server-go/internal/adapters/types.go
+++ b/server-go/internal/adapters/types.go
@@ -68,6 +68,13 @@ type WAN struct {
 	// adapter no los conoce.
 	ContractDownMbps *float64 `json:"contractDownMbps,omitempty"`
 	ContractUpMbps   *float64 `json:"contractUpMbps,omitempty"`
+	// Medición real del test de velocidad (issue #511), inyectada igual que
+	// la contratada: último resultado del scheduler. Puntero/0 = sin datos
+	// (feature desactivada o sin ningún test aún).
+	SpeedtestDownMbps *float64 `json:"speedtestDownMbps,omitempty"`
+	SpeedtestUpMbps   *float64 `json:"speedtestUpMbps,omitempty"`
+	SpeedtestTs       *int64   `json:"speedtestTsMs,omitempty"`
+	SpeedtestServer   string   `json:"speedtestServer,omitempty"`
 }
 
 // TrafficPoint es un punto {t, down, up} de las series de tráfico WAN.

--- a/server-go/internal/alerts/alerts.go
+++ b/server-go/internal/alerts/alerts.go
@@ -86,6 +86,7 @@ const (
 	HintGhostPort      = "ghost-port"
 	HintDegradedLink   = "degraded-link"
 	HintAgentOutdated  = "agent-outdated"
+	HintWanSlow        = "wan-slow"
 )
 
 // Hints maps each alert-type slug to its actionable suggestion. Emitters copy
@@ -103,6 +104,7 @@ var Hints = map[string]string{
 	HintGhostPort:     "Revisa el cable y el dispositivo conectado: un puerto activo que enmudece suele indicar un cable suelto o un equipo apagado.",
 	HintDegradedLink:  "Revisa el cable y los conectores: un enlace degradado suele ser síntoma de cable dañado o conector flojo.",
 	HintAgentOutdated: "Actualiza el agente desde Ajustes, Agentes (botón Actualizar); si es un panel NetGrip, actualiza desde su propio panel.",
+	HintWanSlow:       "Reinicia el router y el módem/ONT y repite el test; si sigue bajo, contacta con tu operador (degrada la línea o hay saturación en tu área).",
 }
 
 // HintFor returns the suggestion for a slug, or "" when it does not exist.

--- a/server-go/internal/httpapi/data.go
+++ b/server-go/internal/httpapi/data.go
@@ -3,6 +3,7 @@
 package httpapi
 
 import (
+	"database/sql"
 	"math"
 	"net/http"
 	"strconv"
@@ -14,6 +15,7 @@ import (
 	"github.com/gnacho/netpulse/server-go/internal/deviceevents"
 	"github.com/gnacho/netpulse/server-go/internal/portseries"
 	"github.com/gnacho/netpulse/server-go/internal/roamevents"
+	"github.com/gnacho/netpulse/server-go/internal/speedtest"
 )
 
 var bands = []string{"5 GHz", "2.4 GHz", "cable"}
@@ -117,22 +119,33 @@ func (s *server) handleOverview(w http.ResponseWriter, r *http.Request) {
 	engine := s.adapter.AlertsEngine()
 	out.Alerts = engine.List()
 	out.UnreadAlerts = engine.UnreadCount()
-	// Menú de orquestación: opt-in por admin (#121). Se expone aquí (no en el
-	// adapter) porque el kv vive en el server, no en el poller.
-	out.Orchestration = kvGetBool(s.db.DB, orchestrationKey)
+	EnrichOverview(s.db.DB, s.speedtest, &out)
+	writeJSON(w, http.StatusOK, &out)
+}
+
+// EnrichOverview inyecta los campos que viven en el kv del server (menú de
+// orquestación #121, velocidad contratada #151 y última medición del
+// speedtest #511). La usan handleOverview Y el poller antes de emitir el
+// snapshot SSE: sin la segunda, el evento pisaría la copia enriquecida del
+// HTTP y los campos desaparecerían de la UI al primer snapshot (bug
+// preexistente de #151 que el speedtest hizo evidente).
+func EnrichOverview(handle *sql.DB, sched *speedtest.Scheduler, out *adapters.Overview) {
+	// Menú de orquestación: opt-in por admin (#121). Se expone aquí (no en
+	// el adapter) porque el kv vive en el server, no en el poller.
+	out.Orchestration = kvGetBool(handle, orchestrationKey)
 	// Velocidad WAN contratada (#151): declarada por el admin en Ajustes y
-	// persistida en kv. Se inyecta aquí por el mismo motivo que orchestration.
-	if v, ok := kvGetFloat(s.db.DB, wanSpeedDownKey); ok {
+	// persistida en kv.
+	if v, ok := kvGetFloat(handle, wanSpeedDownKey); ok {
 		out.WAN.ContractDownMbps = &v
 	}
-	if v, ok := kvGetFloat(s.db.DB, wanSpeedUpKey); ok {
+	if v, ok := kvGetFloat(handle, wanSpeedUpKey); ok {
 		out.WAN.ContractUpMbps = &v
 	}
 	// Última medición real del speedtest (#511): el scheduler escribe la
 	// serie; aquí solo se expone la última para la tarjeta WAN. nil (demo o
 	// sin ningún test) → campos ausentes y la UI muestra su estado vacío.
-	if s.speedtest != nil {
-		if last, err := s.speedtest.Store().Latest(); err == nil && last != nil {
+	if sched != nil {
+		if last, err := sched.Store().Latest(); err == nil && last != nil {
 			down, up := last.DownMbps, last.UpMbps
 			ts := last.TS.UnixMilli()
 			out.WAN.SpeedtestDownMbps = &down
@@ -141,7 +154,6 @@ func (s *server) handleOverview(w http.ResponseWriter, r *http.Request) {
 			out.WAN.SpeedtestServer = last.ServerName
 		}
 	}
-	writeJSON(w, http.StatusOK, &out)
 }
 
 // handleRouters: {routers: [Router…]}.

--- a/server-go/internal/httpapi/data.go
+++ b/server-go/internal/httpapi/data.go
@@ -128,6 +128,19 @@ func (s *server) handleOverview(w http.ResponseWriter, r *http.Request) {
 	if v, ok := kvGetFloat(s.db.DB, wanSpeedUpKey); ok {
 		out.WAN.ContractUpMbps = &v
 	}
+	// Última medición real del speedtest (#511): el scheduler escribe la
+	// serie; aquí solo se expone la última para la tarjeta WAN. nil (demo o
+	// sin ningún test) → campos ausentes y la UI muestra su estado vacío.
+	if s.speedtest != nil {
+		if last, err := s.speedtest.Store().Latest(); err == nil && last != nil {
+			down, up := last.DownMbps, last.UpMbps
+			ts := last.TS.UnixMilli()
+			out.WAN.SpeedtestDownMbps = &down
+			out.WAN.SpeedtestUpMbps = &up
+			out.WAN.SpeedtestTs = &ts
+			out.WAN.SpeedtestServer = last.ServerName
+		}
+	}
 	writeJSON(w, http.StatusOK, &out)
 }
 

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gnacho/netpulse/server-go/internal/configbackup"
 	"github.com/gnacho/netpulse/server-go/internal/db"
 	"github.com/gnacho/netpulse/server-go/internal/firmware"
+	"github.com/gnacho/netpulse/server-go/internal/speedtest"
 	"github.com/gnacho/netpulse/server-go/internal/internethealth"
 	"github.com/gnacho/netpulse/server-go/internal/orchestr"
 	"github.com/gnacho/netpulse/server-go/internal/pathanalysis"
@@ -109,6 +110,8 @@ type Deps struct {
 	ConfigBackup *configbackup.Store
 	// Firmware: targets y upgrades de firmware (#453).
 	Firmware *firmware.Store
+	// Speedtest: scheduler del test periódico WAN (#511). nil → 503.
+	Speedtest *speedtest.Scheduler
 }
 
 type server struct {
@@ -179,6 +182,10 @@ type server struct {
 
 	// Firmware: targets y upgrades de firmware (#453).
 	firmware *firmware.Store
+
+	// Speedtest: scheduler del test de velocidad WAN (#511). nil → rutas
+	// /api/speedtest/* y /api/settings/speedtest responden 503 (demo).
+	speedtest *speedtest.Scheduler
 }
 
 // NewHandler ensambla el handler HTTP completo (API + estáticos + SPA).
@@ -201,6 +208,7 @@ func NewHandler(d Deps) http.Handler {
 		pathAnalysis:    d.PathAnalysis,
 		configBackup:    d.ConfigBackup,
 		firmware:        d.Firmware,
+		speedtest:       d.Speedtest,
 	}
 	// Rearmer compartido entre el endpoint manual y el supervisor de
 	// auto-rearme (cmd/netpulse lo construye y lo pasa para que ambos
@@ -406,6 +414,7 @@ func NewHandler(d Deps) http.Handler {
 
 	// --- Ajustes globales en kv (issue #121: orchestration opt-in) ---
 	s.registerSettingsRoutes(mux)
+	s.registerSpeedtestRoutes(mux)
 
 	// --- Copias de seguridad (issue #158) ---
 	s.registerBackupRoutes(mux)

--- a/server-go/internal/httpapi/settings.go
+++ b/server-go/internal/httpapi/settings.go
@@ -79,6 +79,13 @@ func validWanSpeed(v float64) bool {
 	return v > 0 && v <= maxContractMbps
 }
 
+// WanContractDown expone el plan contratado de bajada (#151) fuera del
+// paquete: lo usa cmd/netpulse para inyectárselo al scheduler del speedtest
+// (#511) sin duplicar la clave kv.
+func WanContractDown(handle *sql.DB) (float64, bool) {
+	return kvGetFloat(handle, wanSpeedDownKey)
+}
+
 // registerSettingsRoutes: GET/PUT /api/settings/orchestration (admin) y
 // GET/PUT /api/settings/wanspeed (admin, #151).
 func (s *server) registerSettingsRoutes(mux *http.ServeMux) {

--- a/server-go/internal/httpapi/speedtest_api.go
+++ b/server-go/internal/httpapi/speedtest_api.go
@@ -1,0 +1,96 @@
+// speedtest_api.go — rutas del test de velocidad WAN (issue #511).
+//
+// GET  /api/speedtest/status   foto: running, último error/resultado, next.
+// GET  /api/speedtest/history  serie de la ventana ?hours= (default 168).
+// POST /api/speedtest/run      lanza un test manual (202; 409 si ya corre).
+// GET/PUT /api/settings/speedtest  configuración (intervalo, servidor,
+//                                 umbral de alerta) — admin.
+//
+// Deps.Speedtest nil (demo) → 503 unavailable, como el resto de deps nulas.
+package httpapi
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/auth"
+	"github.com/gnacho/netpulse/server-go/internal/speedtest"
+)
+
+// historyDefaultHours: una semana hacia atrás por defecto (1-4 puntos/día).
+const (
+	historyDefaultHours = 168
+	historyMaxHours     = 365 * 24
+)
+
+func (s *server) registerSpeedtestRoutes(mux *http.ServeMux) {
+	if s.speedtest == nil {
+		for _, route := range []string{
+			"GET /api/speedtest/status", "GET /api/speedtest/history",
+			"POST /api/speedtest/run",
+			"GET /api/settings/speedtest", "PUT /api/settings/speedtest",
+		} {
+			mux.Handle(route, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				writeError(w, http.StatusServiceUnavailable, "unavailable",
+					"speedtest no disponible en este modo")
+			}))
+		}
+		return
+	}
+
+	mux.HandleFunc("GET /api/speedtest/status", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, s.speedtest.Status())
+	})
+
+	mux.HandleFunc("GET /api/speedtest/history", func(w http.ResponseWriter, r *http.Request) {
+		hours := historyDefaultHours
+		if v := r.URL.Query().Get("hours"); v != "" {
+			n, err := strconv.Atoi(v)
+			if err != nil || n <= 0 || n > historyMaxHours {
+				writeError(w, http.StatusBadRequest, "invalid_input",
+					"hours debe ser un entero entre 1 y 8760")
+				return
+			}
+			hours = n
+		}
+		now := time.Now()
+		items, err := s.speedtest.Store().History(now.Add(-time.Duration(hours)*time.Hour), now)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "db_error")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"items": items})
+	})
+
+	mux.Handle("POST /api/speedtest/run", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := s.speedtest.RunNow(); err != nil {
+			if errors.Is(err, speedtest.ErrAlreadyRunning) {
+				writeError(w, http.StatusConflict, "already_running",
+					"ya hay un test en marcha")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "internal_error")
+			return
+		}
+		writeJSON(w, http.StatusAccepted, map[string]bool{"started": true})
+	})))
+
+	mux.Handle("GET /api/settings/speedtest", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, s.speedtest.LoadSettings())
+	})))
+
+	mux.Handle("PUT /api/settings/speedtest", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body speedtest.Settings
+		if st := readJSONBody(w, r, &body); st != 0 {
+			writeBodyError(w, st, "invalid_body", "")
+			return
+		}
+		if err := s.speedtest.SaveSettings(body); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_input", err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, s.speedtest.LoadSettings())
+	})))
+}

--- a/server-go/internal/httpapi/speedtest_api_test.go
+++ b/server-go/internal/httpapi/speedtest_api_test.go
@@ -1,0 +1,254 @@
+// speedtest_api_test.go — contrato de las rutas del test de velocidad WAN
+// (issue #511): settings, histórico, estado, run-now y 503 en demo.
+package httpapi_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/adapters"
+	"github.com/gnacho/netpulse/server-go/internal/apitoken"
+	"github.com/gnacho/netpulse/server-go/internal/auth"
+	"github.com/gnacho/netpulse/server-go/internal/channelplan"
+	"github.com/gnacho/netpulse/server-go/internal/config"
+	"github.com/gnacho/netpulse/server-go/internal/db"
+	"github.com/gnacho/netpulse/server-go/internal/httpapi"
+	"github.com/gnacho/netpulse/server-go/internal/speedtest"
+	"github.com/gnacho/netpulse/server-go/internal/sse"
+)
+
+// fakeRunner devuelve un resultado fijo; con release != nil bloquea hasta
+// que se cierre (para probar el 409 de single-flight).
+type fakeRunner struct {
+	release chan struct{}
+}
+
+func (f fakeRunner) Run(ctx context.Context, serverID int) (speedtest.Result, error) {
+	if f.release != nil {
+		<-f.release
+	}
+	return speedtest.Result{DownMbps: 300, UpMbps: 150, ServerName: "fake-srv"}, nil
+}
+
+// makeSpeedtestServer: como makeTestServer pero con Deps.Speedtest montado
+// sobre un runner fake (el arnés estándar no admite Deps custom).
+func makeSpeedtestServer(t *testing.T, runner speedtest.Runner) *testServer {
+	t.Helper()
+	dataDir := t.TempDir()
+	cfg, err := config.Load(map[string]string{
+		"AUTH_USER": "admin", "AUTH_PASS": "test123456",
+		"DEMO_MODE": "0", "DATA_DIR": dataDir, "NODE_ENV": "test",
+	}, dataDir)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	d, err := db.Open(dataDir)
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	secret, err := auth.EnsureSessionSecret(d, cfg)
+	if err != nil {
+		t.Fatalf("secret: %v", err)
+	}
+	if err := auth.EnsureUsers(d, cfg); err != nil {
+		t.Fatalf("users: %v", err)
+	}
+	if err := apitoken.EnsureSchema(d); err != nil {
+		t.Fatalf("api_tokens schema: %v", err)
+	}
+	stStore, err := speedtest.NewStore(d.DB)
+	if err != nil {
+		t.Fatalf("speedtest store: %v", err)
+	}
+	handler := httpapi.NewHandler(httpapi.Deps{
+		Config: cfg, DB: d, Adapter: adapters.NewDemo(),
+		Hub: sse.NewHub(d, cfg.MaxSSEClients, func() any { return nil }),
+		Secret: secret, Agents: adapters.NewAgentRegistry(0),
+		TokenStore:  apitoken.NewStore(d, secret),
+		ChannelPlan: channelplan.NewStore(d.DB),
+		Speedtest:   speedtest.NewScheduler(stStore, d.DB, runner),
+		Started:     time.Now(),
+	})
+	srv := httptest.NewServer(handler)
+	ts := &testServer{Server: srv, db: d, secret: secret}
+	t.Cleanup(func() {
+		srv.Close()
+		d.Close()
+	})
+	return ts
+}
+
+func speedtestRequest(t *testing.T, method, base, path, cookie, body string) (*http.Response, map[string]any) {
+	t.Helper()
+	var req *http.Request
+	if body != "" {
+		req, _ = http.NewRequest(method, base+path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req, _ = http.NewRequest(method, base+path, nil)
+	}
+	if cookie != "" {
+		req.Header.Set("Cookie", "session="+cookie)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer res.Body.Close()
+	var parsed map[string]any
+	raw, _ := io.ReadAll(res.Body)
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &parsed)
+	}
+	return res, parsed
+}
+
+// TestSpeedtestSettingsRoundtrip: PUT válido guarda, GET devuelve, PUT
+// inválido → 400, sin sesión → 401.
+func TestSpeedtestSettingsRoundtrip(t *testing.T) {
+	srv := makeSpeedtestServer(t, fakeRunner{})
+	cookie := adminCookie(t, srv)
+	res, body := speedtestRequest(t, "PUT", srv.URL, "/api/settings/speedtest", cookie,
+		`{"enabled":true,"intervalHours":12,"serverId":0,"alertPct":50}`)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("PUT: status %d (%v)", res.StatusCode, body)
+	}
+	if body["enabled"] != true || body["intervalHours"] != float64(12) || body["alertPct"] != float64(50) {
+		t.Fatalf("PUT echo incorrecto: %v", body)
+	}
+	res, body = speedtestRequest(t, "GET", srv.URL, "/api/settings/speedtest", cookie, "")
+	if res.StatusCode != http.StatusOK || body["enabled"] != true {
+		t.Fatalf("GET tras PUT: %d %v", res.StatusCode, body)
+	}
+	res, _ = speedtestRequest(t, "PUT", srv.URL, "/api/settings/speedtest", cookie,
+		`{"enabled":true,"intervalHours":5}`)
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("intervalo inválido: status %d, esperado 400", res.StatusCode)
+	}
+	res, _ = speedtestRequest(t, "GET", srv.URL, "/api/settings/speedtest", "", "")
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("GET sin sesión: status %d, esperado 401", res.StatusCode)
+	}
+}
+
+// TestSpeedtestHistoryAndStatus: la serie insertada sale por history y el
+// último por status; hours inválido → 400.
+func TestSpeedtestHistoryAndStatus(t *testing.T) {
+	srv := makeSpeedtestServer(t, fakeRunner{})
+	cookie := adminCookie(t, srv)
+	// Siembro dos resultados directamente en el store: no hay acceso directo
+	// desde aquí, así que uso el API tras un run-now inmediato... el fake no
+	// bloquea: mejor sembrar via run + esperar status.
+	if res, body := speedtestRequest(t, "POST", srv.URL, "/api/speedtest/run", cookie, ""); res.StatusCode != http.StatusAccepted {
+		t.Fatalf("run: %d %v", res.StatusCode, body)
+	}
+	waitFor(t, 2*time.Second, func() bool {
+		_, body := speedtestRequest(t, "GET", srv.URL, "/api/speedtest/status", cookie, "")
+		return body["last"] != nil
+	})
+	res, body := speedtestRequest(t, "GET", srv.URL, "/api/speedtest/history?hours=1", cookie, "")
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("history: %d", res.StatusCode)
+	}
+	items, _ := body["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("history: %d items, esperado 1", len(items))
+	}
+	first, _ := items[0].(map[string]any)
+	if first["downMbps"] != float64(300) || first["origin"] != "manual" {
+		t.Fatalf("item incorrecto: %v", first)
+	}
+	res, _ = speedtestRequest(t, "GET", srv.URL, "/api/speedtest/history?hours=bogus", cookie, "")
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("hours=bogus: %d, esperado 400", res.StatusCode)
+	}
+	_, st := speedtestRequest(t, "GET", srv.URL, "/api/speedtest/status", cookie, "")
+	if st["running"] != false || st["last"] == nil {
+		t.Fatalf("status: %v", st)
+	}
+}
+
+// TestSpeedtestRunNowSingleFlight: segundo POST mientras corre → 409.
+func TestSpeedtestRunNowSingleFlight(t *testing.T) {
+	runner := fakeRunner{release: make(chan struct{})}
+	srv := makeSpeedtestServer(t, runner)
+	cookie := adminCookie(t, srv)
+	res, body := speedtestRequest(t, "POST", srv.URL, "/api/speedtest/run", cookie, "")
+	if res.StatusCode != http.StatusAccepted {
+		t.Fatalf("primer run: %d %v", res.StatusCode, body)
+	}
+	res, _ = speedtestRequest(t, "POST", srv.URL, "/api/speedtest/run", cookie, "")
+	if res.StatusCode != http.StatusConflict {
+		t.Fatalf("segundo run: %d, esperado 409", res.StatusCode)
+	}
+	close(runner.release)
+	waitFor(t, 2*time.Second, func() bool {
+		_, body := speedtestRequest(t, "GET", srv.URL, "/api/speedtest/status", cookie, "")
+		return body["running"] == false && body["last"] != nil
+	})
+	res, _ = speedtestRequest(t, "POST", srv.URL, "/api/speedtest/run", "", "")
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("run sin sesión: %d, esperado 401", res.StatusCode)
+	}
+}
+
+// TestSpeedtestUnavailableInDemo: Deps.Speedtest nil → 503 en todas las
+// rutas (con sesión válida; sin sesión el gate global responde 401 antes).
+func TestSpeedtestUnavailableInDemo(t *testing.T) {
+	srv := makeTestServer(t)
+	cookie := adminCookie(t, srv)
+	for _, tc := range []struct{ method, path string }{
+		{"GET", "/api/speedtest/status"},
+		{"GET", "/api/speedtest/history"},
+		{"POST", "/api/speedtest/run"},
+		{"GET", "/api/settings/speedtest"},
+	} {
+		req, _ := http.NewRequest(tc.method, srv.URL+tc.path, nil)
+		req.Header.Set("Cookie", "session="+cookie)
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s %s: %v", tc.method, tc.path, err)
+		}
+		res.Body.Close()
+		if res.StatusCode != http.StatusServiceUnavailable {
+			t.Errorf("%s %s: %d, esperado 503", tc.method, tc.path, res.StatusCode)
+		}
+	}
+}
+
+// TestSpeedtestOverviewInjection: tras un run, el overview expone la última
+// medición en wan.speedtestDownMbps (issue #511).
+func TestSpeedtestOverviewInjection(t *testing.T) {
+	srv := makeSpeedtestServer(t, fakeRunner{})
+	cookie := adminCookie(t, srv)
+	speedtestRequest(t, "POST", srv.URL, "/api/speedtest/run", cookie, "")
+	waitFor(t, 2*time.Second, func() bool {
+		_, body := speedtestRequest(t, "GET", srv.URL, "/api/overview", cookie, "")
+		wan, _ := body["wan"].(map[string]any)
+		return wan != nil && wan["speedtestDownMbps"] != nil
+	})
+	// Sin sesión el overview también requiere auth (gate global).
+	res, _ := speedtestRequest(t, "GET", srv.URL, "/api/overview", "", "")
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("overview sin sesión: %d, esperado 401", res.StatusCode)
+	}
+}
+
+// waitFor sondea cond() hasta deadline (los runs manuales son asíncronos).
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("condición no cumplida en %v", timeout)
+}

--- a/server-go/internal/poller/poller.go
+++ b/server-go/internal/poller/poller.go
@@ -28,6 +28,13 @@ type Poller struct {
 	db      *db.DB
 	hub     *sse.Hub
 
+	// enrich (opcional) inyecta en cada overview los campos que viven en el
+	// kv del server (orchestration, plan contratado #151, speedtest #511)
+	// ANTES de cacheálo y emitirlo por SSE. Sin esto, el snapshot del SSE
+	// pisaría la copia enriquecida que sirvió /api/overview y esos campos
+	// desaparecerían de la UI al primer evento.
+	enrich func(*adapters.Overview)
+
 	mu           sync.RWMutex
 	lastOverview *adapters.Overview
 	lastAdguard  *adapters.AdGuardStats
@@ -94,6 +101,10 @@ func (p *Poller) tickOnce() {
 	p.tick()
 }
 
+// SetEnrich fija el hook de enriquecimiento del overview (main lo cablea con
+// las inyecciones kv del httpapi).
+func (p *Poller) SetEnrich(fn func(*adapters.Overview)) { p.enrich = fn }
+
 // Stop detiene el bucle y espera a que termine el tick en curso.
 func (p *Poller) Stop() {
 	p.once.Do(func() {
@@ -119,6 +130,9 @@ func (p *Poller) tick() {
 			log.Printf("[netpulse] error en tick del poller: %v", err)
 		}
 		return
+	}
+	if p.enrich != nil {
+		p.enrich(overview)
 	}
 
 	p.mu.Lock()

--- a/server-go/internal/speedtest/runner.go
+++ b/server-go/internal/speedtest/runner.go
@@ -1,0 +1,79 @@
+// runner.go — motor del test: interfaz pequeña (testeable con fakes) y la
+// implementación real contra speedtest.net vía showwin/speedtest-go.
+package speedtest
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/showwin/speedtest-go/speedtest"
+)
+
+// Runner ejecuta una medición completa. serverID > 0 fija el servidor de
+// speedtest.net; 0 = autoselección del más cercano por latencia.
+type Runner interface {
+	Run(ctx context.Context, serverID int) (Result, error)
+}
+
+// SpeedtestNetRunner es la implementación real (showwin/speedtest-go, MIT).
+// Sin estado: seguro para llamarlo en serie desde el scheduler.
+type SpeedtestNetRunner struct{}
+
+// userAgent identifica la app en las peticiones a los servidores Ookla.
+const userAgent = "netpulse-wan-monitor"
+
+func (SpeedtestNetRunner) Run(ctx context.Context, serverID int) (Result, error) {
+	client := speedtest.New(
+		speedtest.WithUserConfig(&speedtest.UserConfig{UserAgent: userAgent}))
+	list, err := client.FetchServers()
+	if err != nil {
+		return Result{}, fmt.Errorf("fetch servers: %w", err)
+	}
+	var ids []int
+	if serverID > 0 {
+		ids = []int{serverID}
+	}
+	targets, err := list.FindServer(ids)
+	if err != nil {
+		return Result{}, fmt.Errorf("find server: %w", err)
+	}
+	if len(targets) == 0 {
+		return Result{}, fmt.Errorf("no speedtest servers available")
+	}
+	srv := targets[0]
+
+	// Ping primero (barato) y luego las mediciones pesadas. Los tres
+	// métodos respetan ctx: el timeout del scheduler corta el test.
+	if err := srv.PingTestContext(ctx, nil); err != nil {
+		return Result{}, fmt.Errorf("ping: %w", err)
+	}
+	if err := srv.DownloadTestContext(ctx); err != nil {
+		return Result{}, fmt.Errorf("download: %w", err)
+	}
+	if err := srv.UploadTestContext(ctx); err != nil {
+		return Result{}, fmt.Errorf("upload: %w", err)
+	}
+
+	res := Result{
+		TS:         time.Now(),
+		DownMbps:   srv.DLSpeed.Mbps(),
+		UpMbps:     srv.ULSpeed.Mbps(),
+		ServerName: srv.Name,
+		ServerID:   srv.ID,
+	}
+	if srv.Latency > 0 {
+		v := float64(srv.Latency.Microseconds()) / 1000.0
+		res.PingMs = &v
+	}
+	if srv.Jitter > 0 {
+		v := float64(srv.Jitter.Microseconds()) / 1000.0
+		res.JitterMs = &v
+	}
+	// La pérdida del analyzer UDP solo es fiable sin proxy; -1 significa
+	// "sin datos" y se omite (LossPercent ya viene en %).
+	if pct := srv.PacketLoss.LossPercent(); pct >= 0 {
+		res.LossPct = &pct
+	}
+	return res, nil
+}

--- a/server-go/internal/speedtest/scheduler.go
+++ b/server-go/internal/speedtest/scheduler.go
@@ -1,0 +1,329 @@
+// scheduler.go — ejecución periódica del test (issue #511).
+//
+// Bucle de tick corto (30 s) que decide en cada pasada si toca medir: el
+// vencimiento se deriva del último resultado + intervalo configurado, así
+// un cambio de ajustes aplica en menos de 30 s sin canales ni reinicios.
+// Single-flight con CAS: nunca dos tests simultáneos (un test satura el
+// enlace; solaparlos falsearía ambas mediciones).
+package speedtest
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/alerts"
+)
+
+// ErrAlreadyRunning lo devuelve RunNow (y lo traduce el API a 409) cuando un
+// test está en marcha.
+var ErrAlreadyRunning = errors.New("speedtest already running")
+
+// ValidIntervals son los intervalos permitidos (horas). El mínimo de 6 h es
+// deliberado: cada test satura el enlace y consume datos (las notas de la
+// integración de Home Assistant dicen lo mismo).
+var ValidIntervals = []int{6, 12, 24}
+
+// DefaultSettings: desactivado por defecto (opt-in explícito; un test consume
+// datos de la línea y eso lo debe decidir el admin).
+const (
+	DefaultIntervalHours = 12
+	DefaultAlertPct      = 50
+	testTimeout          = 3 * time.Minute
+	tickEvery            = 30 * time.Second
+)
+
+// Settings persistidas en kv (claves settings.speedtest.*).
+type Settings struct {
+	Enabled       bool `json:"enabled"`
+	IntervalHours int  `json:"intervalHours"`
+	ServerID      int  `json:"serverId"`
+	AlertPct      int  `json:"alertPct"`
+}
+
+// Claves kv (mismo formato que settings.wan.speed_* de #151).
+const (
+	kvEnabled   = "settings.speedtest.enabled"
+	kvInterval  = "settings.speedtest.interval_h"
+	kvServerID  = "settings.speedtest.server_id"
+	kvAlertPct  = "settings.speedtest.alert_pct"
+	kvContractD = "settings.wan.speed_down" // del issue #151 (lectura)
+)
+
+// AlertEmitter lo cumple *alerts.Engine (emisión por el mismo motor que el
+// resto de alertas del server; nil = sin alertas, p. ej. en demo).
+type AlertEmitter interface {
+	Emit(ev alerts.AlertEvent) bool
+}
+
+// Scheduler orquesta store + runner + settings.
+type Scheduler struct {
+	store  *Store
+	db     *sql.DB
+	runner Runner
+	emit   AlertEmitter
+
+	// contractDown lee el plan contratado declarado (#151). Inyectada para
+	// no duplicar la lógica kv del httpapi; nil = nunca alertar.
+	contractDown func() (float64, bool)
+
+	now  func() time.Time
+	logf func(format string, args ...any)
+
+	running  atomic.Bool
+	mu       sync.Mutex
+	lastErr  string
+	belowPln bool // debounce de la alerta: true hasta que un test recupere
+}
+
+func NewScheduler(store *Store, db *sql.DB, runner Runner) *Scheduler {
+	return &Scheduler{
+		store: store, db: db, runner: runner,
+		now:  time.Now,
+		logf: func(f string, a ...any) { log.Printf("[speedtest] "+f, a...) },
+	}
+}
+
+// SetAlertEmitter fija el motor de alertas (llamado tras construir el
+// adapter live en main).
+func (s *Scheduler) SetAlertEmitter(e AlertEmitter) { s.emit = e }
+
+// SetContractDown inyecta el lector del plan contratado.
+func (s *Scheduler) SetContractDown(fn func() (float64, bool)) { s.contractDown = fn }
+
+// Start lanza el bucle periódico (daemon; no retorna).
+func (s *Scheduler) Start() {
+	ticker := time.NewTicker(tickEvery)
+	defer ticker.Stop()
+	for range ticker.C {
+		s.tick()
+	}
+}
+
+func (s *Scheduler) tick() {
+	st := s.LoadSettings()
+	if !st.Enabled || s.running.Load() {
+		return
+	}
+	last, err := s.store.Latest()
+	if err != nil {
+		s.setLastError(err)
+		return
+	}
+	// Sin resultados previos (primera activación) el primer test sale en
+	// el siguiente tick: el admin activa y ve datos en <30 s.
+	if last != nil && s.now().Sub(last.TS) < time.Duration(st.IntervalHours)*time.Hour {
+		return
+	}
+	if err := s.tryExecute(st, "scheduled"); err != nil {
+		s.logf("test programado falló: %v", err)
+	}
+}
+
+// RunNow lanza un test manual en segundo plano (POST /api/speedtest/run).
+// ErrAlreadyRunning si ya hay uno en marcha.
+func (s *Scheduler) RunNow() error {
+	if !s.running.CompareAndSwap(false, true) {
+		return ErrAlreadyRunning
+	}
+	go func() {
+		if err := s.executeLocked(s.LoadSettings(), "manual"); err != nil {
+			s.logf("test manual falló: %v", err)
+		}
+	}()
+	return nil
+}
+
+// tryExecute toma el lock de single-flight y ejecuta si estaba libre.
+func (s *Scheduler) tryExecute(st Settings, origin string) error {
+	if !s.running.CompareAndSwap(false, true) {
+		return ErrAlreadyRunning
+	}
+	return s.executeLocked(st, origin)
+}
+
+// executeLocked corre el test asumiendo running==true (el defer libera).
+func (s *Scheduler) executeLocked(st Settings, origin string) error {
+	defer s.running.Store(false)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+	res, err := s.runner.Run(ctx, st.ServerID)
+	if err != nil {
+		s.setLastError(err)
+		return err
+	}
+	res.Origin = origin
+	if res.TS.IsZero() {
+		res.TS = s.now() // runner sin TS (fakes/defensa): la serie exige ts válido
+	}
+	if err := s.store.Insert(res); err != nil {
+		s.setLastError(err)
+		return err
+	}
+	s.setLastError(nil)
+	if err := s.store.PruneBefore(s.now().Add(-RawRetention)); err != nil {
+		s.logf("prune: %v", err)
+	}
+	s.maybeAlert(st, res)
+	s.logf("test %s: %.1f↓ / %.1f↑ Mbps (server %s)",
+		origin, res.DownMbps, res.UpMbps, res.ServerName)
+	return nil
+}
+
+// Status es la foto para GET /api/speedtest/status.
+type Status struct {
+	Running   bool     `json:"running"`
+	LastError string   `json:"lastError,omitempty"`
+	Last      *Result  `json:"last,omitempty"`
+	NextRun   *int64   `json:"nextRunMs,omitempty"` // unix ms; nil = sin programar
+}
+
+// Status compone la foto actual (running, último error, último resultado y
+// próxima ejecución programada según settings + serie).
+func (s *Scheduler) Status() Status {
+	st := s.LoadSettings()
+	out := Status{Running: s.running.Load()}
+	s.mu.Lock()
+	out.LastError = s.lastErr
+	s.mu.Unlock()
+	if last, err := s.store.Latest(); err == nil {
+		out.Last = last
+		if st.Enabled && last != nil {
+			next := last.TS.Add(time.Duration(st.IntervalHours) * time.Hour)
+			if next.Before(s.now()) {
+				next = s.now().Add(tickEvery)
+			}
+			ms := next.UnixMilli()
+			out.NextRun = &ms
+		} else if st.Enabled {
+			ms := s.now().Add(tickEvery).UnixMilli()
+			out.NextRun = &ms
+		}
+	}
+	return out
+}
+
+// maybeAlert emite "velocidad por debajo del plan" con debounce por episode:
+// una alerta cuando empieza el problema y silencio hasta que un test vuelva
+// a superar el umbral (re-alertar cada 12 h sería ruido, no información).
+func (s *Scheduler) maybeAlert(st Settings, res Result) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.emit == nil || st.AlertPct <= 0 || s.contractDown == nil {
+		s.belowPln = false
+		return
+	}
+	contract, ok := s.contractDown()
+	if !ok || contract <= 0 || res.DownMbps >= contract*float64(st.AlertPct)/100 {
+		s.belowPln = false
+		return
+	}
+	if s.belowPln {
+		return
+	}
+	s.belowPln = true
+	s.emit.Emit(alerts.AlertEvent{
+		ID:       fmt.Sprintf("alert-wanslow-%d", res.TS.UnixMilli()),
+		Category: alerts.CatInternet, Urgent: false, Severity: "warn",
+		Title: "Velocidad WAN por debajo del plan",
+		Description: fmt.Sprintf(
+			"Medido %.0f Mbps de bajada contra %.0f Mbps contratados (menos del %d%% del plan)",
+			res.DownMbps, contract, st.AlertPct),
+		Hint: alerts.HintFor(alerts.HintWanSlow),
+		Time: "ahora mismo", Ts: res.TS.Unix(),
+	})
+}
+
+func (s *Scheduler) setLastError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err == nil {
+		s.lastErr = ""
+		return
+	}
+	s.lastErr = err.Error()
+}
+
+// LoadSettings lee la configuración del kv con defaults sanos (valores
+// inválidos o ausentes → default, nunca error: el test debe poder arrancar).
+func (s *Scheduler) LoadSettings() Settings {
+	st := Settings{IntervalHours: DefaultIntervalHours, AlertPct: DefaultAlertPct}
+	if s.db == nil {
+		return st
+	}
+	st.Enabled = kvGet(s.db, kvEnabled) == "1"
+	if v, ok := kvInt(s.db, kvInterval); ok && validInterval(v) {
+		st.IntervalHours = v
+	}
+	if v, ok := kvInt(s.db, kvServerID); ok && v > 0 {
+		st.ServerID = v
+	}
+	if v, ok := kvInt(s.db, kvAlertPct); ok && v >= 0 && v <= 90 {
+		st.AlertPct = v
+	}
+	return st
+}
+
+// SaveSettings valida y persiste (UPSERT por clave).
+func (s *Scheduler) SaveSettings(st Settings) error {
+	if !validInterval(st.IntervalHours) {
+		return fmt.Errorf("intervalo inválido (%d): permite %v", st.IntervalHours, ValidIntervals)
+	}
+	if st.ServerID < 0 {
+		return errors.New("serverId no puede ser negativo")
+	}
+	if st.AlertPct < 0 || st.AlertPct > 90 {
+		return errors.New("alertPct debe estar entre 0 y 90 (0 = desactivada)")
+	}
+	kvSet(s.db, kvEnabled, boolStr(st.Enabled))
+	kvSet(s.db, kvInterval, fmt.Sprintf("%d", st.IntervalHours))
+	kvSet(s.db, kvServerID, fmt.Sprintf("%d", st.ServerID))
+	kvSet(s.db, kvAlertPct, fmt.Sprintf("%d", st.AlertPct))
+	return nil
+}
+
+func validInterval(v int) bool {
+	for _, i := range ValidIntervals {
+		if i == v {
+			return true
+		}
+	}
+	return false
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}
+
+func kvGet(db *sql.DB, key string) string {
+	var v string
+	if err := db.QueryRow("SELECT value FROM kv WHERE key = ?", key).Scan(&v); err != nil {
+		return ""
+	}
+	return v
+}
+
+func kvInt(db *sql.DB, key string) (int, bool) {
+	var n int
+	if _, err := fmt.Sscanf(kvGet(db, key), "%d", &n); err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+func kvSet(db *sql.DB, key, val string) {
+	if _, err := db.Exec(
+		`INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+		key, val); err != nil {
+		log.Printf("[speedtest] kv set %s: %v", key, err)
+	}
+}

--- a/server-go/internal/speedtest/scheduler.go
+++ b/server-go/internal/speedtest/scheduler.go
@@ -93,6 +93,9 @@ func NewScheduler(store *Store, db *sql.DB, runner Runner) *Scheduler {
 // adapter live en main).
 func (s *Scheduler) SetAlertEmitter(e AlertEmitter) { s.emit = e }
 
+// Store expone el store para las rutas de lectura (history/latest).
+func (s *Scheduler) Store() *Store { return s.store }
+
 // SetContractDown inyecta el lector del plan contratado.
 func (s *Scheduler) SetContractDown(fn func() (float64, bool)) { s.contractDown = fn }
 

--- a/server-go/internal/speedtest/speedtest_test.go
+++ b/server-go/internal/speedtest/speedtest_test.go
@@ -1,0 +1,243 @@
+package speedtest
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/alerts"
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+func openStore(t *testing.T) (*Store, *Scheduler) {
+	t.Helper()
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	st, err := NewStore(d.DB)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	return st, NewScheduler(st, d.DB, fakeRunner{})
+}
+
+func TestStoreInsertLatestHistoryPrune(t *testing.T) {
+	st, _ := openStore(t)
+	base := time.Now()
+	for i := 0; i < 3; i++ {
+		ping := float64(10 + i)
+		if err := st.Insert(Result{
+			TS: base.Add(time.Duration(i) * time.Hour), DownMbps: 100, UpMbps: 30,
+			PingMs: &ping, ServerName: "srv", Origin: "scheduled",
+		}); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	last, err := st.Latest()
+	if err != nil || last == nil {
+		t.Fatalf("latest: %v %v", last, err)
+	}
+	if last.TS.Sub(base) < 2*time.Hour-time.Second {
+		t.Fatalf("latest no es el más reciente: %v", last.TS)
+	}
+	hist, err := st.History(base.Add(-time.Minute), base.Add(3*time.Hour))
+	if err != nil || len(hist) != 3 {
+		t.Fatalf("history: %v %d", err, len(hist))
+	}
+	if hist[0].PingMs == nil || *hist[0].PingMs != 10 {
+		t.Fatalf("ping no persistió como nullable: %v", hist[0].PingMs)
+	}
+	// Prune con cutoff posterior a todo → tabla vacía.
+	if err := st.PruneBefore(base.Add(3 * time.Hour)); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if last, _ := st.Latest(); last != nil {
+		t.Fatalf("prune no vació la tabla")
+	}
+}
+
+func TestSettingsRoundtripAndValidation(t *testing.T) {
+	_, sched := openStore(t)
+	got := sched.LoadSettings()
+	if got.Enabled || got.IntervalHours != DefaultIntervalHours {
+		t.Fatalf("defaults inesperados: %+v", got)
+	}
+	if err := sched.SaveSettings(Settings{Enabled: true, IntervalHours: 24, ServerID: 1234, AlertPct: 60}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got = sched.LoadSettings()
+	if !got.Enabled || got.IntervalHours != 24 || got.ServerID != 1234 || got.AlertPct != 60 {
+		t.Fatalf("roundtrip: %+v", got)
+	}
+	if err := sched.SaveSettings(Settings{IntervalHours: 5}); err == nil {
+		t.Fatalf("intervalo inválido aceptado")
+	}
+	if err := sched.SaveSettings(Settings{IntervalHours: 12, AlertPct: 95}); err == nil {
+		t.Fatalf("alertPct fuera de rango aceptado")
+	}
+	// Claves corruptas → defaults, sin error.
+	if _, err := sched.db.Exec("UPDATE kv SET value='garbage' WHERE key=?", kvInterval); err != nil {
+		t.Fatalf("corrupt: %v", err)
+	}
+	if got := sched.LoadSettings(); got.IntervalHours != DefaultIntervalHours {
+		t.Fatalf("valor corrupto no cayó al default: %d", got.IntervalHours)
+	}
+}
+
+func TestTickRunsWhenDueAndNotBefore(t *testing.T) {
+	st, sched := openStore(t)
+	runner := &countingRunner{}
+	sched.runner = runner
+	sched.now = func() time.Time { return time.Unix(1_700_000_000, 0) }
+	if err := sched.SaveSettings(Settings{Enabled: true, IntervalHours: 6}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	// Sin resultados previos: el tick ejecuta (primera activación).
+	sched.tick()
+	if runner.calls() != 1 {
+		t.Fatalf("primer tick no ejecutó: %d", runner.calls())
+	}
+	// Con el último reciente: no debe volver a ejecutar.
+	sched.tick()
+	if runner.calls() != 1 {
+		t.Fatalf("ejecutó antes del intervalo: %d", runner.calls())
+	}
+	// Con now avanzado 7h: ejecuta de nuevo.
+	sched.now = func() time.Time { return time.Unix(1_700_000_000, 0).Add(7 * time.Hour) }
+	sched.tick()
+	if runner.calls() != 2 {
+		t.Fatalf("no ejecutó al vencer: %d", runner.calls())
+	}
+	if last, _ := st.Latest(); last == nil || last.Origin != "scheduled" {
+		t.Fatalf("serie sin resultado programado: %+v", last)
+	}
+	// Desactivado: nunca ejecuta.
+	if err := sched.SaveSettings(Settings{Enabled: false, IntervalHours: 6}); err != nil {
+		t.Fatalf("save off: %v", err)
+	}
+	sched.tick()
+	if runner.calls() != 2 {
+		t.Fatalf("ejecutó estando desactivado: %d", runner.calls())
+	}
+}
+
+func TestRunNowSingleFlight(t *testing.T) {
+	_, sched := openStore(t)
+	runner := &blockingRunner{release: make(chan struct{})}
+	sched.runner = runner
+	if err := sched.RunNow(); err != nil {
+		t.Fatalf("runnow: %v", err)
+	}
+	if err := sched.RunNow(); !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("segundo RunNow no devolvió ErrAlreadyRunning: %v", err)
+	}
+	close(runner.release)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if sched.Status().Running == false && sched.Status().Last != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	st := sched.Status()
+	if st.Running || st.Last == nil || st.Last.Origin != "manual" {
+		t.Fatalf("estado tras runnow: %+v", st)
+	}
+}
+
+func TestMaybeAlertDebounce(t *testing.T) {
+	_, sched := openStore(t)
+	em := &fakeEmitter{}
+	sched.emit = em
+	sched.contractDown = func() (float64, bool) { return 300, true }
+	pct := 50
+	// Sin umbral configurado → nunca.
+	sched.maybeAlert(Settings{AlertPct: 0}, Result{DownMbps: 10})
+	if em.count() != 0 {
+		t.Fatalf("alertó con AlertPct=0")
+	}
+	low := Settings{AlertPct: pct}
+	ok := Result{DownMbps: 200}
+	bad := Result{DownMbps: 100}
+	// Episodio: primera caída alerta, las siguientes no.
+	sched.maybeAlert(low, bad)
+	sched.maybeAlert(low, bad)
+	if em.count() != 1 {
+		t.Fatalf("debounce por episode falló: %d", em.count())
+	}
+	// Recuperación + nueva caída → segunda alerta.
+	sched.maybeAlert(low, ok)
+	sched.maybeAlert(low, bad)
+	if em.count() != 2 {
+		t.Fatalf("no re-alertó tras recuperación: %d", em.count())
+	}
+	// Sin plan declarado → no alerta (y resetea el estado).
+	sched.contractDown = func() (float64, bool) { return 0, false }
+	sched.maybeAlert(low, bad)
+	if em.count() != 2 {
+		t.Fatalf("alertó sin plan contratado")
+	}
+	// La alerta lleva hint y categoría internet.
+	if em.last.Hint != alerts.HintFor(alerts.HintWanSlow) || em.last.Category != alerts.CatInternet {
+		t.Fatalf("evento mal formado: %+v", em.last)
+	}
+}
+
+// fakeRunner devuelve un resultado fijo sin red.
+type fakeRunner struct{}
+
+func (fakeRunner) Run(ctx context.Context, serverID int) (Result, error) {
+	return Result{DownMbps: 100, UpMbps: 30, ServerName: "fake"}, nil
+}
+
+type countingRunner struct {
+	mu    sync.Mutex
+	n     int
+	inner fakeRunner
+}
+
+func (c *countingRunner) Run(ctx context.Context, serverID int) (Result, error) {
+	c.mu.Lock()
+	c.n++
+	c.mu.Unlock()
+	return c.inner.Run(ctx, serverID)
+}
+
+func (c *countingRunner) calls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.n
+}
+
+type blockingRunner struct {
+	release chan struct{}
+}
+
+func (b *blockingRunner) Run(ctx context.Context, serverID int) (Result, error) {
+	<-b.release
+	return Result{DownMbps: 50, UpMbps: 10, ServerName: "blocked"}, nil
+}
+
+type fakeEmitter struct {
+	mu   sync.Mutex
+	n    int
+	last alerts.AlertEvent
+}
+
+func (f *fakeEmitter) Emit(ev alerts.AlertEvent) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.n++
+	f.last = ev
+	return true
+}
+
+func (f *fakeEmitter) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.n
+}

--- a/server-go/internal/speedtest/store.go
+++ b/server-go/internal/speedtest/store.go
@@ -1,0 +1,160 @@
+// Package speedtest — test de velocidad WAN periódico (issue #511).
+//
+// Mide download/upload/latencia/jitter desde el host del server contra
+// speedtest.net (showwin/speedtest-go, MIT), persiste la serie en SQLite y
+// alimenta la tarjeta WAN del router gateway con valores medidos en lugar de
+// aproximaciones. La ejecución es deliberadamente server-side: el router ya
+// dedica su CPU al NAT y un test desde él competiría consigo mismo.
+package speedtest
+
+import (
+	"database/sql"
+	"time"
+)
+
+// RawRetention: los tests son discretos (1-4 al día como mucho), la tabla
+// crece despacio y el valor está en la tendencia anual de la línea.
+const RawRetention = 365 * 24 * time.Hour
+
+const schemaSQL = `
+CREATE TABLE IF NOT EXISTS speedtest_results (
+  ts INTEGER PRIMARY KEY,
+  down_mbps REAL NOT NULL,
+  up_mbps REAL NOT NULL,
+  ping_ms REAL,
+  jitter_ms REAL,
+  loss_pct REAL,
+  server_name TEXT NOT NULL DEFAULT '',
+  server_id TEXT NOT NULL DEFAULT '',
+  origin TEXT NOT NULL DEFAULT 'scheduled',
+  error TEXT
+);
+`
+
+// Result es una medición completada. PingMs/JitterMs/LossPct son nil cuando
+// el servidor no los aportó (se guardan como NULL y el frontend los omite).
+type Result struct {
+	TS         time.Time `json:"ts"`
+	DownMbps   float64   `json:"downMbps"`
+	UpMbps     float64   `json:"upMbps"`
+	PingMs     *float64  `json:"pingMs,omitempty"`
+	JitterMs   *float64  `json:"jitterMs,omitempty"`
+	LossPct    *float64  `json:"lossPct,omitempty"`
+	ServerName string    `json:"serverName,omitempty"`
+	ServerID   string    `json:"serverId,omitempty"`
+	Origin     string    `json:"origin,omitempty"`
+	Error      string    `json:"error,omitempty"`
+}
+
+// Store envuelve la tabla speedtest_results (patrón clientbw: schema en el
+// propio paquete con CREATE TABLE IF NOT EXISTS al construir).
+type Store struct {
+	db *sql.DB
+}
+
+func NewStore(db *sql.DB) (*Store, error) {
+	if db != nil {
+		if _, err := db.Exec(schemaSQL); err != nil {
+			return nil, err
+		}
+	}
+	return &Store{db: db}, nil
+}
+
+// Insert guarda un resultado. La serie solo guarda éxitos: los fallos del
+// runner no ensucian la gráfica (se exponen por Status).
+func (s *Store) Insert(r Result) error {
+	if s.db == nil {
+		return nil
+	}
+	_, err := s.db.Exec(
+		`INSERT OR REPLACE INTO speedtest_results
+		 (ts, down_mbps, up_mbps, ping_ms, jitter_ms, loss_pct, server_name, server_id, origin, error)
+		 VALUES (?,?,?,?,?,?,?,?,?,?)`,
+		r.TS.UnixMilli(), r.DownMbps, r.UpMbps,
+		nullFloat(r.PingMs), nullFloat(r.JitterMs), nullFloat(r.LossPct),
+		r.ServerName, r.ServerID, r.Origin, r.Error)
+	return err
+}
+
+// Latest devuelve el resultado más reciente (nil si la serie está vacía).
+func (s *Store) Latest() (*Result, error) {
+	if s.db == nil {
+		return nil, nil
+	}
+	row := s.db.QueryRow(`SELECT ts, down_mbps, up_mbps, ping_ms, jitter_ms, loss_pct,
+	 server_name, server_id, origin, error FROM speedtest_results ORDER BY ts DESC LIMIT 1`)
+	return scanResult(row)
+}
+
+// History devuelve los resultados de la ventana [from, to] en orden ascendente.
+func (s *Store) History(from, to time.Time) ([]Result, error) {
+	if s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.Query(`SELECT ts, down_mbps, up_mbps, ping_ms, jitter_ms, loss_pct,
+	 server_name, server_id, origin, error FROM speedtest_results
+	 WHERE ts >= ? AND ts <= ? ORDER BY ts`,
+		from.UnixMilli(), to.UnixMilli())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Result
+	for rows.Next() {
+		r, err := scanResult(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *r)
+	}
+	return out, rows.Err()
+}
+
+// PruneBefore elimina resultados anteriores al cutoff (lo llama el
+// scheduler tras cada test con su reloj inyectable: sin trabajo extra, la
+// retención se cumple sola).
+func (s *Store) PruneBefore(cutoff time.Time) error {
+	if s.db == nil {
+		return nil
+	}
+	_, err := s.db.Exec(`DELETE FROM speedtest_results WHERE ts < ?`, cutoff.UnixMilli())
+	return err
+}
+
+func nullFloat(v *float64) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}
+
+// scanner cubre QueryRow y Rows (ambos implementan Scan).
+type scanner interface{ Scan(dest ...any) error }
+
+func scanResult(sc scanner) (*Result, error) {
+	var r Result
+	var ts int64
+	var ping, jitter, loss sql.NullFloat64
+	if err := sc.Scan(&ts, &r.DownMbps, &r.UpMbps, &ping, &jitter, &loss,
+		&r.ServerName, &r.ServerID, &r.Origin, &r.Error); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	r.TS = time.UnixMilli(ts)
+	if ping.Valid {
+		v := ping.Float64
+		r.PingMs = &v
+	}
+	if jitter.Valid {
+		v := jitter.Float64
+		r.JitterMs = &v
+	}
+	if loss.Valid {
+		v := loss.Float64
+		r.LossPct = &v
+	}
+	return &r, nil
+}


### PR DESCRIPTION
Adds a configurable periodic speed test against speedtest.net (showwin/speedtest-go, MIT) that measures real WAN download/upload plus latency, jitter and packet loss from the server host.

- New `internal/speedtest` package: SQLite results series (365-day retention), speedtest.net runner and a 30s-tick scheduler with single-flight (6/12/24h interval, manual run).
- Alert with per-episode debounce when measured download stays below a configurable % of the contracted plan (#151).
- API: `GET /api/speedtest/status|history`, `POST /api/speedtest/run`, `GET/PUT /api/settings/speedtest`; 503 in demo mode.
- Overview now carries the latest measurement (`wan.speedtest*`).
- UI: "Measured speed" strip in the WAN card (last result, plan percentage badge, 7-day chart, run button with live polling) and a settings card in Settings > Data and thresholds. ES/EN strings.
- Fix a pre-existing bug: SSE snapshots were clobbering the enriched overview (contracted plan #151 disappeared after the first snapshot); the poller now enriches before broadcasting (`Poller.SetEnrich` / `httpapi.EnrichOverview`).

Verified: full server + agent suites green; real E2E on the test CT (scheduled and manual runs against Málaga/Granada servers, history/overview/409/400/401) and Playwright 9/9.

Closes #511