### PR TITLE
feat(firmware): schedule unattended firmware upgrades (#494)

### DIFF
--- a/app/node_modules
+++ b/app/node_modules
@@ -1,0 +1,1 @@
+/home/nacho/temp/opencode-work/netpulse-511/app/node_modules

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1447,8 +1447,13 @@
       "verifying": "Verifying",
       "flashing": "Flashing",
       "done": "Done",
-      "failed": "Failed"
+      "failed": "Failed",
+      "scheduled": "Scheduled"
     },
+    "schedule": "Schedule",
+    "scheduleAt": "Schedule for",
+    "scheduledFor": "Scheduled for {{time}}",
+    "cancelSchedule": "Cancel schedule",
     "dismiss": "Dismiss notice"
   },
   "orchestration": {

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1447,8 +1447,13 @@
       "verifying": "Verificando",
       "flashing": "Flasheando",
       "done": "Completada",
-      "failed": "Fallida"
+      "failed": "Fallida",
+      "scheduled": "Programada"
     },
+    "schedule": "Programar",
+    "scheduleAt": "Programar para",
+    "scheduledFor": "Programada para el {{time}}",
+    "cancelSchedule": "Cancelar programación",
     "dismiss": "Descartar aviso"
   },
   "orchestration": {

--- a/app/src/pages/FirmwareUpgrades.tsx
+++ b/app/src/pages/FirmwareUpgrades.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNetPulse } from '@/data/DataProvider'
 import { useAuth } from '@/data/AuthContext'
