### PR TITLE
chore(release): v2.26.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.26.14] - 2026-09-04
+
+### Fixed
+
+- **Acciones de dispositivo (reserva IP + bloqueo) endurecidas y con tests (#439)**: la funcionalidad (reservar IP estática en el DHCP del gateway y bloquear/desbloquear el acceso de un dispositivo por MAC desde su ficha de edición) se ha endurecido: la resolución del router objetivo es ahora fiable (basada en la configuración, no en heurísticas); las reservas detectan y rechazan conflictos de IP (409) y son idempotentes; el bloqueo usa una regla de firewall con nombre determinista; y todas las escrituras son transaccionales con `uci commit` como límite atómico y rollback si el reinicio del servicio (dnsmasq/firewall) falla - nunca se deja una configuración a medias. 23 tests nuevos con SSH simulado.
+
 ## [2.26.13] - 2026-09-04
 
 ### Added

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.26.13",
+  "version": "2.26.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.26.13",
+      "version": "2.26.14",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.26.13",
+  "version": "2.26.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.26.13"
+var Version = "2.26.14"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Release v2.26.14: hardened device actions (reserve IP + block MAC) with conflict checks, transactional rollback and 23 new tests (#439). AGENT_VERSION stays at 2.26.11 (no agent changes).