### PR TITLE
fix(agents): allow rearming a stale NetGrip agent by restarting the netgrip service

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -682,6 +682,9 @@
       "staleTip": "Agent registered but not responding — reinstall it from the router detail",
       "rearm": "Rearm",
       "rearming": "Restarting…",
+      "netgripRestart": "Restart NetGrip",
+      "netgripRestarting": "Restarting NetGrip…",
+      "netgripRestartTip": "Restarts the NetGrip service on the router: reloads the embedded agent from its config",
       "rearmOk": "Agent rearmed",
       "rearmPending": "Restarted; waiting for the first push",
       "rearmFail": "Could not rearm",
@@ -793,7 +796,8 @@
       "kindNetgrip": "NetGrip",
       "kindExternal": "External",
       "netgripTip": "The agent lives inside this router's NetGrip panel",
-      "netgripHint": "The agent lives in the NetGrip panel: Update upgrades the panel itself"
+      "netgripHint": "The agent lives in the NetGrip panel: Update upgrades the panel itself",
+      "netgripStaleHint": "The agent lives in the NetGrip panel. If it stops reporting, restart it with the button (restarts the NetGrip service on the router) or update the panel if a newer version is available."
     },
     "upgradeUpdatedDetail": "Updated · {{count}} steps · {{secs}} s",
     "noVitals": "No system metrics",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -682,6 +682,9 @@
       "staleTip": "Agente registrado pero sin respuesta — reinstálalo desde el detalle",
       "rearm": "Rearmar",
       "rearming": "Reiniciando…",
+      "netgripRestart": "Reiniciar NetGrip",
+      "netgripRestarting": "Reiniciando NetGrip…",
+      "netgripRestartTip": "Reinicia el servicio NetGrip del router: recarga el agente embebido desde su config",
       "rearmOk": "Agente rearmado",
       "rearmPending": "Reiniciado; esperando el primer push",
       "rearmFail": "No se pudo rearmar",
@@ -793,7 +796,8 @@
       "kindNetgrip": "NetGrip",
       "kindExternal": "Externo",
       "netgripTip": "El agente vive dentro del panel NetGrip de este router",
-      "netgripHint": "El agente vive en el panel NetGrip: Actualizar actualiza el propio panel"
+      "netgripHint": "El agente vive en el panel NetGrip: Actualizar actualiza el propio panel",
+      "netgripStaleHint": "El agente vive en el panel NetGrip. Si no reporta, reinícialo con el botón (reinicia el servicio NetGrip en el router) o actualiza el panel si hay versión nueva."
     },
     "upgradeUpdatedDetail": "Actualizado · {{count}} pasos · {{secs}} s",
     "noVitals": "Sin métricas de sistema",

