### PR TITLE
chore(release): v2.28.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.28.10] - 2026-09-07
+
+### Fixed
+
+- **El total de RAM del detalle de router siempre salía como 512 MB (#590)**: el caption "X MB usados de Y MB" se calculaba con el resolver de extras de demo (cuyo fallback para cualquier router desconocido es la entrada demo con 512 MB) aunque se estuviera en live. Ahora usa el `ramMb` real que devuelve el backend (`/api/routers/{id}`).
+
+### Added
+
+- **Panel de rendimiento con historia real en live**: el detalle de router ya mostraba las series reales (1h/24h/7d de cpu/ram/temp agregadas por el server) pero el front las ignoraba y pintaba la serie sintética de demo (siempre "picaba" a las 21:00 y partía del valor actual con ruido). Ahora, en live, las tres curvas usan la historia real por rango; la demo conserva su serie canónica. Sin historia todavía (router recién dado de alta) se muestra un punto con el valor actual sin romper el panel.
+
 ## [2.28.9] - 2026-09-06
 
 ### Changed

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.9",
+  "version": "2.28.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.28.9",
+      "version": "2.28.10",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.9",
+  "version": "2.28.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ SERVICE_NAME="$APP_NAME"
 
 # Versión de ESTE instalador (bumpear en cada release junto a httpapi.Version,
 # para poder saber qué install.sh se está ejecutando; ver CHANGELOG).
-INSTALLER_VERSION="2.28.9"
+INSTALLER_VERSION="2.28.10"
 
 NETPULSE_VERSION=""; UNATTENDED=0; DRY_RUN=0; UNINSTALL=0; PURGE=0; DEMO=0
 

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.9"
+var Version = "2.28.10"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Release v2.28.10: #590 (historia real de rendimiento y total RAM en el detalle). Bump + CHANGELOG.