### PR TITLE
fix(poller): bound Stop wait so a slow SNMP tick cannot hang shutdown (#481)

### DIFF
--- a/server-go/internal/poller/poller.go
+++ b/server-go/internal/poller/poller.go
@@ -105,11 +105,21 @@ func (p *Poller) tickOnce() {
 // las inyecciones kv del httpapi).
 func (p *Poller) SetEnrich(fn func(*adapters.Overview)) { p.enrich = fn }
 
-// Stop detiene el bucle y espera a que termine el tick en curso.
+// stopWait acota cuánto espera Stop al tick en curso. Issue #481: un sondeo
+// SNMP/SSH lento (o una primitiva de red sin deadline) no debe colgar el
+// apagado hasta que systemd mate el proceso por TimeoutStopSec; cuando main
+// retorna, el proceso muere igualmente y se lleva la goroutine colgada.
+var stopWait = 15 * time.Second
+
+// Stop detiene el bucle y espera al tick en curso como mucho stopWait.
 func (p *Poller) Stop() {
 	p.once.Do(func() {
 		close(p.stopCh)
-		<-p.doneCh
+		select {
+		case <-p.doneCh:
+		case <-time.After(stopWait):
+			log.Printf("[netpulse] poller: el tick en curso no terminó en %v; el apagado continúa igualmente", stopWait)
+		}
 	})
 }
 

--- a/server-go/internal/poller/poller_test.go
+++ b/server-go/internal/poller/poller_test.go
@@ -1,0 +1,63 @@
+package poller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/adapters"
+)
+
+// blockingAdapter embebe el adaptador demo (Snapshotter completo) y bloquea
+// GetOverview hasta que release se cierre: simula un sondeo SNMP/SSH colgado
+// (issue #481).
+type blockingAdapter struct {
+	*adapters.Demo
+	release chan struct{}
+}
+
+func (b *blockingAdapter) GetOverview(context.Context) (*adapters.Overview, error) {
+	<-b.release
+	return nil, nil
+}
+
+func newBlockingPoller() (*Poller, *blockingAdapter) {
+	a := &blockingAdapter{Demo: adapters.NewDemo(), release: make(chan struct{})}
+	return New(a, nil, nil), a
+}
+
+func TestStopDoesNotHangOnSlowTick(t *testing.T) {
+	old := stopWait
+	stopWait = 150 * time.Millisecond
+	defer func() { stopWait = old }()
+
+	p, a := newBlockingPoller()
+	p.Start()
+	// espera a que el primer tick entre en GetOverview (bloqueado)
+	time.Sleep(50 * time.Millisecond)
+
+	start := time.Now()
+	p.Stop()
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("Stop se bloqueó %v con un tick colgado; se esperaba <= ~150ms", elapsed)
+	}
+	close(a.release)
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestStopWaitsForFinishedTick(t *testing.T) {
+	old := stopWait
+	stopWait = 150 * time.Millisecond
+	defer func() { stopWait = old }()
+
+	p, a := newBlockingPoller()
+	p.Start()
+	time.Sleep(50 * time.Millisecond)
+	close(a.release) // el tick termina solo
+
+	start := time.Now()
+	p.Stop()
+	if elapsed := time.Since(start); elapsed > stopWait {
+		t.Fatalf("Stop tardó %v con un tick que ya terminó; se esperaba < %v", elapsed, stopWait)
+	}
+}


### PR DESCRIPTION
When a poller tick is stuck on a slow/hung SNMP or SSH poll, Poller.Stop() waited on the in-flight tick forever, so the systemd stop hung until TimeoutStopSec killed the process.

Stop now waits at most 15s (stopWait) and logs that it gave up; main returns and the process exits with the stuck goroutine. The tick itself already terminates on its own thanks to the gosnmp timeout (5s + 1 retry), so bounded waiting never aborts a poll that would otherwise finish.

Includes two regression tests (blocking adapter): Stop returns promptly on a hung tick, and still waits for a tick that finishes.