### PR TITLE
fix(ui): do not show a hardcoded timezone or a fake 'firmware up to date'

### DIFF
--- a/app/src/components/routers/RouterInfo.tsx
+++ b/app/src/components/routers/RouterInfo.tsx
@@ -61,17 +61,17 @@ export function RouterInfo({ router, extras }: { router: Router; extras?: Router
             <StatusPill tone="warn" label={t('routers.firmwareOutdated')} />
           ) : ex.firmwareUpdated ? (
             <StatusPill tone="ok" label={t('routerDetail.info.updated')} />
-          ) : (
+          ) : ex.firmwareAvailable ? (
             <span title={t('routers.firmwareAvailable', { version: ex.firmwareAvailable })}>
-              <StatusPill tone="warn" label={ex.firmwareAvailable ?? ''} />
+              <StatusPill tone="warn" label={ex.firmwareAvailable} />
             </span>
-          )}
+          ) : null}
         </span>
       ),
     },
     { label: 'Uptime', node: fmtUptime(router.uptime) },
     { label: t('routerDetail.info.lastReboot'), node: ex.lastReboot },
-    { label: t('routerDetail.info.timezone'), node: 'Europe/Madrid' },
+    { label: t('routerDetail.info.timezone'), node: ex.timezone ?? '—' },
     {
       label: t('routerDetail.info.access'),
       node: (

--- a/app/src/components/routers/routerExtras.ts
+++ b/app/src/components/routers/routerExtras.ts
@@ -99,6 +99,8 @@ export interface RouterExtras {
   flash: string
   ramMb: number
   bandSplit: BandSplit
+  /** Zona horaria del router (p. ej. 'Europe/Madrid'); vacía si se desconoce. */
+  timezone?: string
   /** Tráfico actual ↓ Mbps (routers.md §③) */
   trafficNow: number
   /** Latencia al gateway en ms (solo APs; gateway = latencia WAN vía mock) */

--- a/app/src/data/DataProvider.tsx
+++ b/app/src/data/DataProvider.tsx
@@ -307,7 +307,7 @@ function emptyBundle(): NetPulseData {
 export const EMPTY_EXTRAS: RouterExtras = {
   mac: '—',
   firmware: '—',
-  firmwareUpdated: true,
+  firmwareUpdated: false,
   lastReboot: '—',
   soc: '—',
   flash: '—',


### PR DESCRIPTION
Partially fixes #566.

On a fresh install the router info card hardcoded the timezone to Europe/Madrid and the live empty extras defaulted `firmwareUpdated: true`, showing an incorrect timezone and an 'up to date' firmware pill before any data was gathered. Use the router timezone when available and otherwise show the empty placeholder, and hide the firmware status pill when there is no real data.

Note: the AdGuard/WireGuard cards only render when the server reports a configured client (nlbwmon-less), so they are not shown on a truly unconfigured install; the broader empty-state work (manufacturer/model, dummy graphs) is tracked separately.