### PR TITLE
chore(release): v2.28.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.28.5] - 2026-09-06
+
+### Fixed
+
+- **El "copy command" para instalar un agente no era ejecutable (#571)**: la app generaba el one-liner con opciones separadas por espacio (`--binary /tmp/netpulse-agent ...`), pero el instalador solo aceptaba `--opt=value`, así que abortaba en la primera opción con `opción desconocida: --binary` y nunca llegaba al paso SSH. El instalador ahora acepta tanto `--opt value` como `--opt=value`.
+- **El instalador no usaba la llave SSH del servidor (#572)**: `install-agent.sh` hacía `ssh root@IP` sin identidad explícita; si el router solo autoriza la llave que genera NetPulse (la que muestra Ajustes), el SSH fallaba aunque `ssh -i <llave> root@IP` funcionara. Ahora se acepta `--ssh-key <ruta>`, se reenvía con `-i` a todos los `ssh`/`scp`, y el copy-command la incluye automáticamente.
+
 ## [2.28.4] - 2026-09-05
 
 ### Added

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.4",
+  "version": "2.28.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.28.4",
+      "version": "2.28.5",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.4",
+  "version": "2.28.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.4"
+var Version = "2.28.5"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Release v2.28.5.

Bump de versión y CHANGELOG para la tanda #571/#572 (fix del copy-command de instalación del agente y del uso de la llave SSH del servidor).