### PR TITLE
feat(roaming): survey channel bars with stacked neighbor overlay (#538)

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -450,8 +450,6 @@
       "legendFree": "< 40% (free)",
       "legendBusy": "40-70% (busy)",
       "legendCongested": "≥ 70% (congested)",
-      "matrixTitle": "Channel matrix",
-      "matrixHint": "each dot is a neighbor network on that channel (signal)"
     },
     "events": {
       "title": "Roaming events",

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -449,7 +449,9 @@
       "inUse": "In use",
       "legendFree": "< 40% (free)",
       "legendBusy": "40-70% (busy)",
-      "legendCongested": "≥ 70% (congested)"
+      "legendCongested": "≥ 70% (congested)",
+      "matrixTitle": "Channel matrix",
+      "matrixHint": "each dot is a neighbor network on that channel (signal)"
     },
     "events": {
       "title": "Roaming events",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -450,8 +450,6 @@
       "legendFree": "< 40% (libre)",
       "legendBusy": "40-70% (ocupado)",
       "legendCongested": "≥ 70% (congestionado)",
-      "matrixTitle": "Matriz de canales",
-      "matrixHint": "cada punto es una red vecina en ese canal (señal)"
     },
     "events": {
       "title": "Eventos de itinerancia",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -449,7 +449,9 @@
       "inUse": "En uso",
       "legendFree": "< 40% (libre)",
       "legendBusy": "40-70% (ocupado)",
-      "legendCongested": "≥ 70% (congestionado)"
+      "legendCongested": "≥ 70% (congestionado)",
+      "matrixTitle": "Matriz de canales",
+      "matrixHint": "cada punto es una red vecina en ese canal (señal)"
     },
     "events": {
       "title": "Eventos de itinerancia",

--- a/app/src/pages/Roaming.tsx
+++ b/app/src/pages/Roaming.tsx
@@ -1078,7 +1078,7 @@ function noiseClass(dbm: number): string {
   return 'text-ok'
 }
 
-// spectrumCellColor (#535): color de la celda de canal según la ocupación.
+// spectrumCellColor: color de la celda de canal según la ocupación.
 // Verde = libre, ámbar = ocupado, rojo = congestionado (misma escala busyClass).
 function spectrumCellBg(p: number): string {
   if (p >= 70) return 'bg-danger/30'
@@ -1086,37 +1086,150 @@ function spectrumCellBg(p: number): string {
   return 'bg-ok/25'
 }
 
-// SurveySpectrum (#535): tira horizontal de espectro por radio. Un bloque por
-// canal (ordenado por frecuencia), coloreado por uso (busyPct), con el canal
-// en el que opera la radio (inUse) resaltado con borde. Tooltip con el detalle
-// (canal, frecuencia, ruido, uso). Visualización al estilo channel_analysis de
-// LuCI, sin tocar la tabla de detalle que se mantiene debajo.
-function SurveySpectrum({ radio }: { radio: SurveyRadio }) {
-  const { t } = useTranslation()
-  const chans = useMemo(() => [...radio.channels].sort((a, b) => a.freq - b.freq), [radio.channels])
-  if (chans.length === 0) return null
+// señal → color (#538): verde fuerte a muy buena, ámbar intermedia, roja débil.
+function signalDot(signal: number): string {
+  if (signal >= -55) return 'bg-ok'
+  if (signal >= -70) return 'bg-warn'
+  return 'bg-danger'
+}
+
+// Neighbor scan del channel-plan (#538): red visible en un canal.
+interface Scan {
+  iface: string
+  bssid: string
+  ssid: string
+  channel: number
+  freq: number
+  signal: number
+  routerId: string
+}
+
+interface ChannelPlanData {
+  routerId: string
+  radios: unknown[]
+  scans: Scan[]
+}
+
+// SurveyMatrix (#538): matriz tipo channel_analysis del LuCI, pero moderna:
+// filas = radios de cada router, columnas = canales (ordenados por frecuencia),
+// cada celda coloreada por uso (busyPct, heatmap verde→ámbar→rojo), el canal
+// en el que opera la radio (inUse) resaltado con anillo, y superpuestas las
+// redes vecinas (puntos por señal) de los scans del channel-plan. La tabla de
+// detalle se mantiene debajo del componente.
+function SurveyMatrix({
+  overview,
+  band,
+  scansByRouter,
+}: {
+  overview: SurveyOverview
+  band: SurveyBand
+  scansByRouter: Record<string, Scan[]>
+}) {
+  const bands: string[] = band === 'all' ? ['2.4 GHz', '5 GHz', '6 GHz'] : [band]
   return (
-    <div className="overflow-x-auto">
-      <div className="flex flex-col gap-1 pb-1">
-        <div className="flex items-end gap-1">
-          {chans.map((c) => (
-            <div key={c.freq} className="flex flex-col items-center gap-0.5">
-              <div
-                title={`${t('roaming.survey.colChannel')} ${c.channel} · ${c.freq} MHz · ${t('roaming.survey.colNoise')} ${c.noiseDbm} dBm · ${t('roaming.survey.colBusy')} ${c.busyPct.toFixed(1)}%`}
-                className={cn(
-                  'h-7 w-7 sm:w-8 rounded-md ring-1 ring-inset transition-colors',
-                  spectrumCellBg(c.busyPct),
-                  c.inUse
-                    ? 'ring-2 ring-accent'
-                    : 'ring-border/60',
-                )}
-              />
-              <span className={cn('font-mono text-[10px] leading-none', c.inUse ? 'font-semibold text-accent' : 'text-text-muted')}>
-                {c.channel}
-              </span>
-            </div>
-          ))}
+    <>
+      {bands
+        .filter(
+          (b) => overview.routers.some((r) => r.available && r.radios.some((rd) => rd.band === b)),
+        )
+        .map((b) => (
+          <SurveyMatrixBand
+            key={b}
+            band={b}
+            overview={overview}
+            scansByRouter={scansByRouter}
+          />
+        ))}
+    </>
+  )
+}
+
+function SurveyMatrixBand({
+  band,
+  overview,
+  scansByRouter,
+}: {
+  band: string
+  overview: SurveyOverview
+  scansByRouter: Record<string, Scan[]>
+}) {
+  const { t } = useTranslation()
+  // Radios de esta banda (de todos los routers disponibles).
+  const radios = overview.routers
+    .filter((r) => r.available)
+    .flatMap((r) =>
+      r.radios
+        .filter((rd) => rd.band === band)
+        .map((rd) => ({ routerId: r.routerId, name: r.name, radio: rd })),
+    )
+  if (radios.length === 0) return null
+
+  // Columnas = canales presentes en la unión de todas las radios de la banda.
+  const chans = Array.from(new Set(radios.flatMap((x) => x.radio.channels.map((c) => c.channel ?? 0))))
+    .filter((c) => c > 0)
+    .sort((a, b) => a - b)
+
+  return (
+    <div className="overflow-x-auto pb-1">
+      <div className="mb-1 flex items-center gap-2">
+        <span className="rounded-md bg-elevated px-2 py-0.5 text-caption font-medium text-text-secondary">{band}</span>
+        <span className="text-caption text-text-muted">{t('roaming.survey.matrixHint')}</span>
+      </div>
+      <div className="inline-flex flex-col gap-1.5">
+        {/* Cabecera de canales */}
+        <div className="flex items-center gap-1.5">
+          <div className="w-40 shrink-0" />
+          <div className="flex gap-1">
+            {chans.map((ch) => (
+              <div key={ch} className="w-10 shrink-0 text-center font-mono text-[10px] leading-none text-text-muted">
+                {ch}
+              </div>
+            ))}
+          </div>
         </div>
+        {/* Filas = radios */}
+        {radios.map(({ routerId, name, radio }) => (
+          <div key={radio.device + routerId} className="flex items-center gap-1.5">
+            <div className="w-40 shrink-0 truncate text-caption text-text-secondary">
+              <span className="font-medium text-text-primary">{name}</span>
+              <span className="ml-1 font-mono text-[10px] text-text-muted">{radio.device}</span>
+            </div>
+            <div className="flex gap-1">
+              {chans.map((ch) => {
+                const c = radio.channels.find((x) => x.channel === ch)
+                const neighbors = (scansByRouter[routerId] ?? []).filter(
+                  (s) => s.channel === ch && s.iface === radio.device,
+                )
+                const label = c
+                  ? `${t('roaming.survey.colChannel')} ${ch} · ${c.freq} MHz · ${t('roaming.survey.colNoise')} ${c.noiseDbm} dBm · ${t('roaming.survey.colBusy')} ${c.busyPct.toFixed(1)}%\n` +
+                    neighbors.map((s) => `${s.ssid} (${s.signal} dBm)`).join('\n')
+                  : `${t('roaming.survey.colChannel')} ${ch}`
+                return (
+                  <div
+                    key={ch}
+                    title={label}
+                    className={cn(
+                      'relative flex h-10 w-10 shrink-0 items-center justify-center rounded-md ring-1 ring-inset transition-colors',
+                      c ? spectrumCellBg(c.busyPct) : 'bg-muted/10 ring-border/40',
+                      c?.inUse && 'ring-2 ring-accent',
+                    )}
+                  >
+                    {neighbors.length > 0 && (
+                      <div className="flex items-center gap-0.5">
+                        {neighbors.map((s) => (
+                          <span key={s.bssid} className={cn('h-2 w-2 rounded-full', signalDot(s.signal))} />
+                        ))}
+                      </div>
+                    )}
+                    {c?.inUse && (
+                      <span className="absolute -top-1 right-1 h-1.5 w-1.5 rounded-full bg-accent" />
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   )
@@ -1140,6 +1253,24 @@ function SurveyPanel({
   const { t } = useTranslation()
   const reduce = useReducedMotion()
   const initial = reduce ? false : { opacity: 0, y: 12 }
+
+  // Vecinos por router (capa de la matriz survey, #538): cada router con
+  // survey pide su canal-plan (scans) para superponer quién ocupa cada canal.
+  const [scansByRouter, setScansByRouter] = useState<Record<string, Scan[]>>({})
+  useEffect(() => {
+    if (!overview?.available) return
+    let active = true
+    setScansByRouter({})
+    for (const r of overview.routers) {
+      if (!r.available) continue
+      fetchJson<ChannelPlanData>(`/api/wifi/channel-plan?routerId=${encodeURIComponent(r.routerId)}`)
+        .then((res) => {
+          if (res.ok && active) setScansByRouter((prev) => ({ ...prev, [r.routerId]: res.data.scans ?? [] }))
+        })
+        .catch(() => { /* capa opcional: la matriz funciona solo con el survey */ })
+    }
+    return () => { active = false }
+  }, [overview])
 
   if (loading && !overview) {
     return (
@@ -1206,6 +1337,32 @@ function SurveyPanel({
         </div>
       </div>
 
+      {/* Matriz de canales por radio (#538): vista gráfica tipo channel_analysis */}
+      {overview.available && (
+        <div className="rounded-2xl border border-border bg-surface p-5 md:p-6">
+          <h3 className="mb-3 font-display text-h3 text-text-primary">{t('roaming.survey.matrixTitle')}</h3>
+          <SurveyMatrix overview={overview} band={band} scansByRouter={scansByRouter} />
+          <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-caption text-text-muted">
+            <span className="inline-flex items-center gap-1.5">
+              <span className="inline-block h-2.5 w-2.5 rounded-sm bg-ok/40 ring-1 ring-inset ring-ok/40" />
+              {t('roaming.survey.legendFree')}
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <span className="inline-block h-2.5 w-2.5 rounded-sm bg-warn/40 ring-1 ring-inset ring-warn/40" />
+              {t('roaming.survey.legendBusy')}
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <span className="inline-block h-2.5 w-2.5 rounded-sm bg-danger/40 ring-1 ring-inset ring-danger/40" />
+              {t('roaming.survey.legendCongested')}
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <span className="inline-block h-2 w-2 rounded-full bg-accent" />
+              {t('roaming.survey.inUse')}
+            </span>
+          </div>
+        </div>
+      )}
+
       {/* Tabla por router */}
       {overview.routers.map((r) => {
         const radios = r.radios.filter((rd) => band === 'all' || rd.band === band)
@@ -1225,10 +1382,6 @@ function SurveyPanel({
                 <div className="mb-2 flex items-center gap-2">
                   <span className="rounded-md bg-elevated px-2 py-0.5 font-mono text-caption text-text-secondary">{radio.device}</span>
                   <span className="text-caption text-text-muted">{radio.band}</span>
-                </div>
-                {/* Espectro por canal (#535): vista gráfica al estilo channel_analysis */}
-                <div className="mb-3">
-                  <SurveySpectrum radio={radio} />
                 </div>
                 <div className="overflow-x-auto">
                   <table className="w-full border-separate border-spacing-0 text-left text-sm">

--- a/app/src/pages/Roaming.tsx
+++ b/app/src/pages/Roaming.tsx
@@ -1110,127 +1110,53 @@ interface ChannelPlanData {
   scans: Scan[]
 }
 
-// SurveyMatrix (#538): matriz tipo channel_analysis del LuCI, pero moderna:
-// filas = radios de cada router, columnas = canales (ordenados por frecuencia),
-// cada celda coloreada por uso (busyPct, heatmap verde→ámbar→rojo), el canal
-// en el que opera la radio (inUse) resaltado con anillo, y superpuestas las
-// redes vecinas (puntos por señal) de los scans del channel-plan. La tabla de
-// detalle se mantiene debajo del componente.
-function SurveyMatrix({
-  overview,
-  band,
-  scansByRouter,
-}: {
-  overview: SurveyOverview
-  band: SurveyBand
-  scansByRouter: Record<string, Scan[]>
-}) {
-  const bands: string[] = band === 'all' ? ['2.4 GHz', '5 GHz', '6 GHz'] : [band]
-  return (
-    <>
-      {bands
-        .filter(
-          (b) => overview.routers.some((r) => r.available && r.radios.some((rd) => rd.band === b)),
-        )
-        .map((b) => (
-          <SurveyMatrixBand
-            key={b}
-            band={b}
-            overview={overview}
-            scansByRouter={scansByRouter}
-          />
-        ))}
-    </>
-  )
-}
-
-function SurveyMatrixBand({
-  band,
-  overview,
-  scansByRouter,
-}: {
-  band: string
-  overview: SurveyOverview
-  scansByRouter: Record<string, Scan[]>
-}) {
+// SurveyBars (#538): gráfico de barras horizontales por canal para una radio
+// (estilo channel_analysis del LuCI, suave): cada canal es una fila con una
+// barra cuyo ancho indica la ocupación (busyPct, gradiente verde->ámbar->rojo)
+// y, apilados dentro de la barra, los vecinos detectados en ese canal (segmentos
+// coloreados por señal). El canal en uso se marca a la derecha. Tooltip con
+// el detalle de cada canal (frecuencia, ruido, uso, redes).
+function SurveyBars({ radio, scans }: { radio: SurveyRadio; scans: Scan[] }) {
   const { t } = useTranslation()
-  // Radios de esta banda (de todos los routers disponibles).
-  const radios = overview.routers
-    .filter((r) => r.available)
-    .flatMap((r) =>
-      r.radios
-        .filter((rd) => rd.band === band)
-        .map((rd) => ({ routerId: r.routerId, name: r.name, radio: rd })),
-    )
-  if (radios.length === 0) return null
-
-  // Columnas = canales presentes en la unión de todas las radios de la banda.
-  const chans = Array.from(new Set(radios.flatMap((x) => x.radio.channels.map((c) => c.channel ?? 0))))
-    .filter((c) => c > 0)
-    .sort((a, b) => a - b)
+  const chans = useMemo(() => [...radio.channels].sort((a, b) => a.freq - b.freq), [radio.channels])
+  if (chans.length === 0) return null
 
   return (
-    <div className="overflow-x-auto pb-1">
-      <div className="mb-1 flex items-center gap-2">
-        <span className="rounded-md bg-elevated px-2 py-0.5 text-caption font-medium text-text-secondary">{band}</span>
-        <span className="text-caption text-text-muted">{t('roaming.survey.matrixHint')}</span>
-      </div>
-      <div className="inline-flex flex-col gap-1.5">
-        {/* Cabecera de canales */}
-        <div className="flex items-center gap-1.5">
-          <div className="w-40 shrink-0" />
-          <div className="flex gap-1">
-            {chans.map((ch) => (
-              <div key={ch} className="w-10 shrink-0 text-center font-mono text-[10px] leading-none text-text-muted">
-                {ch}
-              </div>
-            ))}
-          </div>
-        </div>
-        {/* Filas = radios */}
-        {radios.map(({ routerId, name, radio }) => (
-          <div key={radio.device + routerId} className="flex items-center gap-1.5">
-            <div className="w-40 shrink-0 truncate text-caption text-text-secondary">
-              <span className="font-medium text-text-primary">{name}</span>
-              <span className="ml-1 font-mono text-[10px] text-text-muted">{radio.device}</span>
+    <div className="flex flex-col gap-1.5">
+      {chans.map((c) => {
+        const neighbors = scans.filter((s) => s.channel === c.channel && s.iface === radio.device)
+        const label = `${t('roaming.survey.colChannel')} ${c.channel} · ${c.freq} MHz · ${t('roaming.survey.colNoise')} ${c.noiseDbm} dBm · ${t('roaming.survey.colBusy')} ${c.busyPct.toFixed(1)}%` +
+          (neighbors.length ? '\n' + neighbors.map((s) => `${s.ssid} (${s.signal} dBm)`).join('\n') : '')
+        return (
+          <div key={c.freq} className="flex items-center gap-2">
+            <span className={cn('w-8 shrink-0 text-right font-mono text-mono-sm', c.inUse ? 'font-semibold text-accent' : 'text-text-muted')}>
+              {c.channel || '—'}
+            </span>
+            <div title={label} className="flex h-5 flex-1 items-stretch overflow-hidden rounded-full bg-canvas ring-1 ring-inset ring-border/50">
+              {/* Ocupación (ancho = busyPct, gradiente) */}
+              <div
+                className={cn('h-full rounded-l-full transition-[width] duration-500', spectrumCellBg(c.busyPct))}
+                style={{ width: `${Math.min(100, Math.max(1, c.busyPct))}%` }}
+              />
+              {/* Vecinos apilados (un segmento por red, color por señal) */}
+              {neighbors.slice(0, 8).map((s) => (
+                <span
+                  key={s.bssid}
+                  className={cn('my-1 w-1.5 shrink-0 rounded-full', signalDot(s.signal))}
+                />
+              ))}
             </div>
-            <div className="flex gap-1">
-              {chans.map((ch) => {
-                const c = radio.channels.find((x) => x.channel === ch)
-                const neighbors = (scansByRouter[routerId] ?? []).filter(
-                  (s) => s.channel === ch && s.iface === radio.device,
-                )
-                const label = c
-                  ? `${t('roaming.survey.colChannel')} ${ch} · ${c.freq} MHz · ${t('roaming.survey.colNoise')} ${c.noiseDbm} dBm · ${t('roaming.survey.colBusy')} ${c.busyPct.toFixed(1)}%\n` +
-                    neighbors.map((s) => `${s.ssid} (${s.signal} dBm)`).join('\n')
-                  : `${t('roaming.survey.colChannel')} ${ch}`
-                return (
-                  <div
-                    key={ch}
-                    title={label}
-                    className={cn(
-                      'relative flex h-10 w-10 shrink-0 items-center justify-center rounded-md ring-1 ring-inset transition-colors',
-                      c ? spectrumCellBg(c.busyPct) : 'bg-muted/10 ring-border/40',
-                      c?.inUse && 'ring-2 ring-accent',
-                    )}
-                  >
-                    {neighbors.length > 0 && (
-                      <div className="flex items-center gap-0.5">
-                        {neighbors.map((s) => (
-                          <span key={s.bssid} className={cn('h-2 w-2 rounded-full', signalDot(s.signal))} />
-                        ))}
-                      </div>
-                    )}
-                    {c?.inUse && (
-                      <span className="absolute -top-1 right-1 h-1.5 w-1.5 rounded-full bg-accent" />
-                    )}
-                  </div>
-                )
-              })}
-            </div>
+            <span className={cn('w-14 shrink-0 font-mono text-[10px] text-text-muted', noiseClass(c.noiseDbm))}>
+              {c.noiseDbm} dBm
+            </span>
+            {c.inUse && (
+              <span className="shrink-0 rounded bg-accent-soft px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-accent">
+                {t('roaming.survey.inUse')}
+              </span>
+            )}
           </div>
-        ))}
-      </div>
+        )
+      })}
     </div>
   )
 }
@@ -1337,33 +1263,7 @@ function SurveyPanel({
         </div>
       </div>
 
-      {/* Matriz de canales por radio (#538): vista gráfica tipo channel_analysis */}
-      {overview.available && (
-        <div className="rounded-2xl border border-border bg-surface p-5 md:p-6">
-          <h3 className="mb-3 font-display text-h3 text-text-primary">{t('roaming.survey.matrixTitle')}</h3>
-          <SurveyMatrix overview={overview} band={band} scansByRouter={scansByRouter} />
-          <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-caption text-text-muted">
-            <span className="inline-flex items-center gap-1.5">
-              <span className="inline-block h-2.5 w-2.5 rounded-sm bg-ok/40 ring-1 ring-inset ring-ok/40" />
-              {t('roaming.survey.legendFree')}
-            </span>
-            <span className="inline-flex items-center gap-1.5">
-              <span className="inline-block h-2.5 w-2.5 rounded-sm bg-warn/40 ring-1 ring-inset ring-warn/40" />
-              {t('roaming.survey.legendBusy')}
-            </span>
-            <span className="inline-flex items-center gap-1.5">
-              <span className="inline-block h-2.5 w-2.5 rounded-sm bg-danger/40 ring-1 ring-inset ring-danger/40" />
-              {t('roaming.survey.legendCongested')}
-            </span>
-            <span className="inline-flex items-center gap-1.5">
-              <span className="inline-block h-2 w-2 rounded-full bg-accent" />
-              {t('roaming.survey.inUse')}
-            </span>
-          </div>
-        </div>
-      )}
-
-      {/* Tabla por router */}
+      {/* Grafiquito de canales por router (el de abajo dibuja las barras por radio) */}
       {overview.routers.map((r) => {
         const radios = r.radios.filter((rd) => band === 'all' || rd.band === band)
         if (!r.available || radios.length === 0) {
@@ -1382,6 +1282,10 @@ function SurveyPanel({
                 <div className="mb-2 flex items-center gap-2">
                   <span className="rounded-md bg-elevated px-2 py-0.5 font-mono text-caption text-text-secondary">{radio.device}</span>
                   <span className="text-caption text-text-muted">{radio.band}</span>
+                </div>
+                {/* Barras por canal (#538): uso + vecinos apilados, estilo channel_analysis */}
+                <div className="mb-3">
+                  <SurveyBars radio={radio} scans={scansByRouter[r.routerId] ?? []} />
                 </div>
                 <div className="overflow-x-auto">
                   <table className="w-full border-separate border-spacing-0 text-left text-sm">


### PR DESCRIPTION
Redesign of the survey view per feedback: replaces the cells matrix with a channel bar chart (like LuCI channel_analysis, but modern and smooth). For each radio: one row per channel with a horizontal bar whose width is the utilization (busyPct, green->amber->red gradient) and, stacked inside the bar, the neighbor networks on that channel as segments colored by signal (from the channel-plan scans). The in-use channel is flagged; noise shown at the right; tooltip with channel/freq/noise/usage/networks. The detail table stays below. Removes the matrixTitle/matrixHint keys (dead from the previous iteration).