### PR TITLE
fix(i18n): remove trailing comma that broke translation.json (raw nav.* keys)

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -449,7 +449,7 @@
       "inUse": "In use",
       "legendFree": "< 40% (free)",
       "legendBusy": "40-70% (busy)",
-      "legendCongested": "≥ 70% (congested)",
+      "legendCongested": "≥ 70% (congested)"
     },
     "events": {
       "title": "Roaming events",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -449,7 +449,7 @@
       "inUse": "En uso",
       "legendFree": "< 40% (libre)",
       "legendBusy": "40-70% (ocupado)",
-      "legendCongested": "≥ 70% (congestionado)",
+      "legendCongested": "≥ 70% (congestionado)"
     },
     "events": {
       "title": "Eventos de itinerancia",


### PR DESCRIPTION
My sed cleanup of the survey keys (matrixTitle/matrixHint, #538) left a trailing comma at the end of the survey object in both es and en translation.json, making the files invalid JSON. i18next then fails to load resources and the UI shows raw keys (nav.ROUTERS, nav.DEVICES, ...). Fix: remove the trailing comma (and re-serialize both files). This does not change any translation value.