### PR TITLE
ci(package): build one aarch64_generic apk per package

### DIFF
--- a/.github/workflows/openwrt-package.yml
+++ b/.github/workflows/openwrt-package.yml
@@ -3,8 +3,8 @@ name: openwrt-package
 # Builds the OpenWrt packages for the released agent and attaches them to the
 # published release:
 #   - netpulse-agent as .ipk (24.10 SDK, mediatek/filogic) and .apk (25.12
-#     SDK: qualcommax/ipq807x -> aarch64_cortex-a53 y armsr/armv8 ->
-#     aarch64_generic, para routers aarch64 fuera de cortex-a53).
+#     SDK, armsr/armv8 -> aarch64_generic, instalable en aarch64 genérico y
+#     en cortex-a53, cubriendo routers fuera de cortex-a53).
 #   - luci-app-netpulse (arch all) as .ipk and .apk (#236).
 #   - netpulse on-box server as .ipk and .apk (#364).
 #
@@ -41,9 +41,6 @@ jobs:
           - sdk-version: 24.10.5
             sdk-target: mediatek/filogic
             format: ipk
-          - sdk-version: 25.12.5
-            sdk-target: qualcommax/ipq807x
-            format: apk
           - sdk-version: 25.12.5
             sdk-target: armsr/armv8
             format: apk
@@ -186,9 +183,6 @@ jobs:
           - sdk-version: 24.10.5
             sdk-target: mediatek/filogic
             format: ipk
-          - sdk-version: 25.12.5
-            sdk-target: qualcommax/ipq807x
-            format: apk
           - sdk-version: 25.12.5
             sdk-target: armsr/armv8
             format: apk


### PR DESCRIPTION
Follow-up to #573 (feedback on v2.28.6).

Building both qualcommax/ipq807x (aarch64_cortex-a53) and armsr/armv8 (aarch64_generic) produced the same .apk filename (no arch in the name), so on upload --clobber only one survived. Since aarch64_generic installs on both generic and cortex-a53 targets, build a single apk with armsr/armv8 and drop the qualcommax apk entry (the cortex-a53 ipk stays for opkg).