### PR TITLE
chore(release): v2.28.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.28.2] - 2026-09-05
+
+### Added
+
+- **Análisis de canales: eje X con todos los canales de la banda y red propia visible (#542, #554)**: la gráfica muestra cada canal de la banda activa (2.4 GHz: 1-13; 5 GHz: UNII-1..4) aunque esté vacío, como el análisis de LuCI; la red gestionada se dibuja como una montaña violeta en su canal en uso a -25 dBm (no aparece en los escaneos externos); y se muestra una sola banda a la vez (selector 2.4 GHz / 5 GHz, sin "Todos").
+
+### Fixed
+
+- **La reserva DHCP se escribe en el router que sirve el lease, no siempre en el gateway (#537)**: las acciones de reserva (GET/PUT/DELETE /api/devices/{mac}/reservation) apuntaban siempre al gateway global. En una LAN separada cuyo DHCP lo concede otro router (p. ej. un AP/lab con su propio dnsmasq, como rt-lab en 192.168.2.x) la reserva acababa en el gateway equivocado. Ahora el servidor resuelve el router que reportó el lease de esa MAC (el dnsmasq que se la concedió) y escribe allí; si no hay lease conocido cae al gateway, como antes. El bloqueo de dispositivo ya apuntaba al router de atache.
+
 ## [2.28.1] - 2026-09-05
 
 ### Fixed

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.1",
+  "version": "2.28.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.28.1",
+      "version": "2.28.2",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.1",
+  "version": "2.28.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.1"
+var Version = "2.28.2"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Release v2.28.2: reserva DHCP dirigida al router que sirve el lease (#537, PR #555) + análisis de canales con todos los canales de la banda y red propia (#542/#554, PR #554). Server + front; AGENT_VERSION sin cambios.

Closes #537