### PR TITLE
feat(firmware): dismiss stale failed upgrade notice

### DIFF
--- a/app/node_modules
+++ b/app/node_modules
@@ -1,0 +1,1 @@
+/home/nacho/temp/opencode-work/netpulse-518/app/node_modules

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1448,7 +1448,8 @@
       "flashing": "Flashing",
       "done": "Done",
       "failed": "Failed"
-    }
+    },
+    "dismiss": "Dismiss notice"
   },
   "orchestration": {
     "title": "Orchestration",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1448,7 +1448,8 @@
       "flashing": "Flasheando",
       "done": "Completada",
       "failed": "Fallida"
-    }
+    },
+    "dismiss": "Descartar aviso"
   },
   "orchestration": {
     "title": "Orquestación",

--- a/app/src/pages/FirmwareUpgrades.tsx
+++ b/app/src/pages/FirmwareUpgrades.tsx
@@ -132,6 +132,20 @@ export default function FirmwareUpgrades() {
     }
   }
 
+  // #519: descartar el aviso de un intento de upgrade fallido/obsoleto.
+  const dismissUpgrade = async (id: string) => {
+    setBusy((prev) => ({ ...prev, [id]: 'dismiss' }))
+    try {
+      const res = await fetch(`/api/firmware-upgrades/${encodeURIComponent(id)}/failure`, { method: 'DELETE' })
+      if (!res.ok) throw new Error(await res.text())
+      await fetchItems()
+    } catch (err) {
+      setError(String(err))
+    } finally {
+      setBusy((prev) => ({ ...prev, [id]: '' }))
+    }
+  }
+
   const startUpgrade = async (id: string) => {
     setBusy((prev) => ({ ...prev, [id]: 'upgrade' }))
     try {
@@ -304,12 +318,23 @@ export default function FirmwareUpgrades() {
               )}
 
               {item.upgrade?.error && (
-                <div className="mt-4 rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-600 dark:text-rose-400">
+                <div className="mt-4 flex items-center justify-between gap-3 rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-600 dark:text-rose-400">
                   {/* Timestamp del fallo: un error antiguo NO debe leerse como
                       estado presente del agente (feedback #477). */}
-                  {t('firmwareUpgrades.lastFailure')}
-                  {relTimeFromTs(item.upgrade.startedAt) ? ` (${relTimeFromTs(item.upgrade.startedAt)})` : ''}:{' '}
-                  {item.upgrade.error}
+                  <span>
+                    {t('firmwareUpgrades.lastFailure')}
+                    {relTimeFromTs(item.upgrade.startedAt) ? ` (${relTimeFromTs(item.upgrade.startedAt)})` : ''}:{' '}
+                    {item.upgrade.error}
+                  </span>
+                  {isAdmin && (
+                    <button
+                      onClick={() => void dismissUpgrade(item.routerId)}
+                      disabled={busy[item.routerId] === 'dismiss' || active}
+                      className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-lg border border-rose-500/40 px-2.5 text-xs font-medium transition-colors hover:bg-rose-500/10 disabled:opacity-50"
+                    >
+                      {busy[item.routerId] === 'dismiss' ? t('common.loading') : t('firmwareUpgrades.dismiss')}
+                    </button>
+                  )}
                 </div>
               )}
 

--- a/server-go/internal/firmware/store.go
+++ b/server-go/internal/firmware/store.go
@@ -124,13 +124,14 @@ func (s *Store) SetStatus(id int64, status, errMsg, backupPath string) error {
 func (s *Store) LatestUpgrade(routerID string) (*Upgrade, error) {
 	var u Upgrade
 	var finished sql.NullInt64
+	var errStr, backup sql.NullString
 	err := s.db.QueryRow(`
 		SELECT id, router_id, target_version, target_url, checksum, status, error, backup_path, started_at, finished_at
 		FROM firmware_upgrades
 		WHERE router_id = ?
 		ORDER BY started_at DESC
 		LIMIT 1
-	`, routerID).Scan(&u.ID, &u.RouterID, &u.TargetVersion, &u.TargetURL, &u.Checksum, &u.Status, &u.Error, &u.BackupPath, &u.StartedAt, &finished)
+	`, routerID).Scan(&u.ID, &u.RouterID, &u.TargetVersion, &u.TargetURL, &u.Checksum, &u.Status, &errStr, &backup, &u.StartedAt, &finished)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -139,6 +140,12 @@ func (s *Store) LatestUpgrade(routerID string) (*Upgrade, error) {
 	}
 	if finished.Valid {
 		u.FinishedAt = &finished.Int64
+	}
+	if errStr.Valid {
+		u.Error = errStr.String
+	}
+	if backup.Valid {
+		u.BackupPath = backup.String
 	}
 	return &u, nil
 }
@@ -147,18 +154,41 @@ func (s *Store) LatestUpgrade(routerID string) (*Upgrade, error) {
 func (s *Store) GetUpgradeByID(id int64) (*Upgrade, error) {
 	var u Upgrade
 	var finished sql.NullInt64
+	var errStr, backup sql.NullString
 	err := s.db.QueryRow(`
 		SELECT id, router_id, target_version, target_url, checksum, status, error, backup_path, started_at, finished_at
 		FROM firmware_upgrades WHERE id = ?
-	`, id).Scan(&u.ID, &u.RouterID, &u.TargetVersion, &u.TargetURL, &u.Checksum, &u.Status, &u.Error, &u.BackupPath, &u.StartedAt, &finished)
+	`, id).Scan(&u.ID, &u.RouterID, &u.TargetVersion, &u.TargetURL, &u.Checksum, &u.Status, &errStr, &backup, &u.StartedAt, &finished)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
 	}
+	if errStr.Valid {
+		u.Error = errStr.String
+	}
+	if backup.Valid {
+		u.BackupPath = backup.String
+	}
 	if finished.Valid {
 		u.FinishedAt = &finished.Int64
 	}
 	return &u, nil
+}
+
+// DismissLatest borra el último intento de upgrade del router si está
+// terminado (failed o done). Un upgrade en curso (requested/running) no se
+// toca: el aviso de error obsoleto debe poder descartarse (#519) sin poder
+// cancelar una operación viva por accidente.
+func (s *Store) DismissLatest(routerID string) error {
+	up, err := s.LatestUpgrade(routerID)
+	if err != nil {
+		return err
+	}
+	if up == nil || (up.Status != "failed" && up.Status != "done") {
+		return nil
+	}
+	_, err = s.db.Exec(`DELETE FROM firmware_upgrades WHERE id = ?`, up.ID)
+	return err
 }

