### PR TITLE
fix(agent): throttle passive wifi scans to avoid degrading AP clients

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,7 +39,7 @@ jobs:
       # (agentbin.EmbeddedAgentVersion): el campo updateAvailable de
       # GET /api/agents compara la versión reportada del agente contra esa
       # versión. Bumpear aquí y en agentbin.md el valor único de verdad.
-      AGENT_VERSION: "2.26.11"
+      AGENT_VERSION: "2.26.12"
     strategy:
       matrix:
         arch: [amd64, arm64]

--- a/agent/probe/local.go
+++ b/agent/probe/local.go
@@ -79,13 +79,53 @@ type Prober struct {
 	radiosMu    sync.Mutex
 	radiosCache []Radio
 	radiosAt    time.Time
+
+	// scanMu protege el throttle del scan pasivo de vecinos (#591): el scan
+	// activo (`iw dev scan`) saca la radio del canal y degrada a los clientes
+	// si se repite en cada sondeo (cada ~30 s). Se ejecuta como mucho cada
+	// scanMinInterval, o antes si el server pide un refresh explícito.
+	scanMu     sync.Mutex
+	lastScanAt time.Time
+	scanForced bool
 }
 
 const radiosTTL = 5 * time.Minute
 
+// scanMinInterval: mínimo entre scans pasivos de vecinos. Los datos de
+// "Análisis de canales" apenas cambian; 10 minutos mantienen el mapa fresco
+// sin martillear el aire con off-channel scans (#591).
+const scanMinInterval = 10 * time.Minute
+
 // NewProber crea el prober con el runner dado.
 func NewProber(run Runner, opts Options) *Prober {
 	return &Prober{run: run, opts: opts}
+}
+
+// ForceScan pide un scan en el próximo Build (lo usa el runtime cuando el
+// server envía "refresh" por SSE): no espera al intervalo del throttle.
+func (p *Prober) ForceScan() {
+	p.scanMu.Lock()
+	p.scanForced = true
+	p.scanMu.Unlock()
+}
+
+// scanDue decide si toca lanzar CmdScan en este sondeo completo: true si hay
+// un force pendiente (refresh del server) o si pasó scanMinInterval desde el
+// último intento. La primera Build tras arrancar también escanea (lastScanAt
+// cero). Al devolver true registra el intento para no repetirlo en el ciclo.
+func (p *Prober) scanDue() bool {
+	p.scanMu.Lock()
+	defer p.scanMu.Unlock()
+	if p.scanForced {
+		p.scanForced = false
+		p.lastScanAt = time.Now()
+		return true
+	}
+	if p.lastScanAt.IsZero() || time.Since(p.lastScanAt) >= scanMinInterval {
+		p.lastScanAt = time.Now()
+		return true
+	}
+	return false
 }
 
 // runBest es best-effort: error → "" (la sección queda ausente).
@@ -306,10 +346,12 @@ func (p *Prober) probeWireless(ctx context.Context, full bool) *WirelessData {
 				p.radiosMu.Unlock()
 			}
 		}
