### PR TITLE
fix(wifi): exclude guest/iot/disabled SSIDs from the 802.11r roaming count (#541)

### DIFF
--- a/server-go/internal/adapters/dot11r_test.go
+++ b/server-go/internal/adapters/dot11r_test.go
@@ -220,3 +220,23 @@ func TestUnquoteUci(t *testing.T) {
 		}
 	}
 }
+
+func TestDot11rSkip(t *testing.T) {
+	cases := []struct {
+		name string
+		ifc  Dot11rIface
+		want bool
+	}{
+		{"red principal lan", Dot11rIface{Network: "lan", Disabled: false}, false},
+		{"red invitada guest", Dot11rIface{Network: "guest", Disabled: false}, true},
+		{"red iot", Dot11rIface{Network: "iot", Disabled: false}, true},
+		{"red wan", Dot11rIface{Network: "wan", Disabled: false}, true},
+		{"iface deshabilitada", Dot11rIface{Network: "lan", Disabled: true}, true},
+		{"sin red (indeterminada) se deja pasar", Dot11rIface{Network: "", Disabled: false}, false},
+	}
+	for _, c := range cases {
+		if got := dot11rSkip(c.ifc); got != c.want {
+			t.Errorf("%s: dot11rSkip = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -3137,6 +3137,8 @@ func parseUciWireless(out string) []Dot11rIface {
 			MAC:                f["macaddr"],
 			Channel:            di.channel,
 			Band:               di.band,
+			Network:            f["network"],
+			Disabled:           f["disabled"] == "1",
 			Encryption:         f["encryption"],
 			Dot11REnabled:      f["ieee80211r"] == "1",
 			MobilityDomain:     f["mobility_domain"],
@@ -3151,6 +3153,21 @@ func parseUciWireless(out string) []Dot11rIface {
 		})
 	}
 	return ifaces
+}
+
+// dot11rSkip (#541): una iface no debe contar para usteer si pertenece a una
+// red invitada/aislada (guest/iot/wan) o está deshabilitada. La red principal
+// de roaming es "lan" (o la red no aislada). Si no puede determinarse, se deja
+// pasar (mejor mostrar de más que ocultar la principal por un nombre raro).
+func dot11rSkip(ifc Dot11rIface) bool {
+	if ifc.Disabled {
+		return true
+	}
+	switch ifc.Network {
+	case "guest", "iot", "wan":
+		return true
+	}
+	return false
 }
 
 // unquoteUci quita las comillas simples que uci envuelve a los valores y
@@ -3200,7 +3217,7 @@ func (l *Live) GetDot11r(ctx context.Context) (*Dot11rOverview, error) {
 		r.Ifaces = ifaces
 		out.Routers = append(out.Routers, r)
 		for _, ifc := range ifaces {
-			if ifc.SSID == "" {
+			if ifc.SSID == "" || dot11rSkip(ifc) {
 				continue
 			}
 			ssidIfaces[ifc.SSID] = append(ssidIfaces[ifc.SSID], dot11rIfaceRef{routerID: cfg.ID, iface: ifc})

--- a/server-go/internal/adapters/types.go
+++ b/server-go/internal/adapters/types.go
@@ -651,8 +651,15 @@ type Dot11rIface struct {
 	Ifname  string `json:"ifname"`  // wlan0, wlan1 (puede estar vacío en configs muy nuevas)
 	SSID    string `json:"ssid"`
 	MAC     string `json:"mac"`               // macaddr (BSSID del BSS)
+	Mac     string `json:"mac"`               // macaddr (BSSID del BSS)
 	Channel int    `json:"channel,omitempty"` // mapeado desde radio.channel
 	Band    string `json:"band,omitempty"`    // "2.4 GHz"|"5 GHz" desde radio.band
+
+	// Network es la red del bridge a la que pertenece la iface (lan/guest/iot...)
+	// y Disabled si la iface está desactivada (#541): las redes invitadas/iot y
+	// las ifaces inactivas no deben contar para usteer.
+	Network  string `json:"network,omitempty"`
+	Disabled bool   `json:"disabled,omitempty"`
 
 	Encryption string `json:"encryption,omitempty"` // psk2/sae/psk2-mixed...
 


### PR DESCRIPTION
The 802.11r status (Roaming > 802.11r) counted every SSID in the wireless UCI config, including guest/IoT networks and disabled ifaces, so it showed e.g. "Partial: on 1 of 5 SSIDs" with SSIDs that are not part of the main roaming mesh. GetDot11r now skips ifaces whose UCI network is guest/iot/wan or that are disabled=1 (dot11rSkip helper), so the count reflects only the SSIDs relevant for usteer. Added Network/Disabled to the Dot11rIface parser plus a TestDot11rSkip table; the existing parser tests stay green.