### PR TITLE
chore(release): v2.28.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.28.11] - 2026-09-07
+
+### Fixed
+
+- **El agente degradaba el WiFi de los APs (#591)**: lanzaba un `iw dev scan` (scan activo que saca la radio del canal) en cada sondeo completo, es decir cada ~30-37 s por dispositivo (medido en la tabla de scans). En puntos de acceso eso provoca desconexiones de dispositivos IoT y pérdida de señal. Ahora el scan se ejecuta como mucho cada 10 minutos, tras el arranque, o de inmediato cuando el servidor pide un refresh por SSE. La versión de agente embebida sube a 2.26.12 para que la flota se actualice. Se corrige además un test flaky de orden de mapa en `TestParseUsteer` que rompía el CI.
+- **El re-onboard SSH auto-aceptaba claves cambiadas (#603)**: ante una clave de host distinta en un host conocido, el pool renovaba `known_hosts` en silencio (accept-new con refresh), lo que anulaba la protección MITM. Ahora la conexión se rechaza y el router se marca como `unreachable/hostKeyChanged`; un admin debe confirmar el re-onboard explícitamente (nuevo endpoint `POST /api/routers/{id}/accept-host-key` y botón en el detalle del router), que borra la entrada y vuelve a hacer TOFU en el siguiente sondeo. El tipo de clave registrado es el que presente el dropbear del router (ssh-rsa en nuestra flota OpenWrt), no se fuerza RSA.
+
 ## [2.28.10] - 2026-09-07
 
 ### Fixed

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.10",
+  "version": "2.28.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.28.10",
+      "version": "2.28.11",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.10",
+  "version": "2.28.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ SERVICE_NAME="$APP_NAME"
 
 # Versión de ESTE instalador (bumpear en cada release junto a httpapi.Version,
 # para poder saber qué install.sh se está ejecutando; ver CHANGELOG).
-INSTALLER_VERSION="2.28.10"
+INSTALLER_VERSION="2.28.11"
 
 NETPULSE_VERSION=""; UNATTENDED=0; DRY_RUN=0; UNINSTALL=0; PURGE=0; DEMO=0
 

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.10"
+var Version = "2.28.11"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Release v2.28.11: #591 (throttle de scans WiFi del agente) + #603 (re-onboard SSH con confirmación explícita). Bump package.json/package-lock, install.sh y httpapi.Version + CHANGELOG. AGENT_VERSION ya en 2.26.12 (vino con #591).