--- a/server-go/internal/firmware/store_test.go
+++ b/server-go/internal/firmware/store_test.go
@@ -1,0 +1,61 @@
+// store_test.go — contrato del store de firmware (issue #519: descarte del
+// último intento fallido).
+package firmware
+
+import (
+	"testing"
+
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+func open(t *testing.T) *Store {
+	t.Helper()
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return NewStore(d.DB)
+}
+
+func TestDismissLatestFailed(t *testing.T) {
+	s := open(t)
+	id, err := s.BeginUpgrade("rt1", "v2", "http://x", "abc")
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := s.SetStatus(id, "failed", "agent not connected", ""); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	up, _ := s.LatestUpgrade("rt1")
+	if up == nil || up.Status != "failed" {
+		t.Fatalf("esperaba upgrade failed, got %+v", up)
+	}
+	if err := s.DismissLatest("rt1"); err != nil {
+		t.Fatalf("dismiss: %v", err)
+	}
+	up, _ = s.LatestUpgrade("rt1")
+	if up != nil {
+		t.Fatalf("tras dismiss no debería haber upgrade: %+v", up)
+	}
+}
+
+func TestDismissLatestKeepsRunning(t *testing.T) {
+	s := open(t)
+	id, err := s.BeginUpgrade("rt1", "v2", "http://x", "abc")
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	// Estado en curso (requested): el descarte no debe tocarlo.
+	if err := s.DismissLatest("rt1"); err != nil {
+		t.Fatalf("dismiss: %v", err)
+	}
+	up, _ := s.LatestUpgrade("rt1")
+	if up == nil || up.ID != id {
+		t.Fatalf("un upgrade en curso debe sobrevivir al dismiss: %+v", up)
+	}
+	// Router sin upgrades: no debe fallar.
+	if err := s.DismissLatest("no-existe"); err != nil {
+		t.Fatalf("dismiss sin upgrades: %v", err)
+	}
+}

--- a/server-go/internal/httpapi/firmware.go
+++ b/server-go/internal/httpapi/firmware.go
@@ -99,8 +99,23 @@ func (s *server) registerFirmwareRoutes(mux *http.ServeMux) {
 		writeJSON(w, http.StatusOK, out)
 	})))
 
-	mux.Handle("GET /api/firmware-upgrades/{routerId}", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		id := r.PathValue("routerId")
+	// DELETE /api/firmware-upgrades/{routerId}/failure: descarta el último
+	// intento de upgrade terminado (failed/done) del router (#519). Permite
+	// cerrar un aviso de error obsoleto sin poder cancelar un upgrade vivo.
+	mux.Handle("DELETE /api/firmware-upgrades/{routerId}/failure", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		routerID := r.PathValue("routerId")
+		if routerID == "" {
+			writeError(w, http.StatusBadRequest, "invalid_input", "routerId requerido")
+			return
+		}
+		if err := s.firmware.DismissLatest(routerID); err != nil {
+			writeError(w, http.StatusInternalServerError, "firmware_error")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+	})))
+
+	mux.Handle("GET /api/firmware-upgrades/{routerId}", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {		id := r.PathValue("routerId")
 		item, err := s.firmwareStatus(id)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "firmware_error")


### PR DESCRIPTION
A failed firmware upgrade attempt (e.g. "agent not connected" from an old incident) stayed on the page forever with no way to clear it, even when the router was healthy again and on the target version.

- New endpoint DELETE /api/firmware-upgrades/{routerId}/failure: removes the latest finished (failed/done) upgrade record for the router; an in-progress upgrade is never touched.
- Dismiss button on the failed-notice banner (shown to admins).
- Fixed a latent store bug: LatestUpgrade/GetUpgradeByID failed to scan NULL error/backup_path, so in-progress upgrades were silently missing from the list.

Closes #519