-		// Scan pasivo de vecinos (#452), solo en sondeo completo para no
-		// consumir tiempo/capacidad en el path de eventos.
-		if out := p.runBest(ctx, CmdScan, 10*time.Second); out != "" {
-			wd.Scans = ParseScan(out)
+		// Scan pasivo de vecinos (#452): SOLO en sondeo completo y con
+		// throttle (#591) para no sacar la radio del canal en cada push.
+		if p.scanDue() {
+			if out := p.runBest(ctx, CmdScan, 10*time.Second); out != "" {
+				wd.Scans = ParseScan(out)
+			}
 		}
 	} else {
 		p.radiosMu.Lock()

--- a/agent/probe/probe_test.go
+++ b/agent/probe/probe_test.go
@@ -827,11 +827,19 @@ func TestParseUsteer(t *testing.T) {
 	if len(s.APs) != 2 {
 		t.Fatalf("esperaba 2 APs locales, obtuve %d", len(s.APs))
 	}
-	if !s.APs[0].Local {
-		t.Error("el AP local debería tener Local=true")
+	if !s.APs[0].Local || !s.APs[1].Local {
+		t.Error("los APs locales deberían tener Local=true")
 	}
-	if s.APs[0].BSSID != "9C:9D:7E:1B:EA:B3" {
-		t.Errorf("BSSID local = %q (esperaba uppercased)", s.APs[0].BSSID)
+	// Los BSSID deben ir en mayúsculas. Sin asumir orden (ParseUsteer itera
+	// un mapa): comprobar el conjunto de los dos APs locales.
+	got := map[string]bool{}
+	for _, ap := range s.APs {
+		got[ap.BSSID] = true
+	}
+	for _, want := range []string{"9C:9D:7E:1B:EA:B2", "9C:9D:7E:1B:EA:B3"} {
+		if !got[want] {
+			t.Errorf("falta el AP local %s (BSSID en mayúsculas): %v", want, s.APs)
+		}
 	}
 
 	// 2. APs remotos: hostname = IP de la clave, Local=false.

--- a/agent/probe/scan_throttle_test.go
+++ b/agent/probe/scan_throttle_test.go
@@ -1,0 +1,81 @@
+package probe
+
+// scan_throttle_test.go — #591: el scan pasivo de vecinos (`iw dev scan`)
+// saca la radio del canal y degrada a los clientes si corre en cada push
+// (~30 s). No debe repetirse dentro de scanMinInterval salvo que el server
+// pida un refresh explícito (ForceScan).
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// countingRunner cuenta las invocaciones de CmdScan sobre un fakeRunner.
+type countingRunner struct {
+	fakeRunner
+	scanCalls int
+}
+
+func (r *countingRunner) Run(ctx context.Context, cmd string, timeout time.Duration) (string, error) {
+	if cmd == CmdScan {
+		r.scanCalls++
+	}
+	return r.fakeRunner.Run(ctx, cmd, timeout)
+}
+
+// newScanProber devuelve un Prober cuyo runner solo responde a CmdScan (el
+// resto de sondas falla y Build sigue sin scans/radios: suficiente para
+// probar el throttle).
+func newScanProber() (*Prober, *countingRunner) {
+	run := &countingRunner{fakeRunner: fakeRunner{outs: map[string]string{
+		CmdScan: "==IFACE==wlan0\nBSS 00:11:22:33:44:55\n\tfreq: 2412\n\tsignal: -45.00 dBm\n\tSSID: test\n",
+	}}}
+	return NewProber(run, Options{}), run
+}
+
+func TestScanThrottleNoRepiteDentroDelIntervalo(t *testing.T) {
+	p, run := newScanProber()
+	ctx := context.Background()
+
+	p.Build(ctx, "rt2", "test")
+	if run.scanCalls != 1 {
+		t.Fatalf("primera Build debería escanear (arranque), scanCalls=%d", run.scanCalls)
+	}
+	p.Build(ctx, "rt2", "test")
+	if run.scanCalls != 1 {
+		t.Fatalf("segunda Build dentro del intervalo NO debería escanear, scanCalls=%d", run.scanCalls)
+	}
+}
+
+func TestScanThrottleForceScanDelServer(t *testing.T) {
+	p, run := newScanProber()
+	ctx := context.Background()
+
+	p.Build(ctx, "rt2", "test") // arranque: 1 scan
+	p.ForceScan()
+	p.Build(ctx, "rt2", "test") // refresh del server: 2º scan sin esperar al intervalo
+	if run.scanCalls != 2 {
+		t.Fatalf("ForceScan debería escanear en el siguiente Build, scanCalls=%d", run.scanCalls)
+	}
+	p.Build(ctx, "rt2", "test") // y de nuevo dentro del intervalo: no escanea
+	if run.scanCalls != 2 {
+		t.Fatalf("Build tras ForceScan dentro del intervalo no debería escanear, scanCalls=%d", run.scanCalls)
+	}
+}
+
+func TestScanThrottleExpiraIntervalo(t *testing.T) {
+	p, run := newScanProber()
+	ctx := context.Background()
+
+	p.Build(ctx, "rt2", "test") // arranque: 1 scan
+	// Envejece el último scan más allá de scanMinInterval.
+	p.scanMu.Lock()
+	p.lastScanAt = time.Now().Add(-(scanMinInterval + time.Minute))
+	p.scanMu.Unlock()
+
+	p.Build(ctx, "rt2", "test")
+	if run.scanCalls != 2 {
+		t.Fatalf("pasado scanMinInterval debería volver a escanear, scanCalls=%d", run.scanCalls)
+	}
+}

--- a/agent/runtime/runtime.go
+++ b/agent/runtime/runtime.go
@@ -193,7 +193,10 @@ func Run(ctx context.Context, opts Options) error {
 			a.setRunning(false)
 			return nil
 		case <-refreshCh:
-			// refresh inmediato pedido por el servidor
+			// refresh inmediato pedido por el servidor. Además del sondeo,
+			// forzamos el scan pasivo (no esperar al throttle #591): el
+			// usuario está mirando datos frescos de canales.
+			prober.ForceScan()
 		case <-time.After(client.Delay(opts.Interval)):
 		}
 	}


### PR DESCRIPTION
Closes #591

The agent ran an active `iw dev scan` (takes the radio off channel) on every full probe, about every 30-37 s per device (measured in the wifi_scans table: median gap 37 s). On access points this repeatedly disrupts clients (IoT disconnects, signal loss), matching the report (also +1 from another user; the gateway without radios is unaffected). Scans now run at most every scanMinInterval (10 min), on the first build after startup, or immediately when the server requests a refresh over SSE. Bump the embedded agent version to 2.26.12 so fleet agents can update. Also fix a map-order flake in TestParseUsteer that would break CI.

Verified: unit tests (new throttle tests) and field test on rt2 (agent 2.26.12): wifi_scans cadence dropped from ~every 37 s to none for 4+ min after restart.