### PR TITLE
feat(agents): present the native vs NetGrip install choice honestly

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -753,6 +753,9 @@
     "agents": {
       "subtitle": "{{total}} agent(s) · {{down}} not reporting",
       "empty": "No registered agents.",
+      "installChoice": "How to cover an OpenWrt router without an agent? NetGrip (recommended on routers that can host it) or the native agent. NetPulse does not install NetGrip: the choice happens at onboarding.",
+      "installChoiceNetgrip": "NetGrip: panel on the router (port 8090) with an embedded NetPulse agent and its own management (service toggles). Install it from the router itself; NetPulse then does not deploy the standalone agent over it.",
+      "installChoiceNative": "Native agent: lightweight telemetry managed from NetPulse (reinstall/upgrade), no web UI on the router.",
       "colDevice": "Device",
       "colStatus": "Status",
       "colLastSeen": "Last push",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -753,6 +753,9 @@
     "agents": {
       "subtitle": "{{total}} agente(s) · {{down}} sin reportar",
       "empty": "Sin agentes registrados.",
+      "installChoice": "¿Cómo cubrir un router OpenWrt sin agente? NetGrip (recomendado en routers que puedan alojarlo) o agente nativo. NetPulse no instala NetGrip: la elección se hace al alta.",
+      "installChoiceNetgrip": "NetGrip: panel en el router (puerto 8090) con agente NetPulse embebido y su propia gestión (toggles de servicios). Se instala desde el propio router; luego NetPulse no despliega el agente standalone encima.",
+      "installChoiceNative": "Agente nativo: telemetría ligera gestionada desde NetPulse (reinstalar/actualizar), sin web UI en el router.",
       "colDevice": "Equipo",
       "colStatus": "Estado",
       "colLastSeen": "Último push",

--- a/app/src/components/routers/AgentsSection.tsx
+++ b/app/src/components/routers/AgentsSection.tsx
@@ -494,6 +494,13 @@ export function AgentsSection() {
       <div className="mb-4">
         <h2 id="agents-section-title" className="font-display text-h2 text-text-primary">{t('routers.agents.title')}</h2>
         <p className="text-caption text-text-muted">{t('routers.agents.subtitle', { total, down })}</p>
+        {rows.length > 0 && (
+          <div className="mt-3 flex flex-col gap-1.5 rounded-xl border border-border/60 bg-canvas/50 px-3 py-2.5">
+            <p className="text-caption font-medium text-text-secondary">{t('routers.agents.installChoice')}</p>
+            <p className="text-caption text-text-muted">{t('routers.agents.installChoiceNetgrip')}</p>
+            <p className="text-caption text-text-muted">{t('routers.agents.installChoiceNative')}</p>
+          </div>
+        )}
       </div>
       <DiscoveredStrip />
       {rows.length === 0 ? (


### PR DESCRIPTION
Fixes #570.

When onboarding an OpenWrt router without an agent, the agents section now explains both install options with short honest descriptions and a NetGrip port (8090): NetGrip (panel on the router with an embedded agent and its own management, recommended on routers that can host it) and the native agent (lightweight telemetry managed from NetPulse). NetPulse does not install NetGrip; the choice happens at onboarding. Verified: npm ci + build (tsc + vite) OK, eslint 0 errors.