### PR TITLE
feat(devices): discover wired static-IP hosts via router ARP table (#507)

### DIFF
--- a/server-go/internal/adapters/arp_test.go
+++ b/server-go/internal/adapters/arp_test.go
@@ -29,6 +29,61 @@ func TestBuildDevicesArpFallback(t *testing.T) {
 	}
 }
 
+// TestBuildDevicesArpDiscovery: una MAC visible SOLO por ARP (sin wireless,
+// sin FDB, sin lease, sin device_attrib) aparece como dispositivo cableado
+// online con la IP de la tabla ARP y el RouterID del router que la reportó
+// (#507).
+func TestBuildDevicesArpDiscovery(t *testing.T) {
+	l := NewLive(nil, nil, nil, nil)
+	polled := map[string]*routerPolled{
+		"patio": {
+			cfg: RouterConfig{ID: "patio", Name: "Patio", Host: "192.168.1.2"},
+			arp: map[string]string{
+				"AA:BB:CC:DD:EE:FF": "192.168.1.60",
+			},
+		},
+	}
+	devs := l.buildDevices(polled)
+	if len(devs) != 1 {
+		t.Fatalf("esperado 1 dispositivo, got %d: %+v", len(devs), devs)
+	}
+	d := devs[0]
+	if d.MAC != "AA:BB:CC:DD:EE:FF" {
+		t.Fatalf("MAC esperada AA:BB:CC:DD:EE:FF, got %q", d.MAC)
+	}
+	if d.IP != "192.168.1.60" {
+		t.Fatalf("IP esperada 192.168.1.60, got %q", d.IP)
+	}
+	if d.Band != "cable" {
+		t.Fatalf("Band esperada cable, got %q", d.Band)
+	}
+	if !d.Online {
+		t.Fatalf("Online esperado true (presencia ARP = activo reciente)")
+	}
+	if d.RouterID != "patio" {
+		t.Fatalf("RouterID esperado patio, got %q", d.RouterID)
+	}
+}
+
+// TestBuildDevicesArpRouterExcluded: una MAC de bridge/router presente en la
+// tabla ARP NO debe aparecer como dispositivo (#507).
+func TestBuildDevicesArpRouterExcluded(t *testing.T) {
+	l := NewLive(nil, nil, nil, nil)
+	polled := map[string]*routerPolled{
+		"patio": {
+			cfg:   RouterConfig{ID: "patio", Name: "Patio", Host: "192.168.1.2"},
+			brMac: "AA:BB:CC:DD:EE:FF",
+			arp: map[string]string{
+				"AA:BB:CC:DD:EE:FF": "192.168.1.60",
+			},
+		},
+	}
+	devs := l.buildDevices(polled)
+	if len(devs) != 0 {
+		t.Fatalf("esperado 0 dispositivos (bridge MAC excluida), got %d: %+v", len(devs), devs)
+	}
+}
+
 func TestPolledFromAgentArp(t *testing.T) {
 	l := NewLive(nil, nil, nil, nil)
 	pl := &probe.Payload{Router: "patio", Version: "0.1.0"}

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -1835,6 +1835,34 @@ func (l *Live) buildDevices(polled map[string]*routerPolled) []Device {
 			}
 		}
 	}
+	// (4) ARP (#507): hosts cableados con IP estática visibles SOLO en la
+	// tabla ARP del router (ni wireless, ni FDB, ni lease, ni device_attrib).
+	// Presencia en la tabla = activo recientemente → online este tick. No se
+	// persiste: cuando la entrada envejece, el host desaparece del snapshot.
+	// Se itera en orden de router ID para atribuir deterministamente el
+	// RouterID correcto cuando varios routers ven la misma MAC (misma LAN).
+	// La exclusión de MACs de router/bridge se aplica en el bucle de
+	// dispositivos (routerMacs), igual que para leases/known: aquí no se
+	// duplica ese filtro.
+	arpRouterIDs := make([]string, 0, len(polled))
+	for routerID := range polled {
+		arpRouterIDs = append(arpRouterIDs, routerID)
+	}
+	sort.Strings(arpRouterIDs)
+	for _, routerID := range arpRouterIDs {
+		for mac := range polled[routerID].arp {
+			if _, ok := seen[mac]; ok {
+				continue
+			}
+			if _, ok := leasesByMac[mac]; ok {
+				continue
+			}
+			if _, ok := known[mac]; ok {
+				continue
+			}
+			seen[mac] = seenInfo{routerID, "cable", nil}
+		}
+	}
 
 	allMacs := map[string]bool{}
 	for mac := range leasesByMac {


### PR DESCRIPTION
The agent already pushes its IPv4 neighbor table (MAC -> IP) every 30s and on wireless events, but the server only used it to fill in the IP of devices already known via wireless/FDB/DHCP.

Now any MAC present in a polled router's ARP table that is not already a known device (wireless candidate, FDB candidate, DHCP lease or device_attrib entry) and not a router/bridge MAC appears as a wired (cable) device, online, with the IP from the ARP table and the RouterID of the router that reported it. Per explicit product decision: IPv4 ARP only (no NDP yet) and no persistence - ARP-only hosts show up while the router has them in its neighbor table and disappear when the entry ages out.

Tests: ARP-only MAC appears as wired online device with its ARP IP and RouterID; bridge/router MAC present in ARP is excluded. Full server suite green.