### PR TITLE
chore(release): v2.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.28.1] - 2026-09-05
+
+### Fixed
+
+- **El sondeo SSH ya no satura APs de bajas prestaciones (#550)**: el servidor, cuando sondea un router por SSH (sin agente), seguía usando el par de comandos previo al #373: clientes por `iwinfo assoclist` y resumen de radios por `iwinfo` en cada tick de 5 s. En un AP de un solo núcleo (p. ej. Archer A7 v5) eso disparaba la carga. Ahora el sondeo SSH replica el fix que el agente tiene desde #373: clientes vía `ubus hostapd get_clients` (autoritativo incluso con un AP vacío, sin caer a iwinfo), iwinfo solo en una pasada combinada como fallback, y el resumen de radios cacheado 5 minutos en vez de refrescarse en cada poll.
+
 ## [2.28.0] - 2026-09-05
 
 > **Nota de versionado**: las releases 2.26.13 y 2.26.14 no llegaron a

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.28.0",
+      "version": "2.28.1",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.0",
+  "version": "2.28.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.0"
+var Version = "2.28.1"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Release v2.28.1: port del fix #373 (#368) al sondeo SSH para APs de bajas prestaciones (#550, PR #552). Server-only; AGENT_VERSION sin cambios.

Closes #550