### PR TITLE
feat(router-detail): show real perf history and RAM total in live mode

### DIFF
--- a/app/src/components/routers/RouterPerformance.tsx
+++ b/app/src/components/routers/RouterPerformance.tsx
@@ -3,6 +3,8 @@ import { Area, AreaChart, CartesianGrid, ReferenceArea, ReferenceLine, Responsiv
 import { motion, useReducedMotion } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
 import type { Router } from '@/data/mock'
+import type { PerfSeriesLive } from '@/data/DataProvider'
+import { useNetPulse } from '@/data/DataProvider'
 import { CountUp } from '@/components/CountUp'
 import { SectionHeader } from '@/components/SectionHeader'
 import { SegmentedControl } from '@/components/SegmentedControl'
@@ -58,13 +60,26 @@ function PerfTooltip({
   )
 }
 
-/** ② Rendimiento (router-detail.md §②) — 3 áreas con crosshair sincronizado. */
-export function RouterPerformance({ router }: { router: Router }) {
+/** ② Rendimiento (router-detail.md §②) — 3 áreas con crosshair sincronizado.
+ * En live usa las series reales que sirve el backend (por router y rango);
+ * en demo conserva la serie sintética canónica. */
+export function RouterPerformance({ router, liveSeries, totalRamMb }: { router: Router; liveSeries?: PerfSeriesLive; totalRamMb?: number }) {
   const { t } = useTranslation()
+  const { isDemo } = useNetPulse()
   const [range, setRange] = useState<PerfRange>('24h')
   const reduce = useReducedMotion()
-  const data = useMemo(() => perfSeries(router, range), [router, range])
-  const captions = useMemo(() => perfCaptions(router, data), [router, data])
+  const data = useMemo(() => {
+    if (isDemo) return perfSeries(router, range)
+    const pts = liveSeries?.[range]
+    if (pts && pts.length > 0) return pts as PerfPoint[]
+    // Sin historia todavía (router recién dado de alta): un punto con el
+    // valor actual para que el gráfico y los captions no se rompan.
+    return [{ t: '', cpu: router.cpu ?? 0, ram: router.ram ?? 0, temp: router.temp ?? 0 }]
+  }, [isDemo, router, range, liveSeries])
+  const captions = useMemo(
+    () => perfCaptions(router, data, isDemo ? undefined : totalRamMb),
+    [router, data, isDemo, totalRamMb],
+  )
 
   // #441: null cuando la fuente no reporta vitals (el panel no se monta,
   // pero el tipo lo exige); se normaliza a 0 para el render defensivo.

--- a/app/src/components/routers/routerExtras.ts
+++ b/app/src/components/routers/routerExtras.ts
@@ -311,15 +311,26 @@ export function perfSeries(router: Router, range: '1h' | '24h' | '7d'): PerfPoin
   return points
 }
 
-export function perfCaptions(router: Router, data: PerfPoint[]): { cpu: string; ram: string; temp: string } {
-  const extras = getRouterExtras(router.id)
-  if (data.length === 0) throw new Error('perfCaptions: empty perf series')
+export function perfCaptions(router: Router, data: PerfPoint[], totalMb?: number): { cpu: string; ram: string; temp: string } {
+  // totalMb es la RAM total real (live, del backend). En demo (sin totalMb)
+  // se usa el resolver demo, igual que antes.
+  const total = totalMb && totalMb > 0 ? totalMb : getRouterExtras(router.id).ramMb
+  if (data.length === 0) {
+    const cpu = router.cpu ?? 0
+    const temp = router.temp ?? 0
+    const ramUsed = Math.round(((router.ram ?? 0) / 100) * total)
+    return {
+      cpu: i18n.t('routerDetail.perf.peakCpu', { pct: cpu, t: '—' }),
+      ram: i18n.t('routerDetail.perf.ramUsed', { used: ramUsed, total }),
+      temp: i18n.t('routerDetail.perf.maxTemp', { temp }),
+    }
+  }
   const cpuMax = data.reduce((m, p) => (p.cpu > m.cpu ? p : m), data[0]!)
   const tempMax = data.reduce((m, p) => (p.temp > m.temp ? p : m), data[0]!)
-  const ramUsed = Math.round(((router.ram ?? 0) / 100) * extras.ramMb)
+  const ramUsed = Math.round(((router.ram ?? 0) / 100) * total)
   return {
     cpu: i18n.t('routerDetail.perf.peakCpu', { pct: cpuMax.cpu, t: cpuMax.t }),
-    ram: i18n.t('routerDetail.perf.ramUsed', { used: ramUsed, total: extras.ramMb }),
+    ram: i18n.t('routerDetail.perf.ramUsed', { used: ramUsed, total }),
     temp: i18n.t('routerDetail.perf.maxTemp', { temp: tempMax.temp }),
   }
 }

--- a/app/src/data/DataProvider.tsx
+++ b/app/src/data/DataProvider.tsx
@@ -69,10 +69,28 @@ import type { RouterExtras } from '@/components/routers/routerExtras'
 
 export type ConnectionStatus = 'connected' | 'reconnecting' | 'demo'
 
+/** Punto de la serie real de rendimiento que sirve el backend (cpu/ram %,
+ * temp °C) agregado por bucket; `t` es la etiqueta ya formateada. */
+export interface LivePerfPoint {
+  t: string
+  cpu: number
+  ram: number
+  temp: number
+}
+
+/** Series 1h/24h/7d del detalle de router (live). En demo no llegan. */
+export interface PerfSeriesLive {
+  '1h'?: LivePerfPoint[]
+  '24h'?: LivePerfPoint[]
+  '7d'?: LivePerfPoint[]
+}
+
 export interface RouterDetailData {
   router: Router
   extras: RouterExtras
   clients: Device[]
+  /** Series reales de rendimiento del router (live; ausente en demo). */
+  series?: PerfSeriesLive
   /** Solo en el gateway */
   adguard?: AdGuardStats
   wireguard?: WireGuardStats
@@ -960,6 +978,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
         backhaul?: RouterExtras['backhaul'] | null
         clients?: Device[]
         extras?: RouterExtras
+        series?: PerfSeriesLive
         adguard?: AdGuardStats
         wireguard?: WireGuardStats
         vlans?: VlanPort[]
@@ -975,6 +994,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
         router: json.router,
         extras,
         clients: json.clients ?? [],
+        series: json.series,
         adguard: json.adguard,
         wireguard: json.wireguard,
         vlans: json.vlans,

--- a/app/src/pages/RouterDetail.tsx
+++ b/app/src/pages/RouterDetail.tsx
@@ -132,7 +132,7 @@ export default function RouterDetail() {
             </div>
           </section>
         ) : (
-          <RouterPerformance router={router} />
+          <RouterPerformance router={router} liveSeries={detail?.series} totalRamMb={detail?.extras?.ramMb} />
         )}
       </div>
 


### PR DESCRIPTION
Closes #590

The router detail performance panel ran the demo perf generator in live mode too: synthetic history that always 'peaks at 21:00' and a RAM total caption taken from the demo extras fallback (always 512 MB). The backend already serves the real per-router series (1h/24h/7d) and extras.ramMb from GET /api/routers/{id}; those were ignored by the front.

- DataProvider: RouterDetailData now carries the live `series` (1h/24h/7d).
- RouterPerformance: in live it renders the real series and uses the real `ramMb` for the 'X MB used of Y MB' caption; demo keeps the canonical synthetic series.
- perfCaptions accepts an optional real total and no longer throws on an empty history (single point with current values while a device has no history yet).

Verified in production preview on the gateway: '433 MB usados de 1030 MB' (real total), CPU peak from real hourly data.