### PR TITLE
fix(release): untrack app/node_modules symlink that broke goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # Dependencias
 dist/
 node_modules/
+# node_modules sin barra: también ignora el SYMLINK app/node_modules (git
+# trata un symlink como archivo y `node_modules/` no lo cubre; un `git add -A`
+# en un worktree con el symlink lo commiteó y rompió goreleaser: "dirty state"
+# al borrar npm ci el enlace durante la release v2.26.13/14)
+app/node_modules
 
 # Backend: datos y secretos
 server/data/

--- a/app/node_modules
+++ b/app/node_modules
@@ -1,1 +1,0 @@
-/home/nacho/temp/opencode-work/netpulse-511/app/node_modules


### PR DESCRIPTION
A local symlink app/node_modules (mode 120000) was accidentally committed (a git add -A on a worktree that had the symlink). app/node_modules is not covered by the "node_modules/" ignore pattern because git treats a symlink as a file, not a directory. On every v* tag the release workflow runs npm ci, which removes the symlink, and goreleaser then fails with "git is in a dirty state" (D app/node_modules) - this is why the v2.26.13 and v2.26.14 releases were never published.

Fix: remove the symlink from the index and add an explicit "app/node_modules" (no trailing slash) ignore line.