### PR TITLE
chore(release): v2.28.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.28.7] - 2026-09-06
+
+### Fixed
+
+- **Colisión de nombres de los `.apk` en la release (#573, fix #586)**: se construía el `.apk` con dos targets (`qualcommax/ipq807x` y `armsr/armv8`) que generaban el **mismo nombre de fichero** (sin el arch), así que en el upload (`--clobber`) solo sobrevivía uno. Ahora se publica un **único `.apk` `aarch64_generic`** (target `armsr/armv8`), instalable en aarch64 genérico y en cortex-a53; el `.ipk` cortex-a53 se mantiene para opkg. (Nota: fix al workflow de empaquetado OpenWrt, sin cambio de código runtime.)
+
 ## [2.28.6] - 2026-09-06
 
 ### Fixed

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.6",
+  "version": "2.28.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.28.6",
+      "version": "2.28.7",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.6",
+  "version": "2.28.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ SERVICE_NAME="$APP_NAME"
 
 # Versión de ESTE instalador (bumpear en cada release junto a httpapi.Version,
 # para poder saber qué install.sh se está ejecutando; ver CHANGELOG).
-INSTALLER_VERSION="2.28.6"
+INSTALLER_VERSION="2.28.7"
 
 NETPULSE_VERSION=""; UNATTENDED=0; DRY_RUN=0; UNINSTALL=0; PURGE=0; DEMO=0
 

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.6"
+var Version = "2.28.7"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Release v2.28.7.

Incluye el fix #586 (colisión de apk en openwrt-package) en el tag, para que la release sea consistente y re-ejecutable.