--- a/app/src/components/routers/AgentRearmButton.tsx
+++ b/app/src/components/routers/AgentRearmButton.tsx
@@ -16,12 +16,16 @@ type RearmState = 'idle' | 'busy' | 'ok' | 'pending' | 'fail'
 /**
  * Botón «Rearmar» (Fase 5, Plan B): solo aparece con un agente registrado,
  * NO fresh (caído) y sesión con rol admin (la API exige admin en el rearme;
- * auditoría v2.4.0 §2, issue #7). Reinicia el servicio procd en el router
- * vía POST /api/agents/{slug}/rearm y refleja el resultado real:
+ * auditoría v2.4.0 §2, issue #7). Reinicia el servicio del agente en el
+ * router vía POST /api/agents/{slug}/rearm y refleja el resultado real:
  *   ok      → el agente volvió a empujar (recuperado)
  *   pending → reiniciado pero sin push en 30 s
  *   fail    → petición fallida (SSH, cooldown, sin servidor…)
  * El estado ok/pending/fail dura 6 s y vuelve a idle.
+ *
+ * #569: para un agente NetGrip stale el botón dice «Reiniciar NetGrip» (el
+ * backend reinicia el SERVICIO netgrip, que recarga el env del agente
+ * embebido); para un agente nativo dice «Rearmar» (reinicia netpulse-agent).
  */
 export function AgentRearmButton({ agent, className }: AgentRearmButtonProps) {
   const { t } = useTranslation()
@@ -32,11 +36,13 @@ export function AgentRearmButton({ agent, className }: AgentRearmButtonProps) {
   if (!agent || agent.fresh) return null
   if (auth?.role !== 'admin') return null
 
+  const netgrip = agent.kind === 'netgrip'
   const label =
-    state === 'busy' ? t('routers.agent.rearming')
+    state === 'busy' ? (netgrip ? t('routers.agent.netgripRestarting') : t('routers.agent.rearming'))
     : state === 'ok' ? t('routers.agent.rearmOk')
     : state === 'pending' ? t('routers.agent.rearmPending')
     : state === 'fail' ? t('routers.agent.rearmFail')
+    : netgrip ? t('routers.agent.netgripRestart')
     : t('routers.agent.rearm')
 
   const onClick = async () => {
@@ -53,7 +59,7 @@ export function AgentRearmButton({ agent, className }: AgentRearmButtonProps) {
       type="button"
       onClick={onClick}
       disabled={state === 'busy'}
-      title={t('routers.agent.staleTip')}
+      title={netgrip ? t('routers.agent.netgripRestartTip') : t('routers.agent.staleTip')}
       className={cn(
         'inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[11px] font-semibold transition-opacity hover:opacity-90 disabled:opacity-50',
         state === 'ok' ? 'bg-ok text-canvas'

--- a/app/src/components/routers/AgentsSection.tsx
+++ b/app/src/components/routers/AgentsSection.tsx
@@ -212,10 +212,20 @@ function AgentRow({ agent, router }: { agent?: AgentInfo; router: Router | undef
         <div className="flex flex-wrap items-center gap-2">
           {/* Actualizar: self-update del agente con progreso en vivo (#243).
               NetGrip (#363): el evento SSE dispara el self-update del propio
-              panel; rearm/reinstall no aplican (no hay proceso standalone). */}
+              panel; el reinstall no aplica (no hay proceso standalone), y el
+              rearm de un NetGrip STALE reinicia el servicio netgrip (#569). */}
           <AgentUpgradeButton agent={agent} className="h-8" />
           {isNetgrip ? (
-            <span className="text-caption text-text-muted">{t('routers.agents.netgripHint')}</span>
+            // #569: un NetGrip STALE (caído) SÍ se puede recuperar desde
+            // aquí: el botón reinicia el servicio netgrip del router por SSH
+            // (recarga el env del agente embebido). El hint explica el caso
+            // fresco; el stale ofrece el botón + su hint.
+            <>
+              {!agent?.fresh && <AgentRearmButton agent={agent} />}
+              <span className="text-caption text-text-muted">
+                {agent?.fresh ? t('routers.agents.netgripHint') : t('routers.agents.netgripStaleHint')}
+              </span>
+            </>
           ) : (
             <>
           {/* Rearm: canal preferente para heartbeat stale (proceso vivo).

--- a/server-go/internal/httpapi/agent_kind_test.go
+++ b/server-go/internal/httpapi/agent_kind_test.go
@@ -8,9 +8,9 @@ import (
 	"time"
 )
 
-// TestAgentsNetgripKind (#363): un push con kind "netgrip" se lista como tal,
-// no marca updateAvailable y el servidor rechaza upgrade, rearm y reinstall
-// (el agente es el panel NetGrip; se gestiona desde el propio router).
+// TestAgentsNetgripKind (#363): un push con kind "netgrip" se lista como tal
+// y el servidor rechaza rearm de un NetGrip FRESH (el agente es el panel
+// NetGrip; un NetGrip stale SÍ se rearma reiniciando el servicio, #569).
 func TestAgentsNetgripKind(t *testing.T) {
 	ts := makeAgentTestServer(t)
 	_, token, _ := createAgentToken(t, ts, "patio")

--- a/server-go/internal/rearmer/rearmer.go
+++ b/server-go/internal/rearmer/rearmer.go
@@ -28,6 +28,14 @@ import (
 const (
 	// Cmd es el comando de reinicio del servicio procd del agente.
 	Cmd = "/etc/init.d/netpulse-agent restart"
+	// CmdNetgrip (#569): reinicia el servicio NetGrip del router. El agente
+	// embebido vive DENTRO del proceso netgrip: reiniciar el servicio recarga
+	// el env desde disco (NETPULSE_*) y relanza el agente, lo que recupera un
+	// NetGrip cuyo proceso arrastra un token/estado obsoleto en memoria (401s
+	// eternos en ingest). NO instala nada sobre el panel: solo lo reinicia.
+	// stop explícito + arranque: "restart" de procd puede ser no-op en NetGrip
+	// (PID intacto), stop+start es el patrón verificado.
+	CmdNetgrip = "/etc/init.d/netgrip stop; sleep 1; /etc/init.d/netgrip start"
 	// SSHWait: timeout del comando SSH de reinicio.
 	SSHWait = 10 * time.Second
 	// PollWait: cuánto esperar el push de vuelta tras el reinicio.
@@ -152,11 +160,19 @@ func (r *Rearmer) Rearm(slug string) (Result, error) {
 	if r.db == nil {
 		return Result{}, ErrNoDB
 	}
-	// #363: los agentes embebidos en NetGrip no se rearman por SSH (el
-	// servicio del agente es el propio panel).
+	// #363 + #569: un agente embebido en NetGrip NO se rearma con el init del
+	// agente nativo (el servicio del agente es el propio panel NetGrip).
+	// - FRESH (el panel empuja): no hay nada que rearmar → ErrNetgripAgent.
+	// - STALE (el panel no reporta): se reinicia el SERVICIO netgrip por SSH
+	//   (CmdNetgrip), que recarga el env y relanza el agente embebido; es la
+	//   vía de recuperación real para un NetGrip caído (#569).
+	cmd := Cmd
 	if r.agents != nil {
 		if _, _, kind, _, ok := r.agents.Info(slug); ok && kind == "netgrip" {
-			return Result{}, ErrNetgripAgent
+			if _, fresh := r.agents.Fresh(slug); fresh {
+				return Result{}, ErrNetgripAgent
+			}
+			cmd = CmdNetgrip
 		}
 	}
 	// El slug debe tener token registrado (si no, 404 como DELETE).
@@ -202,7 +218,7 @@ func (r *Rearmer) Rearm(slug string) (Result, error) {
 		}
 	}
 
-	if _, err := r.pool.Run(host, Cmd, SSHWait); err != nil {
+	if _, err := r.pool.Run(host, cmd, SSHWait); err != nil {
 		return Result{}, fmt.Errorf("no pude reiniciar el servicio en %s: %w", host, err)
 	}
 
@@ -216,7 +232,7 @@ func (r *Rearmer) Rearm(slug string) (Result, error) {
 				ID:       fmt.Sprintf("alert-agent-rearm-%s-%d", slug, time.Now().UnixMilli()),
 				Category: alerts.CatSystem, Urgent: false, Severity: "info",
 				Title:       fmt.Sprintf("Agente rearmado en %s", slug),
-				Description: "Reinicio del servicio netpulse-agent desde el servidor — el agente vuelve a empujar",
+				Description: "Reinicio del servicio del agente desde el servidor — el agente vuelve a empujar",
 				Time:        "ahora mismo", RouterID: slug,
 			})
 		}

--- a/server-go/internal/rearmer/rearmer_test.go
+++ b/server-go/internal/rearmer/rearmer_test.go
@@ -436,3 +436,52 @@ func TestSupervisorSinEscaladoQuedaEnRearm(t *testing.T) {
 		t.Fatalf("sin escalado quiero solo el rearm, tuve %d", env.ssh.count())
 	}
 }
+
+// pushNetgrip simula un push de un agente embebido en NetGrip (kind netgrip).
+func (e *rearmEnv) pushNetgrip(slug string) {
+	e.reg.Ingest(&probe.Payload{Router: slug, Ts: e.now.Unix(), Version: "0.70.0", Kind: "netgrip"})
+}
+
+// TestRearmNetgripStaleUsaCmdNetgrip (#569): un agente NetGrip STALE (sin
+// push reciente) SÍ se rearma reiniciando el servicio netgrip del router (no
+// el netpulse-agent, que no existe en ese escenario).
+func TestRearmNetgripStaleUsaCmdNetgrip(t *testing.T) {
+	env := makeRearmEnv(t, "patio")
+	env.pushNetgrip("patio")
+	env.expira(time.Minute)
+	env.arm.SetPollWait(100 * time.Millisecond)
+
+	res, err := env.arm.Rearm("patio")
+	if err != nil {
+		t.Fatalf("rearm netgrip stale: %v", err)
+	}
+	if !res.Restarted {
+		t.Fatalf("rearm netgrip stale: Restarted=false %+v", res)
+	}
+	if env.ssh.count() != 1 {
+		t.Fatalf("quiero 1 comando SSH, tuve %d", env.ssh.count())
+	}
+	cmd := env.ssh.cmds[0]
+	if !strings.Contains(cmd, "/etc/init.d/netgrip") {
+		t.Fatalf("el rearm netgrip debe reiniciar el servicio netgrip, cmd=%q", cmd)
+	}
+	if strings.Contains(cmd, "netpulse-agent") {
+		t.Fatalf("el rearm netgrip NO debe tocar netpulse-agent, cmd=%q", cmd)
+	}
+}
+
+// TestRearmNetgripFreshRechazado (#569): un NetGrip FRESH (empujando) no
+// tiene nada que rearmar: se sigue rechazando con ErrNetgripAgent (el panel
+// está vivo; rearmarlo reiniciaría el servicio sin necesidad).
+func TestRearmNetgripFreshRechazado(t *testing.T) {
+	env := makeRearmEnv(t, "patio")
+	env.pushNetgrip("patio") // push reciente: dentro del TTL
+
+	res, err := env.arm.Rearm("patio")
+	if !errors.Is(err, rearmer.ErrNetgripAgent) {
+		t.Fatalf("netgrip fresh: quiero ErrNetgripAgent, tuve %v (%+v)", err, res)
+	}
+	if env.ssh.count() != 0 {
+		t.Fatalf("netgrip fresh no debe ejecutar SSH, tuve %d", env.ssh.count())
+	}
+}


### PR DESCRIPTION
## What

Closes #569.

A router whose agent is the embedded NetGrip one (`kind=netgrip`) can end up stale with **no recovery action** in the fleet UI: Rearm/Reinstall are blocked for netgrip (#363) and the Update button only shows when `updateAvailable` is true. The typical root cause is a NetGrip process started before an agent token rotation: it keeps the old token in memory, every ingest push returns `HTTP 401` and the agent looks unrecoverable.

## Changes

- **Server (`rearmer.go`)**: `Rearm()` now distinguishes NetGrip freshness:
  - NetGrip **fresh** (panel pushing): still rejected with `409 netgrip_managed` - nothing to rearm.
  - NetGrip **stale** (not reporting): runs `/etc/init.d/netgrip stop; sleep 1; /etc/init.d/netgrip start` over SSH instead of the native `netpulse-agent restart`, then waits for the push. Restarting the netgrip service reloads the env from disk and relaunches the embedded agent, curing stale-token/memory states without installing anything over the panel (does not violate #363).
- **UI (`AgentsSection.tsx`, `AgentRearmButton.tsx`)**: a stale NetGrip agent now shows a **"Restart NetGrip"** button plus an explanatory hint; fresh NetGrip keeps the previous hint. New i18n keys (ES/EN).
- **Tests**: `TestRearmNetgripStaleUsaCmdNetgrip` (stale → runs the netgrip service command, never netpulse-agent) and `TestRearmNetgripFreshRechazado` (fresh → ErrNetgripAgent, no SSH).

## Verification

- server-go suite: 39 packages ok (only `TestOpenArmVariants` fails: needs agent binaries present, environment).
- front: `tsc`, `vite build` and `eslint` clean.
- Preview `v2.28.4-569` deployed on the production CT: health OK, 6 agents connected, bundle serves the new button and ES/EN strings. Rearm of a fresh NetGrip still returns `409 netgrip_managed`.

## Notes

- Recovery of a stale NetGrip agent was already possible by restarting the netgrip service on the router manually; this makes it a one-click server-driven action.
- Distinct from #564/#566/#567 (fresh-install SSH discovery flow).