### PR TITLE
feat(ui): honest no-traffic message and document the per-client source

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -96,6 +96,8 @@ NetPulse descubre dispositivos clientes a partir de tres fuentes que se ejecutan
 
 LLDP solo se usa para identificar routers/switches vecinos, no dispositivos finales. El descubrimiento requiere que el agente de NetPulse esté corriendo en el router que ve a los clientes; una instalación nueva con solo routers dados de alta manualmente y sin agente en el gateway mostrará una lista de dispositivos vacía hasta que se instale el agente.
 
+El tráfico por cliente prefiere `nlbwmon` para los clientes por cable (contadores por MAC) y cae a los contadores de bytes de hostapd para los WiFi. `nlbwmon` no viene en todos los builds de OpenWrt y puede ser pesado en memoria en routers con poca RAM; `vnstat` mide totales por interfaz, no tráfico por MAC, así que no es un sustituto. Si un cliente por cable no muestra serie de tráfico, instala `nlbwmon` en ese router (o confía en el fallback WiFi).
+
 ## Capturas
 
 **Topología: inferida en vivo del FDB del bridge, túneles incluidos**

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ NetPulse discovers client devices from three sources that run on the monitored r
 
 LLDP is used only to identify neighbouring routers/switches, not end devices. Discovery requires the NetPulse agent to be running on the router that sees the clients; a fresh install with only manually onboarded routers and no agent on the gateway will show an empty device list until the agent is installed.
 
+Per-client traffic prefers `nlbwmon` for wired clients (per-MAC counters) and falls back to the hostapd byte counters for Wi-Fi clients. `nlbwmon` is not included in every OpenWrt build and can be memory-hungry on very low-RAM routers; `vnstat` tracks per-interface totals, not per-client MAC traffic, so it is not a substitute. If a wired client shows no traffic series, install `nlbwmon` on that router (or rely on the Wi-Fi fallback).
+
 ## Screenshots
 
 **Topology: inferred live from the bridge FDB, tunnels included**

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -187,6 +187,7 @@
       "traffic24h": "Traffic 24 h",
       "trafficCurrent": "Current traffic",
       "traffic": "Client traffic",
+      "trafficNoSource": "No per-client traffic: wired clients need nlbwmon on the router (WiFi uses hostapd counters).",
       "unfiltered": "Unfiltered"
     },
     "deviceType": "Device type",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -187,6 +187,7 @@
       "traffic24h": "Tráfico 24 h",
       "trafficCurrent": "Tráfico actual",
       "traffic": "Tráfico por cliente",
+      "trafficNoSource": "Sin tráfico por cliente: los clientes por cable necesitan nlbwmon en el router (los WiFi usan los contadores de hostapd).",
       "unfiltered": "Sin filtrar"
     },
     "deviceType": "Tipo de dispositivo",

--- a/app/src/components/DeviceTraffic.tsx
+++ b/app/src/components/DeviceTraffic.tsx
@@ -141,7 +141,7 @@ export function DeviceTrafficDetail({ mac, online }: { mac: string; online: bool
         </div>
       ) : (
         <div className="flex h-8 items-center justify-center text-caption text-text-muted">
-          {t('routerDetail.ports.seriesNoData')}
+          {t('devices.detail.trafficNoSource')}
         </div>
       )}
     </div>


### PR DESCRIPTION
Fixes #574.

When per-client traffic has no series, the device detail showed a generic 'no data'. Show an honest note that wired clients need nlbwmon on the router (WiFi uses hostapd counters), and document the per-client source plus the nlbwmon RAM caveat in the README (EN/ES).