-import { AlertCircle, Cpu, Radar, RefreshCw, Rocket, ShieldCheck, TriangleAlert } from 'lucide-react'
+import { AlertCircle, CalendarClock, Cpu, Radar, RefreshCw, Rocket, ShieldCheck, TriangleAlert } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { relTimeFromTs } from '@/i18n'
 import {
@@ -27,6 +27,8 @@ interface FirmwareUpgrade {
   backupPath?: string
   startedAt: number
   finishedAt?: number
+  /** Epoch ms UTC de una programación desatendida (#494); ausente = flujo manual. */
+  scheduledFor?: number
 }
 
 interface FirmwareItem {
@@ -52,6 +54,7 @@ const STATUS_COLORS: Record<string, string> = {
   flashing: 'bg-orange-500/10 text-orange-600 dark:text-orange-400 border-orange-500/30',
   done: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/30',
   failed: 'bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/30',
+  scheduled: 'bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 border-indigo-500/30',
 }
 
 export default function FirmwareUpgrades() {
@@ -66,6 +69,8 @@ export default function FirmwareUpgrades() {
   const [busy, setBusy] = useState<Record<string, string>>({})
   const [error, setError] = useState('')
   const [confirmId, setConfirmId] = useState<string | null>(null)
+  // #494: hora local elegida para programar (datetime-local) por router.
+  const [scheduleAt, setScheduleAt] = useState<Record<string, string>>({})
 
   const sortedRouters = useMemo(() => {
     return [...routers].sort((a, b) => (a.roleBadge === 'Principal' ? -1 : 1) || a.name.localeCompare(b.name))
@@ -164,10 +169,48 @@ export default function FirmwareUpgrades() {
     }
   }
 
+  // #494: programar un upgrade desatendido (hora local → epoch ms UTC).
+  const scheduleUpgrade = async (id: string) => {
+    const at = scheduleAt[id]
+    if (!at) return
+    const scheduledFor = new Date(at).getTime()
+    setBusy((prev) => ({ ...prev, [id]: 'schedule' }))
+    try {
+      const res = await fetch(`/api/firmware-upgrades/${encodeURIComponent(id)}/schedule`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scheduledFor }),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.message ?? await res.text())
+      await fetchItems()
+    } catch (err) {
+      setError(String(err))
+    } finally {
+      setBusy((prev) => ({ ...prev, [id]: '' }))
+    }
+  }
+
+  // #494: cancelar una programación aún no iniciada.
+  const cancelSchedule = async (id: string) => {
+    setBusy((prev) => ({ ...prev, [id]: 'cancel' }))
+    try {
+      const res = await fetch(`/api/firmware-upgrades/${encodeURIComponent(id)}/schedule`, { method: 'DELETE' })
+      if (!res.ok) throw new Error(await res.text())
+      await fetchItems()
+    } catch (err) {
+      setError(String(err))
+    } finally {
+      setBusy((prev) => ({ ...prev, [id]: '' }))
+    }
+  }
+
   const upgradeActive = (item: FirmwareItem) => {
     const s = item.upgrade?.status
-    return !!s && s !== 'done' && s !== 'failed'
+    return !!s && s !== 'done' && s !== 'failed' && s !== 'scheduled'
   }
+
+  const scheduledPending = (item: FirmwareItem) => item.upgrade?.status === 'scheduled'
 
   // #477: el upgrade usa el target GUARDADO (no el buffer de edición), así
   // que el modal resume exactamente lo que se va a flashear.
@@ -217,6 +260,7 @@ export default function FirmwareUpgrades() {
         {items.map((item) => {
           const e = edits[item.routerId] ?? {}
           const active = upgradeActive(item)
+          const scheduled = scheduledPending(item)
           // #477 P2: resumen de lo detectado por el agente (board info).
           const detectedBits: string[] = []
           if (item.detectedModel || item.detectedBoard) {
@@ -339,7 +383,7 @@ export default function FirmwareUpgrades() {
               )}
 
               {isAdmin && (
-                <div className="mt-4 flex items-center gap-3">
+                <div className="mt-4 flex flex-wrap items-center gap-3">
                   <button
                     onClick={() => saveTarget(item.routerId)}
                     disabled={busy[item.routerId] === 'save' || !e.targetVersion || !e.targetUrl || !e.model}
@@ -347,17 +391,54 @@ export default function FirmwareUpgrades() {
                   >
                     {busy[item.routerId] === 'save' ? t('common.loading') : t('common.save')}
                   </button>
-                  <button
-                    onClick={() => setConfirmId(item.routerId)}
-                    disabled={active || busy[item.routerId] === 'upgrade' || !item.targetVersion}
-                    className="inline-flex h-9 items-center gap-2 rounded-lg border border-border bg-elevated px-4 text-sm font-medium text-text-primary transition-colors hover:bg-canvas disabled:opacity-50"
-                  >
-                    {active
-                      ? t('firmwareUpgrades.inProgress')
-                      : busy[item.routerId] === 'upgrade'
-                        ? t('common.loading')
-                        : t('firmwareUpgrades.upgrade')}
-                  </button>
+                  {scheduled ? (
+                    // #494: programación pendiente → hora + cancelar (sin
+                    // "actualizar ahora" para no pisar la fila programada).
+                    <>
+                      <span className="inline-flex items-center gap-1.5 text-sm text-text-secondary">
+                        <CalendarClock className="h-4 w-4 text-accent" strokeWidth={1.75} />
+                        {t('firmwareUpgrades.scheduledFor', {
+                          time: item.upgrade?.scheduledFor ? new Date(item.upgrade.scheduledFor).toLocaleString() : '',
+                        })}
+                      </span>
+                      <button
+                        onClick={() => void cancelSchedule(item.routerId)}
+                        disabled={busy[item.routerId] === 'cancel'}
+                        className="inline-flex h-9 items-center gap-2 rounded-lg border border-border bg-elevated px-4 text-sm font-medium text-text-primary transition-colors hover:bg-canvas disabled:opacity-50"
+                      >
+                        {busy[item.routerId] === 'cancel' ? t('common.loading') : t('firmwareUpgrades.cancelSchedule')}
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <button
+                        onClick={() => setConfirmId(item.routerId)}
+                        disabled={active || busy[item.routerId] === 'upgrade' || !item.targetVersion}
+                        className="inline-flex h-9 items-center gap-2 rounded-lg border border-border bg-elevated px-4 text-sm font-medium text-text-primary transition-colors hover:bg-canvas disabled:opacity-50"
+                      >
+                        {active
+                          ? t('firmwareUpgrades.inProgress')
+                          : busy[item.routerId] === 'upgrade'
+                            ? t('common.loading')
+                            : t('firmwareUpgrades.upgrade')}
+                      </button>
+                      <input
+                        type="datetime-local"
+                        value={scheduleAt[item.routerId] ?? ''}
+                        onChange={(ev) => setScheduleAt((prev) => ({ ...prev, [item.routerId]: ev.target.value }))}
+                        disabled={active || !item.targetVersion}
+                        aria-label={t('firmwareUpgrades.scheduleAt')}
+                        className="h-9 rounded-lg border border-border bg-canvas px-3 text-sm text-text-primary disabled:opacity-60"
+                      />
+                      <button
+                        onClick={() => void scheduleUpgrade(item.routerId)}
+                        disabled={active || busy[item.routerId] === 'schedule' || !scheduleAt[item.routerId] || !item.targetVersion}
+                        className="inline-flex h-9 items-center gap-2 rounded-lg border border-border bg-elevated px-4 text-sm font-medium text-text-primary transition-colors hover:bg-canvas disabled:opacity-50"
+                      >
+                        {busy[item.routerId] === 'schedule' ? t('common.loading') : t('firmwareUpgrades.schedule')}
+                      </button>
+                    </>
+                  )}
                 </div>
               )}
             </div>

--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -425,6 +425,10 @@ func run() error {
 		return checkAgentToken(dbHandle, slug, token)
 	})
 
+	// Scheduler de upgrades programados (#494): tick 30 s, reutiliza el motor
+	// compartido (firmware.Engine) del flujo manual vía el AgentHub.
+	fwScheduler := firmware.NewScheduler(fwStore, firmware.NewEngine(fwStore, agentHub))
+
 	// Fase 9 R2/R3: TLS autofirmado + pairing token (on-box only).
 	// Se generan ANTES del handler para que serverFP esté disponible en Deps.
 	var (
@@ -542,6 +546,7 @@ func run() error {
 		log.Printf("[netpulse] datos: %s · estáticos: %s", cfg.DataDir, staticDesc)
 		p.Start()
 		upd.Start()
+		fwScheduler.Start()
 		if eventsCollector != nil {
 			eventsCollector.Start()
 		}
@@ -571,6 +576,7 @@ func run() error {
 		}
 		p.Stop()
 		upd.Stop()
+		fwScheduler.Stop()
 		if eventsCollector != nil {
 			eventsCollector.Stop()
 		}

--- a/server-go/internal/db/db.go
+++ b/server-go/internal/db/db.go
@@ -344,7 +344,10 @@ CREATE TABLE IF NOT EXISTS firmware_upgrades (
   error          TEXT NOT NULL DEFAULT '',
   backup_path    TEXT,
   started_at     INTEGER NOT NULL,
-  finished_at    INTEGER
+  finished_at    INTEGER,
+  -- #494: programación de upgrades desatendidos (epoch ms UTC; NULL = flujo
+  -- manual/inmediato sin programar). started_at/finished_at siguen en segundos.
+  scheduled_for  INTEGER
 );
 CREATE INDEX IF NOT EXISTS idx_firmware_upgrades_router_started ON firmware_upgrades(router_id, started_at DESC);
 
@@ -457,6 +460,8 @@ func Open(dataDir string, opts ...OpenOption) (*DB, error) {
 	migrate(sqldb, "routers", "snmp_port", "ALTER TABLE routers ADD COLUMN snmp_port INTEGER NOT NULL DEFAULT 0")
 	// issue #414: intervalo de polling SNMP configurable (segundos; default 60).
 	migrate(sqldb, "routers", "snmp_poll_interval", "ALTER TABLE routers ADD COLUMN snmp_poll_interval INTEGER NOT NULL DEFAULT 60")
+	// issue #494: upgrades desatendidos programados (epoch ms UTC; NULL = manual).
+	migrate(sqldb, "firmware_upgrades", "scheduled_for", "ALTER TABLE firmware_upgrades ADD COLUMN scheduled_for INTEGER")
 
 	// Si no hubo migración Node (instalación fresca creada por Go), marca la
 	// DB para que el siguiente arranque no dispare una "migración" espuria

--- a/server-go/internal/firmware/engine.go
+++ b/server-go/internal/firmware/engine.go
@@ -1,0 +1,95 @@
+// engine.go — motor compartido de upgrades de firmware (#494).
+//
+// El flujo manual (POST /api/firmware-upgrades/{routerId}/upgrade) y el
+// scheduler de upgrades programados usan las MISMAS transiciones de estado y
+// el MISMO comando SSE "firmware_upgrade" hacia el agente. La validación ASU,
+// el backup pre-upgrade y el flash los ejecuta el agente tras recibir ese
+// comando; aquí solo se orquesta el inicio (fila requested + envío) y la
+// transición a failed si el agente no está disponible.
+package firmware
+
+import "errors"
+
+// Errores centinela del motor, mapeados por httpapi a los códigos HTTP que el
+// flujo manual ya devolvía (no_target 400, upgrade_in_progress 409,
+// agent_not_connected 503).
+var (
+	ErrNoTarget           = errors.New("firmware: no target configurado")
+	ErrUpgradeInProgress  = errors.New("firmware: upgrade en curso")
+	ErrAgentNotConnected  = errors.New("firmware: agente no conectado")
+)
+
+// Sender envía comandos al agente vía SSE. Lo implementa *sse.AgentHub.
+type Sender interface {
+	Send(slug, event string, data any) bool
+}
+
+// Engine ejecuta upgrades con el motor compartido (store + sender).
+type Engine struct {
+	store *Store
+	send  Sender
+}
+
+// NewEngine construye el motor sobre el store y el transport al agente.
+func NewEngine(store *Store, send Sender) *Engine {
+	return &Engine{store: store, send: send}
+}
+
+// StartUpgrade inicia un upgrade manual: valida el target, comprueba que no
+// haya otro upgrade en curso, crea la fila 'requested' y envía el comando al
+// agente. Devuelve el id del upgrade o un error centinela.
+func (e *Engine) StartUpgrade(routerID string) (int64, error) {
+	target, err := e.store.GetTarget(routerID)
+	if err != nil {
+		return 0, err
+	}
+	if target == nil || target.TargetURL == "" {
+		return 0, ErrNoTarget
+	}
+	if up, _ := e.store.LatestUpgrade(routerID); up != nil && up.Status != "done" && up.Status != "failed" {
+		return 0, ErrUpgradeInProgress
+	}
+	id, err := e.store.BeginUpgrade(routerID, target.TargetVersion, target.TargetURL, target.Checksum)
+	if err != nil {
+		return 0, err
+	}
+	if err := e.dispatch(id, routerID, target.TargetURL, target.Checksum); err != nil {
+		return id, err
+	}
+	return id, nil
+}
+
+// LaunchScheduled lanza una programación vencida (#494): transiciona la fila
+// 'scheduled' a 'requested' y envía el comando. No-op si la fila ya fue
+// lanzada o cancelada (StartScheduled devuelve false).
+func (e *Engine) LaunchScheduled(u Upgrade) error {
+	ok, err := e.store.StartScheduled(u.ID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	return e.dispatch(u.ID, u.RouterID, u.TargetURL, u.Checksum)
+}
+
+// dispatch envía el comando firmware_upgrade y fija el estado inicial
+// (requested si salió, failed si no). Secuencia idéntica al flujo manual.
+func (e *Engine) dispatch(id int64, routerID, targetURL, checksum string) error {
+	if e.send == nil {
+		_ = e.store.SetStatus(id, "failed", "no agent hub", "")
+		return ErrAgentNotConnected
+	}
+	cmd := map[string]any{
+		"upgradeId":  id,
+		"targetUrl":  targetURL,
+		"checksum":   checksum,
+		"keepConfig": true,
+	}
+	if !e.send.Send(routerID, "firmware_upgrade", cmd) {
+		_ = e.store.SetStatus(id, "failed", "agent not connected", "")
+		return ErrAgentNotConnected
+	}
+	_ = e.store.SetStatus(id, "requested", "", "")
+	return nil
+}

--- a/server-go/internal/firmware/engine_test.go
+++ b/server-go/internal/firmware/engine_test.go
@@ -1,0 +1,144 @@
+// engine_test.go — motor compartido de upgrades (#494). Usa fakes: un sender
+// que registra los comandos y NUNCA toca un router real ni firmware real.
+package firmware
+
+import (
+	"errors"
+	"testing"
+)
+
+// fakeSender implementa Sender registrando los comandos enviados. `ok` fija el
+// resultado de Send (false = agente no conectado).
+type fakeSender struct {
+	sent []struct {
+		slug  string
+		event string
+		data  any
+	}
+	ok bool
+}
+
+func (f *fakeSender) Send(slug, event string, data any) bool {
+	f.sent = append(f.sent, struct {
+		slug  string
+		event string
+		data  any
+	}{slug, event, data})
+	return f.ok
+}
+
+func (f *fakeSender) count() int { return len(f.sent) }
+
+func setTarget(t *testing.T, s *Store, routerID string) {
+	t.Helper()
+	if err := s.SetTarget(Target{
+		RouterID: routerID, Model: "m", CurrentVersion: "v1",
+		TargetVersion: "v2", TargetURL: "http://x/image.bin", Checksum: "abc",
+	}); err != nil {
+		t.Fatalf("set target: %v", err)
+	}
+}
+
+// TestEngineStartUpgradeNoTarget: sin target devuelve ErrNoTarget.
+func TestEngineStartUpgradeNoTarget(t *testing.T) {
+	s := open(t)
+	e := NewEngine(s, &fakeSender{ok: true})
+	if _, err := e.StartUpgrade("rt1"); !errors.Is(err, ErrNoTarget) {
+		t.Fatalf("esperaba ErrNoTarget, got %v", err)
+	}
+}
+
+// TestEngineStartUpgradeInProgress: un upgrade activo rechaza con
+// ErrUpgradeInProgress.
+func TestEngineStartUpgradeInProgress(t *testing.T) {
+	s := open(t)
+	setTarget(t, s, "rt1")
+	if _, err := s.BeginUpgrade("rt1", "v2", "http://x", "abc"); err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	e := NewEngine(s, &fakeSender{ok: true})
+	if _, err := e.StartUpgrade("rt1"); !errors.Is(err, ErrUpgradeInProgress) {
+		t.Fatalf("esperaba ErrUpgradeInProgress, got %v", err)
+	}
+}
+
+// TestEngineStartUpgradeSendsCommand: el flujo manual crea la fila requested
+// y envía el comando firmware_upgrade con el payload correcto.
+func TestEngineStartUpgradeSendsCommand(t *testing.T) {
+	s := open(t)
+	setTarget(t, s, "rt1")
+	send := &fakeSender{ok: true}
+	e := NewEngine(s, send)
+	id, err := e.StartUpgrade("rt1")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	up, _ := s.GetUpgradeByID(id)
+	if up == nil || up.Status != "requested" {
+		t.Fatalf("esperaba requested, got %+v", up)
+	}
+	if send.count() != 1 || send.sent[0].event != "firmware_upgrade" || send.sent[0].slug != "rt1" {
+		t.Fatalf("comando no enviado correctamente: %+v", send.sent)
+	}
+	cmd := send.sent[0].data.(map[string]any)
+	if cmd["upgradeId"] != id || cmd["targetUrl"] != "http://x/image.bin" || cmd["checksum"] != "abc" {
+		t.Fatalf("payload incorrecto: %+v", cmd)
+	}
+}
+
+// TestEngineStartUpgradeAgentOffline: si el agente no responde, la fila queda
+// failed y devuelve ErrAgentNotConnected.
+func TestEngineStartUpgradeAgentOffline(t *testing.T) {
+	s := open(t)
+	setTarget(t, s, "rt1")
+	e := NewEngine(s, &fakeSender{ok: false})
+	if _, err := e.StartUpgrade("rt1"); !errors.Is(err, ErrAgentNotConnected) {
+		t.Fatalf("esperaba ErrAgentNotConnected, got %v", err)
+	}
+	up, _ := s.LatestUpgrade("rt1")
+	if up == nil || up.Status != "failed" {
+		t.Fatalf("esperaba failed, got %+v", up)
+	}
+}
+
+// TestEngineLaunchScheduled: una programación vencida se lanza por el motor
+// (transición requested + comando enviado).
+func TestEngineLaunchScheduled(t *testing.T) {
+	s := open(t)
+	id, err := s.ScheduleUpgrade("rt1", "v2", "http://x/image.bin", "abc", 1000)
+	if err != nil {
+		t.Fatalf("schedule: %v", err)
+	}
+	send := &fakeSender{ok: true}
+	e := NewEngine(s, send)
+	u, _ := s.GetUpgradeByID(id)
+	if err := e.LaunchScheduled(*u); err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	up, _ := s.GetUpgradeByID(id)
+	if up == nil || up.Status != "requested" {
+		t.Fatalf("esperaba requested, got %+v", up)
+	}
+	if send.count() != 1 || send.sent[0].slug != "rt1" {
+		t.Fatalf("comando no enviado: %+v", send.sent)
+	}
+}
+
+// TestEngineLaunchScheduledAgentOffline: si el agente está caído al disparar,
+// la fila pasa a failed (sin tocar ningún dispositivo).
+func TestEngineLaunchScheduledAgentOffline(t *testing.T) {
+	s := open(t)
+	id, err := s.ScheduleUpgrade("rt1", "v2", "http://x/image.bin", "abc", 1000)
+	if err != nil {
+		t.Fatalf("schedule: %v", err)
+	}
+	e := NewEngine(s, &fakeSender{ok: false})
+	u, _ := s.GetUpgradeByID(id)
+	if err := e.LaunchScheduled(*u); !errors.Is(err, ErrAgentNotConnected) {
+		t.Fatalf("esperaba ErrAgentNotConnected, got %v", err)
+	}
+	up, _ := s.GetUpgradeByID(id)
+	if up == nil || up.Status != "failed" {
+		t.Fatalf("esperaba failed, got %+v", up)
+	}
+}

--- a/server-go/internal/firmware/scheduler.go
+++ b/server-go/internal/firmware/scheduler.go
@@ -1,0 +1,83 @@
+// scheduler.go — scheduler de upgrades programados (#494).
+//
+// Bucle de tick corto (30 s) que recoge las programaciones vencidas
+// (status 'scheduled' y scheduled_for <= now) y las lanza a través del motor
+// compartido (Engine.LaunchScheduled). Single-flight por fila: StartScheduled
+// transiciona guarded, así un segundo tick o un cancelado no relanzan.
+package firmware
+
+import (
+	"log"
+	"sync"
+	"time"
+)
+
+// tickEvery: cadencia del barrido de programaciones (dominio fijo; igual que
+// speedtest.tickEvery). Un cambio de hora de programación se aplica en < 30 s.
+const tickEvery = 30 * time.Second
+
+// Launcher lanza una programación vencida (lo implementa *Engine).
+type Launcher interface {
+	LaunchScheduled(Upgrade) error
+}
+
+// Scheduler orquesta el barrido periódico de programaciones vencidas.
+type Scheduler struct {
+	store    *Store
+	launcher Launcher
+
+	now  func() time.Time
+	logf func(format string, args ...any)
+
+	stop chan struct{}
+	wg   sync.WaitGroup
+}
+
+// NewScheduler construye el scheduler con su store y el launcher compartido.
+func NewScheduler(store *Store, launcher Launcher) *Scheduler {
+	return &Scheduler{
+		store:    store,
+		launcher: launcher,
+		now:      time.Now,
+		logf:     func(f string, a ...any) { log.Printf("[firmware] "+f, a...) },
+		stop:     make(chan struct{}),
+	}
+}
+
+// Start lanza el bucle periódico (daemon; no retorna hasta Stop).
+func (s *Scheduler) Start() {
+	s.wg.Add(1)
+	defer s.wg.Done()
+	ticker := time.NewTicker(tickEvery)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-ticker.C:
+			s.Tick()
+		}
+	}
+}
+
+// Stop detiene el bucle y espera a que termine la pasada en curso.
+func (s *Scheduler) Stop() {
+	close(s.stop)
+	s.wg.Wait()
+}
+
+// Tick recoge las programaciones vencidas y las lanza una a una. Los errores
+// de lanzamiento se registran (un agente caído marca la fila como failed) sin
+// interrumpir el resto del barrido.
+func (s *Scheduler) Tick() {
+	due, err := s.store.DueScheduled(s.now().UnixMilli())
+	if err != nil {
+		s.logf("listado de programaciones vencidas: %v", err)
+		return
+	}
+	for _, u := range due {
+		if err := s.launcher.LaunchScheduled(u); err != nil {
+			s.logf("programación %s (id %d): %v", u.RouterID, u.ID, err)
+		}
+	}
+}

--- a/server-go/internal/firmware/scheduler_test.go
+++ b/server-go/internal/firmware/scheduler_test.go
@@ -1,0 +1,83 @@
+// scheduler_test.go — scheduler de programaciones (#494). El launcher es un
+// fake que registra las llamadas; nunca se toca un router ni firmware real.
+package firmware
+
+import (
+	"testing"
+	"time"
+)
+
+// fakeLauncher registra los upgrades lanzados.
+type fakeLauncher struct {
+	launched []Upgrade
+}
+
+func (f *fakeLauncher) LaunchScheduled(u Upgrade) error {
+	f.launched = append(f.launched, u)
+	return nil
+}
+
+func schedulerWithNow(t *testing.T, now time.Time) (*Store, *Scheduler, *fakeLauncher) {
+	t.Helper()
+	s := open(t)
+	l := &fakeLauncher{}
+	sch := NewScheduler(s, l)
+	sch.now = func() time.Time { return now }
+	return s, sch, l
+}
+
+// TestSchedulerTickPicksDue (#494): recoge las vencidas y las lanza; la no
+// vencida no se toca.
+func TestSchedulerTickPicksDue(t *testing.T) {
+	now := time.UnixMilli(5_000)
+	s, sch, l := schedulerWithNow(t, now)
+
+	if _, err := s.ScheduleUpgrade("due", "v2", "http://x", "a", 4_000); err != nil {
+		t.Fatalf("schedule due: %v", err)
+	}
+	if _, err := s.ScheduleUpgrade("future", "v2", "http://x", "b", 9_000); err != nil {
+		t.Fatalf("schedule future: %v", err)
+	}
+
+	sch.Tick()
+
+	if len(l.launched) != 1 || l.launched[0].RouterID != "due" {
+		t.Fatalf("esperaba solo 'due' lanzada, got %+v", l.launched)
+	}
+	// La lanzada ya no está scheduled (la transiciona el launcher real; aquí
+	// el fake no muta el store, pero un segundo Tick no debe volver a listarla
+	// porque sigue 'scheduled' en el store del fake). Se verifica el filtro en
+	// DueScheduled por separado; aquí basta con que el tick no liste la futura.
+}
+
+// TestSchedulerTickIgnoresNonDue (#494): sin vencidas no se lanza nada.
+func TestSchedulerTickIgnoresNonDue(t *testing.T) {
+	now := time.UnixMilli(5_000)
+	s, sch, l := schedulerWithNow(t, now)
+
+	if _, err := s.ScheduleUpgrade("future", "v2", "http://x", "b", 9_000); err != nil {
+		t.Fatalf("schedule future: %v", err)
+	}
+	sch.Tick()
+	if len(l.launched) != 0 {
+		t.Fatalf("nada debía lanzarse, got %+v", l.launched)
+	}
+}
+
+// TestSchedulerStop (#494): Start lanza el bucle y Stop lo termina.
+func TestSchedulerStop(t *testing.T) {
+	s := open(t)
+	l := &fakeLauncher{}
+	sch := NewScheduler(s, l)
+	done := make(chan struct{})
+	go func() {
+		sch.Start()
+		close(done)
+	}()
+	sch.Stop()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop no terminó el bucle")
+	}
+}

--- a/server-go/internal/firmware/store.go
+++ b/server-go/internal/firmware/store.go
@@ -29,6 +29,10 @@ type Upgrade struct {
 	BackupPath    string  `json:"backupPath,omitempty"`
 	StartedAt     int64   `json:"startedAt"`
 	FinishedAt    *int64  `json:"finishedAt,omitempty"`
+	// ScheduledFor: programación desatendida (#494), epoch ms UTC. nil = el
+	// upgrade es del flujo manual/inmediato. Nota: StartedAt/FinishedAt siguen
+	// en unix SEGUNDOS (convención previa), ScheduledFor en ms.
+	ScheduledFor *int64 `json:"scheduledFor,omitempty"`
 }
 
 // Store persiste targets y upgrades.
@@ -120,26 +124,29 @@ func (s *Store) SetStatus(id int64, status, errMsg, backupPath string) error {
 	return err
 }
 
-// LatestUpgrade devuelve el upgrade más reciente de un router.
-func (s *Store) LatestUpgrade(routerID string) (*Upgrade, error) {
+// rowScanner abstrae *sql.Row y *sql.Rows para un único helper de escaneo.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+// scanUpgrade escanea una fila completa de firmware_upgrades (11 columnas,
+// incluida scheduled_for #494). Reutilizada por LatestUpgrade, GetUpgradeByID
+// y DueScheduled para no duplicar el mapeo de columnas.
+func scanUpgrade(sc rowScanner) (*Upgrade, error) {
 	var u Upgrade
-	var finished sql.NullInt64
+	var finished, scheduled sql.NullInt64
 	var errStr, backup sql.NullString
-	err := s.db.QueryRow(`
-		SELECT id, router_id, target_version, target_url, checksum, status, error, backup_path, started_at, finished_at
-		FROM firmware_upgrades
-		WHERE router_id = ?
-		ORDER BY started_at DESC
-		LIMIT 1
-	`, routerID).Scan(&u.ID, &u.RouterID, &u.TargetVersion, &u.TargetURL, &u.Checksum, &u.Status, &errStr, &backup, &u.StartedAt, &finished)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	}
-	if err != nil {
+	if err := sc.Scan(
+		&u.ID, &u.RouterID, &u.TargetVersion, &u.TargetURL, &u.Checksum,
+		&u.Status, &errStr, &backup, &u.StartedAt, &finished, &scheduled,
+	); err != nil {
 		return nil, err
 	}
 	if finished.Valid {
 		u.FinishedAt = &finished.Int64
+	}
+	if scheduled.Valid {
+		u.ScheduledFor = &scheduled.Int64
 	}
 	if errStr.Valid {
 		u.Error = errStr.String
@@ -150,31 +157,37 @@ func (s *Store) LatestUpgrade(routerID string) (*Upgrade, error) {
 	return &u, nil
 }
 
-// GetUpgradeByID busca un upgrade por ID (para validar propiedad del agente).
-func (s *Store) GetUpgradeByID(id int64) (*Upgrade, error) {
-	var u Upgrade
-	var finished sql.NullInt64
-	var errStr, backup sql.NullString
-	err := s.db.QueryRow(`
-		SELECT id, router_id, target_version, target_url, checksum, status, error, backup_path, started_at, finished_at
-		FROM firmware_upgrades WHERE id = ?
-	`, id).Scan(&u.ID, &u.RouterID, &u.TargetVersion, &u.TargetURL, &u.Checksum, &u.Status, &errStr, &backup, &u.StartedAt, &finished)
+// LatestUpgrade devuelve el upgrade más reciente de un router.
+func (s *Store) LatestUpgrade(routerID string) (*Upgrade, error) {
+	u, err := scanUpgrade(s.db.QueryRow(`
+		SELECT id, router_id, target_version, target_url, checksum, status, error, backup_path, started_at, finished_at, scheduled_for
+		FROM firmware_upgrades
+		WHERE router_id = ?
+		ORDER BY started_at DESC
+		LIMIT 1
+	`, routerID))
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
 	}
-	if errStr.Valid {
-		u.Error = errStr.String
+	return u, nil
+}
+
+// GetUpgradeByID busca un upgrade por ID (para validar propiedad del agente).
+func (s *Store) GetUpgradeByID(id int64) (*Upgrade, error) {
+	u, err := scanUpgrade(s.db.QueryRow(`
+		SELECT id, router_id, target_version, target_url, checksum, status, error, backup_path, started_at, finished_at, scheduled_for
+		FROM firmware_upgrades WHERE id = ?
+	`, id))
+	if err == sql.ErrNoRows {
+		return nil, nil
 	}
-	if backup.Valid {
-		u.BackupPath = backup.String
+	if err != nil {
+		return nil, err
 	}
-	if finished.Valid {
-		u.FinishedAt = &finished.Int64
-	}
-	return &u, nil
+	return u, nil
 }
 
 // DismissLatest borra el último intento de upgrade del router si está
@@ -191,4 +204,81 @@ func (s *Store) DismissLatest(routerID string) error {
 	}
 	_, err = s.db.Exec(`DELETE FROM firmware_upgrades WHERE id = ?`, up.ID)
 	return err
+}
+
+// ScheduleUpgrade crea o actualiza la fila 'scheduled' del router (#494).
+// Una fila por router: si ya hay una pendiente, se actualizan target y hora;
+// si no, se inserta. scheduledFor es epoch ms UTC.
+func (s *Store) ScheduleUpgrade(routerID, targetVersion, targetURL, checksum string, scheduledFor int64) (int64, error) {
+	var id int64
+	err := s.db.QueryRow(`
+		SELECT id FROM firmware_upgrades WHERE router_id = ? AND status = 'scheduled'
+	`, routerID).Scan(&id)
+	switch {
+	case err == nil:
+		_, err = s.db.Exec(`
+			UPDATE firmware_upgrades
+			SET target_version = ?, target_url = ?, checksum = ?, scheduled_for = ?, started_at = ?
+			WHERE id = ?
+		`, targetVersion, targetURL, checksum, scheduledFor, time.Now().Unix(), id)
+		return id, err
+	case err == sql.ErrNoRows:
+		res, err := s.db.Exec(`
+			INSERT INTO firmware_upgrades (router_id, target_version, target_url, checksum, status, started_at, scheduled_for)
+			VALUES (?, ?, ?, ?, 'scheduled', ?, ?)
+		`, routerID, targetVersion, targetURL, checksum, time.Now().Unix(), scheduledFor)
+		if err != nil {
+			return 0, err
+		}
+		return res.LastInsertId()
+	default:
+		return 0, err
+	}
+}
+
+// CancelScheduled borra la fila 'scheduled' pendiente del router (#494).
+// No-op si no hay programación pendiente.
+func (s *Store) CancelScheduled(routerID string) error {
+	_, err := s.db.Exec(`
+		DELETE FROM firmware_upgrades WHERE router_id = ? AND status = 'scheduled'
+	`, routerID)
+	return err
+}
+
+// DueScheduled devuelve las programaciones vencidas (status 'scheduled' y
+// scheduled_for <= nowMs), ordenadas por hora para lanzarlas en orden.
+func (s *Store) DueScheduled(nowMs int64) ([]Upgrade, error) {
+	rows, err := s.db.Query(`
+		SELECT id, router_id, target_version, target_url, checksum, status, error, backup_path, started_at, finished_at, scheduled_for
+		FROM firmware_upgrades
+		WHERE status = 'scheduled' AND scheduled_for <= ?
+		ORDER BY scheduled_for ASC
+	`, nowMs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []Upgrade{}
+	for rows.Next() {
+		u, err := scanUpgrade(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *u)
+	}
+	return out, rows.Err()
+}
+
+// StartScheduled pasa una fila 'scheduled' vencida a 'requested' (#494).
+// Guarded: solo transiciona si sigue en 'scheduled' (single-flight frente a
+// un segundo tick o a un cancelado). Devuelve true si la transición se aplicó.
+func (s *Store) StartScheduled(id int64) (bool, error) {
+	res, err := s.db.Exec(`
+		UPDATE firmware_upgrades SET status = 'requested' WHERE id = ? AND status = 'scheduled'
+	`, id)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	return n > 0, err
 }

--- a/server-go/internal/firmware/store_test.go
+++ b/server-go/internal/firmware/store_test.go
@@ -59,3 +59,104 @@ func TestDismissLatestKeepsRunning(t *testing.T) {
 		t.Fatalf("dismiss sin upgrades: %v", err)
 	}
 }
+
+// TestScheduleUpgradeUpsert (#494): una programación por router; reprogramar
+// actualiza la hora y no crea una segunda fila.
+func TestScheduleUpgradeUpsert(t *testing.T) {
+	s := open(t)
+	id1, err := s.ScheduleUpgrade("rt1", "v2", "http://x", "abc", 1000)
+	if err != nil {
+		t.Fatalf("schedule: %v", err)
+	}
+	up, _ := s.LatestUpgrade("rt1")
+	if up == nil || up.Status != "scheduled" {
+		t.Fatalf("esperaba fila scheduled, got %+v", up)
+	}
+	if up.ScheduledFor == nil || *up.ScheduledFor != 1000 {
+		t.Fatalf("scheduled_for = %v, want 1000", up.ScheduledFor)
+	}
+	id2, err := s.ScheduleUpgrade("rt1", "v3", "http://y", "def", 2000)
+	if err != nil {
+		t.Fatalf("reschedule: %v", err)
+	}
+	if id1 != id2 {
+		t.Fatalf("reprogramar debe reutilizar la fila: id1=%d id2=%d", id1, id2)
+	}
+	up, _ = s.LatestUpgrade("rt1")
+	if up == nil || *up.ScheduledFor != 2000 || up.TargetVersion != "v3" {
+		t.Fatalf("reschedule no aplicó: %+v", up)
+	}
+	// Una sola fila.
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM firmware_upgrades WHERE router_id='rt1'`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("esperaba 1 fila, got %d", n)
+	}
+}
+
+// TestCancelScheduled (#494): borra solo la programación pendiente; un
+// upgrade en curso (requested) no se toca.
+func TestCancelScheduled(t *testing.T) {
+	s := open(t)
+	if _, err := s.ScheduleUpgrade("rt1", "v2", "http://x", "abc", 1000); err != nil {
+		t.Fatalf("schedule: %v", err)
+	}
+	if err := s.CancelScheduled("rt1"); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	if up, _ := s.LatestUpgrade("rt1"); up != nil {
+		t.Fatalf("tras cancelar no debería haber fila: %+v", up)
+	}
+	// Cancelar sin programación: no-op sin error.
+	if err := s.CancelScheduled("rt1"); err != nil {
+		t.Fatalf("cancel sin fila: %v", err)
+	}
+}
+
+// TestDueScheduled (#494): solo las vencidas y en orden de hora.
+func TestDueScheduled(t *testing.T) {
+	s := open(t)
+	if _, err := s.ScheduleUpgrade("rt1", "v2", "http://x", "a", 3000); err != nil {
+		t.Fatalf("schedule rt1: %v", err)
+	}
+	if _, err := s.ScheduleUpgrade("rt2", "v2", "http://x", "b", 1000); err != nil {
+		t.Fatalf("schedule rt2: %v", err)
+	}
+	if _, err := s.ScheduleUpgrade("rt3", "v2", "http://x", "c", 9000); err != nil {
+		t.Fatalf("schedule rt3: %v", err)
+	}
+	due, err := s.DueScheduled(5000)
+	if err != nil {
+		t.Fatalf("due: %v", err)
+	}
+	if len(due) != 2 {
+		t.Fatalf("esperaba 2 vencidas, got %d", len(due))
+	}
+	if due[0].RouterID != "rt2" || due[1].RouterID != "rt1" {
+		t.Fatalf("orden de vencidas incorrecto: %v, %v", due[0].RouterID, due[1].RouterID)
+	}
+}
+
+// TestStartScheduled (#494): transiciona scheduled→requested una sola vez.
+func TestStartScheduled(t *testing.T) {
+	s := open(t)
+	id, err := s.ScheduleUpgrade("rt1", "v2", "http://x", "abc", 1000)
+	if err != nil {
+		t.Fatalf("schedule: %v", err)
+	}
+	ok, err := s.StartScheduled(id)
+	if err != nil || !ok {
+		t.Fatalf("start: ok=%v err=%v", ok, err)
+	}
+	up, _ := s.GetUpgradeByID(id)
+	if up == nil || up.Status != "requested" {
+		t.Fatalf("esperaba requested, got %+v", up)
+	}
+	// Segunda transición: guard devuelve false (ya no está scheduled).
+	ok, err = s.StartScheduled(id)
+	if err != nil || ok {
+		t.Fatalf("segundo start debe ser no-op: ok=%v err=%v", ok, err)
+	}
+}

--- a/server-go/internal/httpapi/firmware.go
+++ b/server-go/internal/httpapi/firmware.go
@@ -2,6 +2,7 @@
 package httpapi
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gnacho/netpulse/server-go/internal/adapters"
@@ -160,47 +161,78 @@ func (s *server) registerFirmwareRoutes(mux *http.ServeMux) {
 
 	mux.Handle("POST /api/firmware-upgrades/{routerId}/upgrade", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("routerId")
+		// #494: el flujo manual delega en el motor compartido (mismo que el
+		// scheduler). El contrato HTTP no cambia: mismos códigos y mensajes.
+		if s.agentHub == nil {
+			writeError(w, http.StatusServiceUnavailable, "no_agent_hub")
+			return
+		}
+		upgradeID, err := s.firmwareEngine.StartUpgrade(id)
+		switch {
+		case errors.Is(err, firmware.ErrNoTarget):
+			writeError(w, http.StatusBadRequest, "no_target", "Configura el target de firmware antes de actualizar")
+		case errors.Is(err, firmware.ErrUpgradeInProgress):
+			writeError(w, http.StatusConflict, "upgrade_in_progress", "Ya hay un upgrade en curso")
+		case errors.Is(err, firmware.ErrAgentNotConnected):
+			writeError(w, http.StatusServiceUnavailable, "agent_not_connected", "El agente no está conectado vía SSE")
+		case err != nil:
+			writeError(w, http.StatusInternalServerError, "firmware_error")
+		default:
+			writeJSON(w, http.StatusAccepted, map[string]any{"upgradeId": upgradeID, "status": "requested"})
+		}
+	})))
+
+	// POST /api/firmware-upgrades/{routerId}/schedule: programa un upgrade
+	// desatendido para el target conocido del router (#494).
+	mux.Handle("POST /api/firmware-upgrades/{routerId}/schedule", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("routerId")
+		var body struct {
+			ScheduledFor int64 `json:"scheduledFor"`
+		}
+		if st := readJSONBody(w, r, &body); st != 0 {
+			writeBodyError(w, st, "invalid_body", "")
+			return
+		}
+		if body.ScheduledFor <= 0 {
+			writeError(w, http.StatusBadRequest, "invalid_body", "scheduledFor (epoch ms) es requerido")
+			return
+		}
 		target, err := s.firmware.GetTarget(id)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "firmware_error")
 			return
 		}
 		if target == nil || target.TargetURL == "" {
-			writeError(w, http.StatusBadRequest, "no_target", "Configura el target de firmware antes de actualizar")
+			writeError(w, http.StatusBadRequest, "no_target", "Configura el target de firmware antes de programar")
 			return
 		}
-
-		// Si hay un upgrade en curso reciente, rechazar.
-		if up, _ := s.firmware.LatestUpgrade(id); up != nil && up.Status != "done" && up.Status != "failed" {
-			writeError(w, http.StatusConflict, "upgrade_in_progress", "Ya hay un upgrade en curso")
+		// Rechazar si hay un upgrade activo; una programación ya pendiente se
+		// actualiza (UPSERT en el store), no se duplica.
+		if up, _ := s.firmware.LatestUpgrade(id); up != nil && up.Status != "done" && up.Status != "failed" && up.Status != "scheduled" {
+			writeError(w, http.StatusBadRequest, "upgrade_in_progress", "Ya hay un upgrade en curso")
 			return
 		}
-
-		upgradeID, err := s.firmware.BeginUpgrade(id, target.TargetVersion, target.TargetURL, target.Checksum)
+		upgradeID, err := s.firmware.ScheduleUpgrade(id, target.TargetVersion, target.TargetURL, target.Checksum, body.ScheduledFor)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "firmware_error")
 			return
 		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "upgradeId": upgradeID})
+	})))
 
-		// Enviar comando al agente vía SSE.
-		if s.agentHub == nil {
-			writeError(w, http.StatusServiceUnavailable, "no_agent_hub")
+	// DELETE /api/firmware-upgrades/{routerId}/schedule: cancela una
+	// programación aún no iniciada (#494). No-op si no hay ninguna.
+	mux.Handle("DELETE /api/firmware-upgrades/{routerId}/schedule", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		routerID := r.PathValue("routerId")
+		if routerID == "" {
+			writeError(w, http.StatusBadRequest, "invalid_input", "routerId requerido")
 			return
 		}
-		cmd := map[string]any{
-			"upgradeId":  upgradeID,
-			"targetUrl":  target.TargetURL,
-			"checksum":   target.Checksum,
-			"keepConfig": true,
-		}
-		if !s.agentHub.Send(id, "firmware_upgrade", cmd) {
-			// El agente no está conectado: marcar fallo y devolver 503.
-			_ = s.firmware.SetStatus(upgradeID, "failed", "agent not connected", "")
-			writeError(w, http.StatusServiceUnavailable, "agent_not_connected", "El agente no está conectado vía SSE")
+		if err := s.firmware.CancelScheduled(routerID); err != nil {
+			writeError(w, http.StatusInternalServerError, "firmware_error")
 			return
 		}
-		_ = s.firmware.SetStatus(upgradeID, "requested", "", "")
-		writeJSON(w, http.StatusAccepted, map[string]any{"upgradeId": upgradeID, "status": "requested"})
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 	})))
 
 	// El agente reporta progreso del upgrade (Bearer, misma auth que ingesta).

--- a/server-go/internal/httpapi/firmware_schedule_test.go
+++ b/server-go/internal/httpapi/firmware_schedule_test.go
@@ -1,0 +1,120 @@
+// firmware_schedule_test.go — endpoints de programación de upgrades (#494).
+// Sin agente conectado en ningún test: nunca se toca un router ni firmware real.
+package httpapi_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/firmware"
+)
+
+// findFirmwareItem busca el item del router en la lista de upgrades.
+func findFirmwareItem(t *testing.T, arr []any, routerID string) map[string]any {
+	t.Helper()
+	for _, v := range arr {
+		item := v.(map[string]any)
+		if item["routerId"] == routerID {
+			return item
+		}
+	}
+	t.Fatalf("router %s no aparece en la lista", routerID)
+	return nil
+}
+
+func deleteReq(t *testing.T, base, path, cookie string) *http.Response {
+	t.Helper()
+	req, _ := http.NewRequest("DELETE", base+path, nil)
+	req.Header.Set("Cookie", "session="+cookie)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE %s: %v", path, err)
+	}
+	return res
+}
+
+// TestFirmwareScheduleAndCancel (#494): sin target → 400 no_target; con target
+// → programa (lista expone status scheduled + scheduledFor); DELETE cancela.
+func TestFirmwareScheduleAndCancel(t *testing.T) {
+	srv, _ := firmwareTestServer(t)
+	cookie := adminCookieFor(t, srv)
+	rid := addTestRouter(t, srv.db)
+
+	// Sin target: 400 no_target.
+	res := postJSON(t, srv.URL, "/api/firmware-upgrades/"+rid+"/schedule", `{"scheduledFor": 9999999999999}`, cookie)
+	body := readJSON(t, res)
+	if res.StatusCode != 400 || body["error"] != "no_target" {
+		t.Fatalf("esperaba 400 no_target, got %d %v", res.StatusCode, body)
+	}
+	res.Body.Close()
+
+	// Configurar target.
+	payload := `{"model":"glinet-flint2","currentVersion":"23.05.3","targetVersion":"23.05.4","targetUrl":"http://x/image.bin","checksum":"abc"}`
+	postJSON(t, srv.URL, "/api/firmware-upgrades/"+rid+"/target", payload, cookie).Body.Close()
+
+	// Programar para mañana.
+	scheduledFor := time.Now().Add(24 * time.Hour).UnixMilli()
+	res = postJSON(t, srv.URL, "/api/firmware-upgrades/"+rid+"/schedule", fmt.Sprintf(`{"scheduledFor": %d}`, scheduledFor), cookie)
+	body = readJSON(t, res)
+	if res.StatusCode != 200 {
+		t.Fatalf("POST schedule: %d %v", res.StatusCode, body)
+	}
+	res.Body.Close()
+
+	// La lista expone la programación.
+	res = get(t, srv.URL, "/api/firmware-upgrades", cookie)
+	arr := readJSONArray(t, res)
+	res.Body.Close()
+	item := findFirmwareItem(t, arr, rid)
+	up, ok := item["upgrade"].(map[string]any)
+	if !ok {
+		t.Fatalf("sin upgrade en el item: %v", item)
+	}
+	if up["status"] != "scheduled" {
+		t.Fatalf("status: %v", up["status"])
+	}
+	if int64(up["scheduledFor"].(float64)) != scheduledFor {
+		t.Fatalf("scheduledFor: %v != %d", up["scheduledFor"], scheduledFor)
+	}
+
+	// Cancelar: la lista ya no expone upgrade.
+	res = deleteReq(t, srv.URL, "/api/firmware-upgrades/"+rid+"/schedule", cookie)
+	body = readJSON(t, res)
+	if res.StatusCode != 200 {
+		t.Fatalf("DELETE schedule: %d %v", res.StatusCode, body)
+	}
+	res.Body.Close()
+	res = get(t, srv.URL, "/api/firmware-upgrades", cookie)
+	arr = readJSONArray(t, res)
+	res.Body.Close()
+	item = findFirmwareItem(t, arr, rid)
+	if _, ok := item["upgrade"].(map[string]any); ok {
+		t.Fatalf("tras cancelar no debería haber upgrade: %v", item["upgrade"])
+	}
+}
+
+// TestFirmwareScheduleInProgress (#494): con un upgrade en curso se rechaza la
+// programación (400 upgrade_in_progress).
+func TestFirmwareScheduleInProgress(t *testing.T) {
+	srv, _ := firmwareTestServer(t)
+	cookie := adminCookieFor(t, srv)
+	rid := addTestRouter(t, srv.db)
+
+	payload := `{"model":"glinet-flint2","currentVersion":"23.05.3","targetVersion":"23.05.4","targetUrl":"http://x/image.bin","checksum":"abc"}`
+	postJSON(t, srv.URL, "/api/firmware-upgrades/"+rid+"/target", payload, cookie).Body.Close()
+
+	// Upgrade en curso (requested) sembrado directamente en el store, sin
+	// agente: simula una operación viva.
+	if _, err := firmware.NewStore(srv.db.DB).BeginUpgrade(rid, "23.05.4", "http://x/image.bin", "abc"); err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+
+	res := postJSON(t, srv.URL, "/api/firmware-upgrades/"+rid+"/schedule", `{"scheduledFor": 9999999999999}`, cookie)
+	body := readJSON(t, res)
+	if res.StatusCode != 400 || body["error"] != "upgrade_in_progress" {
+		t.Fatalf("esperaba 400 upgrade_in_progress, got %d %v", res.StatusCode, body)
+	}
+	res.Body.Close()
+}

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -182,6 +182,9 @@ type server struct {
 
 	// Firmware: targets y upgrades de firmware (#453).
 	firmware *firmware.Store
+	// FirmwareEngine: motor compartido de upgrades (manual + programados #494).
+	// Se construye desde Deps.Firmware + Deps.AgentHub.
+	firmwareEngine *firmware.Engine
 
 	// Speedtest: scheduler del test de velocidad WAN (#511). nil → rutas
 	// /api/speedtest/* y /api/settings/speedtest responden 503 (demo).
@@ -208,6 +211,7 @@ func NewHandler(d Deps) http.Handler {
 		pathAnalysis:    d.PathAnalysis,
 		configBackup:    d.ConfigBackup,
 		firmware:        d.Firmware,
+		firmwareEngine:  firmware.NewEngine(d.Firmware, d.AgentHub),
 		speedtest:       d.Speedtest,
 	}
 	// Rearmer compartido entre el endpoint manual y el supervisor de


### PR DESCRIPTION
Schedule a firmware upgrade to run unattended at a chosen time, reusing the exact manual upgrade engine (ASU validation + pre-upgrade backup + flash happen agent-side after the same SSE command).

Backend: nullable scheduled_for column on firmware_upgrades (migration helper, epoch ms UTC, NULL = manual flow untouched); shared firmware.Engine extracted from the manual POST /upgrade path (identical HTTP contract, sentinel errors); 30s Scheduler ticker (Start/Stop wired in main) that launches due rows single-flight via guarded status transition scheduled->requested; POST/DELETE /api/firmware-upgrades/{routerId}/schedule (admin) to set/cancel. GET list now surfaces status scheduled + scheduledFor.

Frontend: FirmwareUpgrades card gets a datetime-local Schedule button when a target exists and no upgrade is running; a pending schedule renders as 'Scheduled for <local time>' with a Cancel button (hides Upgrade now). New es/en i18n keys.

Tests (all fakes/temp SQLite, never touching the live fleet): store upsert/cancel/due/guarded-start, engine start/launch paths incl. agent-not-connected, scheduler picks due and skips non-due, endpoint schedule/cancel/in-progress. Full server suite + npm build green. Manual flow HTTP contract unchanged; no ViewModelVersion bump (firmware payloads carry no vm).