### PR TITLE
chore(release): v2.28.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.28.9] - 2026-09-06
+
+### Changed
+
+- **La tarjeta del gateway en "Dispositivos" se identifica por rol, no por id de demo (#597)**: antes detectaba el gateway con el id demo `flint2`, así que en modo live la tarjeta nunca recibía el tratamiento de router principal. Ahora usa `roleBadge Principal`, igual que el detalle del router, y el subtítulo muestra el `model` real del dispositivo (se elimina el literal "GL.iNet Flint 2 · GL-MT6000" tanto de la tarjeta como de la cabecera de detalle). Se elimina también la clave de traducción `msToGateway` (quedó sin uso tras quitar el footer en #593).
+
 ## [2.28.8] - 2026-09-06
 
 ### Fixed

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.8",
+  "version": "2.28.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.28.8",
+      "version": "2.28.9",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.8",
+  "version": "2.28.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ SERVICE_NAME="$APP_NAME"
 
 # Versión de ESTE instalador (bumpear en cada release junto a httpapi.Version,
 # para poder saber qué install.sh se está ejecutando; ver CHANGELOG).
-INSTALLER_VERSION="2.28.8"
+INSTALLER_VERSION="2.28.9"
 
 NETPULSE_VERSION=""; UNATTENDED=0; DRY_RUN=0; UNINSTALL=0; PURGE=0; DEMO=0
 

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.8"
+var Version = "2.28.9"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Release v2.28.9: #597 (limpieza tarjeta del gateway). Bump package.json/package-lock, install.sh y httpapi.Version + CHANGELOG.