### PR TITLE
chore(release): v2.28.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.28.4] - 2026-09-05
+
+### Added
+
+- **Identificación de hosts Proxmox y sus contenedores vía la API del cluster (#561)**: el detalle de Dispositivos y la topología ahora sellan correctamente los hosts de Proxmox VE como **hipervisor** y sus CTs/VMs como **contenedores** colgados de su host, con nombres e IPs reales. La heurística de red (FDB/OUI) no podía deducir la relación contenedor→host cuando un puerto del router mezcla dispositivos o los CTs usan MACs no estándar; la relación vive en el cluster. La integración es de **solo lectura** (token API con privilegios de auditoría, `PVEAuditor`) y se configura en Ajustes > Proxmox VE (URL del cluster + token). Nota: en PVE 9.x los privilegios de un token no se editan desde la UI; se asignan por CLI (`pvesh set /access/acl -path / -roles PVEAuditor -tokens "usuario@realm!token"`).
+
+### Changed
+
+- **CI: Node 24 (Active LTS Krypton) y `.nvmrc`/`engines` fijados (#542, #560)**: los workflows usan Node 24 y el repo declara la versión para reproducibilidad.
+
 ## [2.28.3] - 2026-09-05
 
 ### Added

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.3",
+  "version": "2.28.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.28.3",
+      "version": "2.28.4",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.3",
+  "version": "2.28.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.3"
+var Version = "2.28.4"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Release v2.28.4: #561 (Proxmox identification) + #560 (CI Node 24).