### PR TITLE
fix(roaming): translate and clarify the 'client not found' kick message (#533)

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -400,7 +400,8 @@
     "kick": {
       "title": "Kick from AP to force reconnection",
       "label": "Kick {{name}}",
-      "error": "Could not kick the client"
+      "error": "Could not kick the client",
+      "notFound": "is no longer connected to any access point: it may have disconnected or roamed off the network. The list refreshes automatically."
     },
     "dot11r": {
       "title": "802.11r status",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -400,7 +400,8 @@
     "kick": {
       "title": "Expulsar del AP para forzar reconexión",
       "label": "Expulsar a {{name}}",
-      "error": "No se pudo expulsar al cliente"
+      "error": "No se pudo expulsar al cliente",
+      "notFound": "ya no está conectado a ningún punto de acceso: puede que se haya desconectado o movido a otra red. La lista se refresca sola."
     },
     "dot11r": {
       "title": "Estado 802.11r",

--- a/app/src/pages/Roaming.tsx
+++ b/app/src/pages/Roaming.tsx
@@ -360,7 +360,11 @@ export default function Roaming() {
         let msg = t('roaming.kick.error')
         try {
           const j = (await res.json()) as { error?: string; message?: string }
-          if (j.message) msg = j.message
+          if (res.status === 404 || j.error === 'not_found') {
+            // #533: el cliente ya no está en ningún AP (se desconectó o se
+            // movió): mensaje propio traducido, no el crudo del backend.
+            msg = t('roaming.kick.notFound')
+          } else if (j.message) msg = j.message
           else if (j.error) msg = j.error
         } catch { /* si el body no es JSON, usamos el mensaje por defecto */ }
         setKickError(`${nameByMac.get(mac) ?? mac}: ${msg}`)


### PR DESCRIPTION
When kicking a client from the Roaming matrix and the client is no longer on any AP, the UI showed the raw backend message ('m5-salon2: client not found'), untranslated and with no context. The backend already distinguishes this case (404, error code not_found). Now the kick UI maps that case to a translated, informative message (es/en) under roaming.kick.notFound (e.g. 'is no longer connected to any access point: it may have disconnected or moved'), keeping the client-name prefix. Other backend errors keep their behavior.