### PR TITLE
fix(install): parse the release tag by name instead of field position

### DIFF
--- a/install-agent.sh
+++ b/install-agent.sh
@@ -171,7 +171,7 @@ HANDOFF
         elif command -v wget >/dev/null 2>&1; then FETCH="wget -q -O-"
         else fatal 21 "necesito curl o wget"; fi
         NG_TAG=$($FETCH "https://api.github.com/repos/gnacho/netgrip/releases/latest" \
-            | grep '"tag_name"' | head -1 | cut -d'"' -f4) || fatal 41 "no pude resolver la última release de NetGrip"
+            | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4) || fatal 41 "no pude resolver la última release de NetGrip"
         NG_VER=$(echo "$NG_TAG" | sed 's/^v//')
         ARCH=$(ssh $SSH_IDENT_ARGS "$SSH" uname -m)
         case "$ARCH" in
@@ -249,7 +249,7 @@ else
     if [ -z "$NETPULSE_VERSION" ]; then
         info "resolviendo última release"
         NETPULSE_VERSION=$($FETCH "https://api.github.com/repos/$GH_REPO/releases/latest" \
-            | grep '"tag_name"' | head -1 | cut -d'"' -f4) \
+            | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4) \
             || fatal 31 "no pude resolver la última release; usa --version=X.Y.Z"
     fi
     VERSION_NORM=$(echo "$NETPULSE_VERSION" | sed 's/^v//')

--- a/install-collector.sh
+++ b/install-collector.sh
@@ -200,7 +200,7 @@ fi
 if [ -z "$NETPULSE_VERSION" ]; then
     info "resolving latest stable version"
     NETPULSE_VERSION=$($FETCH "https://api.github.com/repos/$GH_REPO/releases/latest" \
-        | grep '"tag_name"' | head -1 | cut -d'"' -f4) \
+        | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4) \
         || fatal 31 "could not resolve the latest version. Use --version=X.Y.Z"
     [ -n "$NETPULSE_VERSION" ] || fatal 31 "no stable release found yet. Use --version=X.Y.Z"
 fi

--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,10 @@ INSTALL_DIR="/usr/local/bin"
 STATE_DIR="/var/lib/$APP_NAME"
 SERVICE_NAME="$APP_NAME"
 
+# Versión de ESTE instalador (bumpear en cada release junto a httpapi.Version,
+# para poder saber qué install.sh se está ejecutando; ver CHANGELOG).
+INSTALLER_VERSION="2.28.5"
+
 NETPULSE_VERSION=""; UNATTENDED=0; DRY_RUN=0; UNINSTALL=0; PURGE=0; DEMO=0
 
 # ---------------------------------------------------------------- logging ---
@@ -169,6 +173,7 @@ if [ ! -d /run/systemd/system ] || ! command -v systemctl >/dev/null 2>&1; then
     fatal 23 "NetPulse needs systemd (this machine doesn't run it). See https://github.com/$GH_REPO for manual setup"
 fi
 info "detected: $OS_PRETTY · linux/$GOARCH · systemd"
+info "install.sh version: $INSTALLER_VERSION"
 
 if command -v curl >/dev/null 2>&1; then FETCH="curl -fsSL --retry 3 --connect-timeout 10"
 elif command -v wget >/dev/null 2>&1; then FETCH="wget -q -O-"
@@ -256,7 +261,7 @@ fi
 if [ -z "$NETPULSE_VERSION" ]; then
     info "resolving latest stable version"
     NETPULSE_VERSION=$($FETCH "https://api.github.com/repos/$GH_REPO/releases/latest" \
-        | grep '"tag_name"' | head -1 | cut -d'"' -f4) \
+        | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4) \
         || fatal 31 "could not resolve the latest version (GitHub rate-limit?). Use --version=X.Y.Z"
     [ -n "$NETPULSE_VERSION" ] || fatal 31 "no stable release found yet. Use --version=X.Y.Z"
 fi


### PR DESCRIPTION
Fixes #564.

The installers resolved `releases/latest` with a positional `cut -d\" -f4`. When GitHub returns the payload minified on a line, that 4th field is the release URL, not the tag, so the version resolved to the API URL and the download path broke (install.sh, install-agent.sh, install-collector.sh). Extract `tag_name` by name with `grep -oE`. Also echo `install.sh` version so the running installer can be told apart.