### PR TITLE
refactor(fleet): derive gateway card styling from roleBadge and use the real model

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -728,7 +728,6 @@
     "gatewayLatency": "Gateway latency",
     "highTemp": "High temperature: {{temp}} °C · ventilation recommended",
     "mainGateway": "Main gateway",
-    "msToGateway": "{{ms}} ms to gateway",
     "sortBy": "Sort by {{column}}",
     "statusAria": "{{online}} routers online, {{warnings}} with warnings",
     "summary": "{{total}} routers · {{online}} online · {{warnings}} with warnings",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -728,7 +728,6 @@
     "gatewayLatency": "Latencia a la puerta de enlace",
     "highTemp": "Temperatura alta: {{temp}} °C · ventilación recomendada",
     "mainGateway": "Puerta de enlace",
-    "msToGateway": "{{ms}} ms a la puerta de enlace",
     "sortBy": "Ordenar por {{column}}",
     "statusAria": "{{online}} equipos online, {{warnings}} con aviso",
     "summary": "{{total}} equipos · {{online}} online · {{warnings}} con aviso",

--- a/app/src/components/routers/FleetCard.tsx
+++ b/app/src/components/routers/FleetCard.tsx
@@ -65,9 +65,8 @@ export function FleetCard({ router, index = 0, refreshKey = 0 }: FleetCardProps)
   const agentDown = isOpenWrt && agent !== undefined && !agent.fresh
   const agentMissing = isOpenWrt && agent === undefined && router.agentOnly
   const reduce = useReducedMotion()
-  const isGateway = router.id === 'flint2'
-  // El gateway real lo marca el server (roleBadge 'Principal'); su tarjeta
-  // lleva la pill verde "puerta de enlace" junto al nombre.
+  // El gateway real lo marca el server (roleBadge 'Principal'): su tarjeta
+  // lleva la pill verde "puerta de enlace", el tile en acento y su modelo.
   const isPrimary = router.roleBadge === 'Principal'
   const traffic = router.sparkline.map((v, i) => ({ i, v }))
 
@@ -120,7 +119,7 @@ export function FleetCard({ router, index = 0, refreshKey = 0 }: FleetCardProps)
               layoutId={`router-tile-${router.id}`}
               className={cn(
                 'flex h-11 w-11 shrink-0 items-center justify-center rounded-xl',
-                isGateway
+                isPrimary
                   ? 'bg-gradient-to-br from-accent to-tunnel text-canvas'
                   : 'bg-accent-soft text-accent',
               )}
@@ -134,9 +133,9 @@ export function FleetCard({ router, index = 0, refreshKey = 0 }: FleetCardProps)
                 <AgentBadge agent={agent} agentOnly={router.agentOnly} deviceType={router.type} />
               </div>
               <div className="truncate text-caption text-text-muted">
-                {isGateway ? 'GL.iNet Flint 2 · GL-MT6000' : `OpenWrt · ${router.modelShort}`}
+                {isPrimary ? router.model : `OpenWrt · ${router.modelShort}`}
               </div>
-              {isGateway && (
+              {isPrimary && (
                 <div className="mt-1.5 inline-flex items-center gap-1.5 rounded-full bg-elevated px-2 py-0.5">
                   <span className="h-1.5 w-1.5 rounded-full bg-ok" />
                   <span className="text-[10px] font-semibold uppercase tracking-wide text-text-secondary">AdGuard</span>

--- a/app/src/components/routers/RouterDetailHeader.tsx
+++ b/app/src/components/routers/RouterDetailHeader.tsx
@@ -67,7 +67,7 @@ export function RouterDetailHeader({ router }: { router: Router }) {
           <div className="min-w-0">
             <h1 className="font-display text-h1 text-text-primary">{router.name}</h1>
             <p className="text-caption text-text-muted">
-              {isGateway ? 'GL.iNet Flint 2 · GL-MT6000' : `OpenWrt · ${router.modelShort}`}
+              {isGateway ? router.model : `OpenWrt · ${router.modelShort}`}
             </p>
             <div className="mt-2 flex flex-wrap items-center gap-1.5">
               {pills.map((p, i) => (


### PR DESCRIPTION
Closes #597

FleetCard detected the gateway with the demo-only id 'flint2', so in live mode the gateway card never received the primary styling. It now uses roleBadge === 'Principal', matching RouterDetailHeader. The hardcoded 'GL.iNet Flint 2 · GL-MT6000' captions are replaced with the real router.model in both components, and the unused msToGateway i18n key (es/en) is removed.