### PR TITLE
fix(firmware): run scheduled-upgrade ticker in its own goroutine (#494)

### DIFF
--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -546,7 +546,7 @@ func run() error {
 		log.Printf("[netpulse] datos: %s · estáticos: %s", cfg.DataDir, staticDesc)
 		p.Start()
 		upd.Start()
-		fwScheduler.Start()
+		go fwScheduler.Start()
 		if eventsCollector != nil {
 			eventsCollector.Start()
 		}


### PR DESCRIPTION
The firmware Scheduler.Start() is a blocking ticker loop (like speedtest.Scheduler, started with 'go'), but main.go called fwScheduler.Start() without 'go', which blocked the server goroutine before ListenAndServe: after updating the CT to v2.26.13 the service never bound :3000. Wrap it in 'go' (Stop already waits via the WaitGroup).