### PR TITLE
chore(release): v2.28.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.28.8] - 2026-09-06
+
+### Fixed
+
+- **Las tarjetas de "Dispositivos" marcaban a todos los routers como "Gateway principal" (#593)**: el footer de cada `FleetCard` pintaba la etiqueta del gateway siempre que la latencia al gateway no estuviera disponible, y en modo live esos extras nunca llegan (solo la demo los rellena), así que la etiqueta salía en todas las tarjetas, incluidos APs y switches. Ahora la indicación es una **pill verde "Puerta de enlace"** junto al nombre, visible solo en la tarjeta del router con `roleBadge Principal` (el gateway real), y se elimina la fila del footer con el texto y el enlace "Ver detalle" (toda la tarjeta ya es clicable).
+
+### Changed
+
+- **Copy en español sin anglicismos**: las cadenas visibles pasan de "gateway" a "puerta de enlace" (pill de tarjeta, "Estado de la puerta de enlace", enlaces y latencia en el detalle de AP, captions de AdGuard/reserva/aviso, copy de Orchestration y tooltip vía Internet). El texto en inglés no cambia.
+
 ## [2.28.7] - 2026-09-06
 
 ### Fixed

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.7",
+  "version": "2.28.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.28.7",
+      "version": "2.28.8",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.7",
+  "version": "2.28.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ SERVICE_NAME="$APP_NAME"
 
 # Versión de ESTE instalador (bumpear en cada release junto a httpapi.Version,
 # para poder saber qué install.sh se está ejecutando; ver CHANGELOG).
-INSTALLER_VERSION="2.28.7"
+INSTALLER_VERSION="2.28.8"
 
 NETPULSE_VERSION=""; UNATTENDED=0; DRY_RUN=0; UNINSTALL=0; PURGE=0; DEMO=0
 

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.7"
+var Version = "2.28.8"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Release v2.28.8: #593 (pill 'puerta de enlace' en la tarjeta del gateway y copy ES sin anglicismos). Bump de versiones en package.json/package-lock, install.sh y httpapi.Version + CHANGELOG.