### PR TITLE
fix(probe): resolve the dnsmasq lease file via UCI

### DIFF
--- a/agent/probe/probe.go
+++ b/agent/probe/probe.go
@@ -33,7 +33,12 @@ const (
 	// CmdPingGateway: ping corto al gateway desde un AP. %s = host gateway.
 	CmdPingGateway = "ping -c 2 -W 2 %s 2>/dev/null | tail -1"
 	CmdDhcpUbus    = "ubus call dhcp ipv4leases"
-	CmdDhcpFile    = "cat /tmp/dhcp.leases 2>/dev/null || true"
+	// CmdDhcpFile: cat del fichero de leases de dnsmasq. Resuelve la ubicación
+	// real vía UCI (dhcp.@dnsmasq[0].leasefile), porque puede NO ser la
+	// standard /tmp/dhcp.leases (p. ej. en un SSD montado, #568); si el valor
+	// UCI no existe o está vacío, cae a /tmp/dhcp.leases. Busybox: test -n y
+	// comillas simples para $f.
+	CmdDhcpFile = `f=$(uci -q get dhcp.@dnsmasq[0].leasefile 2>/dev/null); [ -n "$f" ] || f=/tmp/dhcp.leases; cat "$f" 2>/dev/null || true`
 	// CmdGlClients (GL.iNet): base de clientes completa del firmware. Es un
 	// SUPERSET de dhcp.leases: incluye equipos con IP estática o sin lease
 	// DHCP que el dnsmasq del Flint2 no lista (issue #5 bug 1).


### PR DESCRIPTION
Fixes #568 (hostnames part).

The DHCP lease file was read from /tmp/dhcp.leases, but dnsmasq can be configured to store it elsewhere (uci dhcp.@dnsmasq[0].leasefile, e.g. on a mounted SSD). Hostnames then did not show. Resolve the real path from UCI and fall back to /tmp/dhcp.leases. Applies to the agent probe and the server SSH poller, which share CmdDhcpFile.

Follow-up: a per-device toggle to control which routers ingest DHCP leases (and skip routers without dnsmasq) is out of scope here.