### PR TITLE
feat(ssh): per-router custom SSH port

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1157,7 +1157,9 @@
       "snmpEnabled": "SNMP polling",
       "snmpCommunity": "Community (SNMPv2c)",
       "snmpPort": "Port",
-      "snmpPollInterval": "Interval (s)"
+      "snmpPollInterval": "Interval (s)",
+      "sshPort": "SSH port",
+      "sshPortHint": "SSH port of the router (default 22)"
     },
     "overrides": {
       "title": "Topology — manual tagging",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1157,7 +1157,9 @@
       "snmpEnabled": "Sondeo SNMP",
       "snmpCommunity": "Comunidad (SNMPv2c)",
       "snmpPort": "Puerto",
-      "snmpPollInterval": "Intervalo (s)"
+      "snmpPollInterval": "Intervalo (s)",
+      "sshPort": "Puerto SSH",
+      "sshPortHint": "Puerto SSH del router (22 por defecto)"
     },
     "overrides": {
       "title": "Topología — etiquetado manual",

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -280,6 +280,7 @@ interface ConfigRouter {
   snmp_community: string
   snmp_port: number
   snmp_poll_interval: number
+  ssh_port?: number
 }
 
 interface DiscoverCandidate {
@@ -302,6 +303,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
   const [type, setType] = useState<RouterType>('openwrt')
   const [gateway, setGateway] = useState(false)
   const [agentOnly, setAgentOnly] = useState(false)
+  const [addSshPort, setAddSshPort] = useState(22)
   const [submitting, setSubmitting] = useState(false)
   const [confirmDeleteFor, setConfirmDeleteFor] = useState<string | null>(null)
   const [editing, setEditing] = useState<ConfigRouter | null>(null)
@@ -315,6 +317,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
   const [editSnmpCommunity, setEditSnmpCommunity] = useState('')
   const [editSnmpPort, setEditSnmpPort] = useState(161)
   const [editSnmpPollInterval, setEditSnmpPollInterval] = useState(60)
+  const [editSshPort, setEditSshPort] = useState(22)
   const [editSubmitting, setEditSubmitting] = useState(false)
   const [pubkey, setPubkey] = useState<{ publicKey: string; fingerprint: string } | null>(null)
   const [copied, setCopied] = useState(false)
@@ -477,6 +480,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
           type,
           gateway,
           agent_only: agentOnly,
+          ssh_port: addSshPort,
         }),
       })
       if (res.status === 409) {
@@ -489,6 +493,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
       setType('openwrt')
       setGateway(false)
       setAgentOnly(false)
+      setAddSshPort(22)
       setShowAddForm(false)
       await load()
       refresh()
@@ -512,6 +517,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
     setEditSnmpCommunity(r.snmp_community ?? '')
     setEditSnmpPort(r.snmp_port ?? 161)
     setEditSnmpPollInterval(r.snmp_poll_interval ?? 60)
+    setEditSshPort(r.ssh_port ?? 22)
     setError(null)
   }
 
@@ -535,6 +541,7 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
           snmp_community: editSnmpCommunity.trim() || undefined,
           snmp_port: editSnmpPort,
           snmp_poll_interval: editSnmpPollInterval,
+          ssh_port: editSshPort,
         }),
       })
       if (res.status === 409) {
@@ -738,6 +745,17 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
             aria-label={t('settings.routers.name')}
             className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
           />
+          <input
+            type="number"
+            min={1}
+            max={65535}
+            value={addSshPort}
+            onChange={(e) => setAddSshPort(Number(e.target.value))}
+            placeholder={t('settings.routers.sshPort')}
+            aria-label={t('settings.routers.sshPort')}
+            title={t('settings.routers.sshPortHint')}
+            className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+          />
         </div>
         <div className="mt-2.5 flex flex-wrap items-center gap-3">
           <SegmentedControl
@@ -803,6 +821,22 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
                   onChange={(e) => setEditName(e.target.value)}
                   placeholder={t('settings.routers.name')}
                   aria-label={t('settings.routers.name')}
+                  className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+                />
+              </div>
+              <div>
+                <label htmlFor="ssh-port" className="mb-1 block text-caption font-medium uppercase tracking-[0.06em] text-text-muted">
+                  {t('settings.routers.sshPort')}
+                </label>
+                <input
+                  id="ssh-port"
+                  type="number"
+                  min={1}
+                  max={65535}
+                  value={editSshPort}
+                  onChange={(e) => setEditSshPort(Number(e.target.value))}
+                  aria-label={t('settings.routers.sshPort')}
+                  title={t('settings.routers.sshPortHint')}
                   className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
                 />
               </div>

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -880,7 +880,7 @@ func (l *Live) pollRouter(ctx context.Context, cfg RouterConfig) (*routerPolled,
 
 	// Calienta la conexión SSH en serie (equivalente al `ssh true` del JS:
 	// las llamadas de abajo multiplexan sobre la conexión ya establecida).
-	if _, err := l.pool.Run(cfg.Host, "true", 0); err != nil {
+	if _, err := l.pool.Run(cfg.SSHAddr(), "true", 0); err != nil {
 		return nil, err
 	}
 	// Layout de puertos (board.json): se lee una vez y se cachea
@@ -1734,7 +1734,7 @@ func (l *Live) pollWireGuard(devices []Device) *WireGuardStats {
 			peerNames[d.IP] = WGPeerName{ID: d.ID, Name: d.Name, Type: d.Type}
 		}
 	}
-	stats, err := GetWireGuardStats(l.pool, gw.Host, l.cfg.WGInterface, "", peerNames)
+	stats, err := GetWireGuardStats(l.pool, gw.SSHAddr(), l.cfg.WGInterface, "", peerNames)
 	if err != nil {
 		log.Printf("[netpulse] WireGuard no disponible: %v", err)
 		return &WireGuardStats{Interface: l.cfg.WGInterface, Subnet: "", Status: "inactive", Peers: []WGPeer{}}
@@ -2480,7 +2480,7 @@ func (l *Live) usteerAvailableCached() bool {
 	}
 	l.mu.Lock()
 	l.usteerChecking = true
-	host := gw.Host
+	host := gw.SSHAddr()
 	l.mu.Unlock()
 	go func() {
 		out, err := l.pool.Run(host, "ubus call usteer local_info", 4*time.Second)
@@ -3007,7 +3007,7 @@ func (l *Live) GetUsteer(context.Context) (*Usteer, error) {
 			mesh = append(mesh, UsteerMesh{RouterID: cfg.ID, Name: name, Usteer: false, ApsSeen: 0})
 			continue
 		}
-		localOut, err := l.pool.Run(cfg.Host, "ubus call usteer local_info", 0)
+		localOut, err := l.pool.Run(cfg.SSHAddr(), "ubus call usteer local_info", 0)
 		if err != nil {
 			mesh = append(mesh, UsteerMesh{RouterID: cfg.ID, Name: name, Usteer: false, ApsSeen: 0})
 			continue
@@ -3017,7 +3017,7 @@ func (l *Live) GetUsteer(context.Context) (*Usteer, error) {
 			mesh = append(mesh, UsteerMesh{RouterID: cfg.ID, Name: name, Usteer: false, ApsSeen: 0})
 			continue
 		}
-		clientsOut, _ := l.pool.Run(cfg.Host, "ubus call usteer connected_clients", 0)
+		clientsOut, _ := l.pool.Run(cfg.SSHAddr(), "ubus call usteer connected_clients", 0)
 		clientsByIface := map[string]map[string]usteerClientRaw{}
 		_ = json.Unmarshal([]byte(clientsOut), &clientsByIface)
 
@@ -3340,7 +3340,7 @@ func (l *Live) GetDot11r(ctx context.Context) (*Dot11rOverview, error) {
 			out.Routers = append(out.Routers, r)
 			continue
 		}
-		uciOut, err := l.pool.Run(cfg.Host, "uci show wireless", 0)
+		uciOut, err := l.pool.Run(cfg.SSHAddr(), "uci show wireless", 0)
 		if err != nil {
 			out.Routers = append(out.Routers, r)
 			continue
@@ -3639,7 +3639,7 @@ func (l *Live) GetSurvey(ctx context.Context) (*SurveyOverview, error) {
 			continue
 		}
 		// Lista de interfaces wifi (wlanX).
-		devsOut, err := l.pool.Run(cfg.Host, "iw dev 2>/dev/null | awk '/Interface/ {print $2}'", 0)
+		devsOut, err := l.pool.Run(cfg.SSHAddr(), "iw dev 2>/dev/null | awk '/Interface/ {print $2}'", 0)
 		if err != nil {
 			out.Routers = append(out.Routers, r)
 			continue
@@ -3662,7 +3662,7 @@ func (l *Live) GetSurvey(ctx context.Context) (*SurveyOverview, error) {
 		r.Available = true
 		any = true
 		for _, dev := range devs {
-			surveyOut, err := l.pool.Run(cfg.Host, "iw dev "+dev+" survey dump 2>/dev/null", 0)
+			surveyOut, err := l.pool.Run(cfg.SSHAddr(), "iw dev "+dev+" survey dump 2>/dev/null", 0)
 			if err != nil {
 				continue
 			}

--- a/server-go/internal/adapters/openwrt.go
+++ b/server-go/internal/adapters/openwrt.go
@@ -102,7 +102,8 @@ func NewOpenWrtClient(cfg RouterConfig, pool poolRunner, user, password string) 
 	if user == "" {
 		user = "root"
 	}
-	return &OpenWrtClient{Host: cfg.Host, User: user, Password: password, pool: pool}
+	// Host aquí es el destino `host:port` (#605) para el pool SSH.
+	return &OpenWrtClient{Host: cfg.SSHAddr(), User: user, Password: password, pool: pool}
 }
 
 // ---------------------------------------------------------------------------

--- a/server-go/internal/adapters/sshpool.go
+++ b/server-go/internal/adapters/sshpool.go
@@ -32,6 +32,16 @@ const (
 	sshBackoffMax     = 5 * time.Minute
 )
 
+// addrOf devuelve el destino `host:port` para conectar. Los callers pasan el
+// host ya con puerto (RouterConfig.SSHAddr, issue #605); si vienen sin puerto
+// (back-compat) se asume 22.
+func addrOf(host string) string {
+	if _, _, err := net.SplitHostPort(host); err == nil {
+		return host
+	}
+	return net.JoinHostPort(host, "22")
+}
+
 // SSHPool gestiona conexiones persistentes a los routers.
 type SSHPool struct {
 	keyPath string
@@ -210,7 +220,7 @@ func (p *SSHPool) dial(host string) (*ssh.Client, error) {
 		HostKeyCallback: cb,
 		Timeout:         sshDialTimeout,
 	}
-	client, err := p.dialTCP("tcp", net.JoinHostPort(host, "22"), cfg)
+	client, err := p.dialTCP("tcp", addrOf(host), cfg)
 
 	p.mu.Lock()
 	close(entry.dialing)

--- a/server-go/internal/adapters/sshpool_test.go
+++ b/server-go/internal/adapters/sshpool_test.go
@@ -203,3 +203,24 @@ func TestHostKeyCallbackRejectsChangedKey(t *testing.T) {
 		t.Fatal("el known_hosts no debería tocarse al rechazar la clave cambiada")
 	}
 }
+
+func TestAddrOf(t *testing.T) {
+	if got := addrOf("192.168.1.2"); got != "192.168.1.2:22" {
+		t.Fatalf("addrOf(sin puerto) = %q, esperaba 192.168.1.2:22", got)
+	}
+	if got := addrOf("192.168.1.2:2222"); got != "192.168.1.2:2222" {
+		t.Fatalf("addrOf(con puerto) = %q, esperaba 192.168.1.2:2222", got)
+	}
+}
+
+func TestRouterConfigSSHAddr(t *testing.T) {
+	if got := (RouterConfig{Host: "192.168.1.2"}).SSHAddr(); got != "192.168.1.2:22" {
+		t.Fatalf("SSHAddr sin puerto = %q", got)
+	}
+	if got := (RouterConfig{Host: "192.168.1.2", SSHPort: 2222}).SSHAddr(); got != "192.168.1.2:2222" {
+		t.Fatalf("SSHAddr con puerto = %q", got)
+	}
+	if got := (RouterConfig{Host: "10.0.0.5", SSHPort: -1}).SSHAddr(); got != "10.0.0.5:22" {
+		t.Fatalf("SSHAddr con puerto inválido = %q", got)
+	}
+}

--- a/server-go/internal/adapters/types.go
+++ b/server-go/internal/adapters/types.go
@@ -13,6 +13,8 @@ package adapters
 
 import (
 	"context"
+	"net"
+	"strconv"
 
 	"github.com/gnacho/netpulse/server-go/internal/alerts"
 )
@@ -804,6 +806,20 @@ type RouterConfig struct {
 	SnmpCommunity    string `json:"snmp_community,omitempty"`
 	SnmpPort         int    `json:"snmp_port,omitempty"`
 	SnmpPollInterval int    `json:"snmp_poll_interval,omitempty"` // segundos; 0 → default 60
+	// SSHPort (issue #605): puerto SSH del router (dropbear en puerto no
+	// estándar). 0/ausente → 22. Se usa en el pool, discovery e install.
+	SSHPort int `json:"ssh_port,omitempty"`
+}
+
+// SSHAddr devuelve el destino `host:port` para conectar por SSH, usando
+// SSHPort (default 22). Es lo que recibe el pool (`pool.Run`) y los probes
+// que arman `ssh` con `-p`.
+func (c RouterConfig) SSHAddr() string {
+	port := c.SSHPort
+	if port <= 0 {
+		port = 22
+	}
+	return net.JoinHostPort(c.Host, strconv.Itoa(port))
 }
 
 // ---------------------------------------------------------------------------

--- a/server-go/internal/db/db.go
+++ b/server-go/internal/db/db.go
@@ -464,6 +464,8 @@ func Open(dataDir string, opts ...OpenOption) (*DB, error) {
 	migrate(sqldb, "routers", "snmp_port", "ALTER TABLE routers ADD COLUMN snmp_port INTEGER NOT NULL DEFAULT 0")
 	// issue #414: intervalo de polling SNMP configurable (segundos; default 60).
 	migrate(sqldb, "routers", "snmp_poll_interval", "ALTER TABLE routers ADD COLUMN snmp_poll_interval INTEGER NOT NULL DEFAULT 60")
+	// issue #605: puerto SSH por router (dropbear en puerto no estándar).
+	migrate(sqldb, "routers", "ssh_port", "ALTER TABLE routers ADD COLUMN ssh_port INTEGER NOT NULL DEFAULT 22")
 	// issue #494: upgrades desatendidos programados (epoch ms UTC; NULL = manual).
 	migrate(sqldb, "firmware_upgrades", "scheduled_for", "ALTER TABLE firmware_upgrades ADD COLUMN scheduled_for INTEGER")
 

--- a/server-go/internal/httpapi/agent.go
+++ b/server-go/internal/httpapi/agent.go
@@ -31,9 +31,9 @@ import (
 
 	"github.com/gnacho/netpulse/agent/probe"
 	"github.com/gnacho/netpulse/server-go/internal/agentbin"
-	"github.com/gnacho/netpulse/server-go/internal/reinstall"
 	"github.com/gnacho/netpulse/server-go/internal/auth"
 	"github.com/gnacho/netpulse/server-go/internal/rearmer"
+	"github.com/gnacho/netpulse/server-go/internal/reinstall"
 	"github.com/gnacho/netpulse/server-go/internal/routerstore"
 	"github.com/gnacho/netpulse/server-go/internal/vercmp"
 )
@@ -376,7 +376,7 @@ type agentListItem struct {
 	// con esta tercera clave la UI puede emparejar fila↔router sin duplicar
 	// (#483).
 	Hostname string `json:"hostname,omitempty"`
-	LastSeen *int64 `json:"lastSeen"`           // unix SEGUNDOS; null si nunca empujó
+	LastSeen *int64 `json:"lastSeen"` // unix SEGUNDOS; null si nunca empujó
 	Version  string `json:"version,omitempty"`
 	Fresh    bool   `json:"fresh"`
 	// UpdateAvailable: true si el agente reportó una versión distinta de la
@@ -682,7 +682,7 @@ func (s *server) handleAgentReinstall(w http.ResponseWriter, r *http.Request) {
 	host := ""
 	for _, rc := range routerstore.ListRouters(s.db.DB) {
 		if rc.ID == slug {
-			host = rc.Host
+			host = rc.SSHAddr()
 			break
 		}
 	}

--- a/server-go/internal/httpapi/config.go
+++ b/server-go/internal/httpapi/config.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	hostRe    = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+	hostRe     = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 	hostPortRe = regexp.MustCompile(`^([a-zA-Z0-9._-]+)(:[0-9]{1,5})?$`)
 )
 
@@ -97,10 +97,13 @@ type routerInput struct {
 	// FirmwareTarget: versión objetivo del firmware (issue #241; opcional).
 	FirmwareTarget *string `json:"firmware_target"`
 	// SNMP (issue #309): credenciales para sondeo SNMP del switch gestionado.
-	SnmpEnabled       *bool   `json:"snmp_enabled"`
-	SnmpCommunity     *string `json:"snmp_community"`
-	SnmpPort          *int    `json:"snmp_port"`
-	SnmpPollInterval  *int    `json:"snmp_poll_interval"` // issue #414; segundos
+	SnmpEnabled      *bool   `json:"snmp_enabled"`
+	SnmpCommunity    *string `json:"snmp_community"`
+	SnmpPort         *int    `json:"snmp_port"`
+	SnmpPollInterval *int    `json:"snmp_poll_interval"` // issue #414; segundos
+	// SSHPort (issue #605): puerto SSH del router (dropbear en puerto no
+	// estándar). Ausente/0 → 22.
+	SSHPort *int `json:"ssh_port"`
 }
 
 // validateHost replica hostSchema (trim, 1..253, regex). Devuelve el valor
@@ -216,10 +219,20 @@ func (s *server) handleAddConfigRouter(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	sshPort := 0
+	if in.SSHPort != nil {
+		p := *in.SSHPort
+		if p < 1 || p > 65535 {
+			writeError(w, http.StatusBadRequest, "invalid_input", "ssh_port must be between 1 and 65535")
+			return
+		}
+		sshPort = p
+	}
 	created, err := routerstore.AddRouter(s.db.DB, routerstore.AddInput{
 		Name: name, Host: host, Type: typ, IsGateway: in.Gateway, AgentOnly: in.AgentOnly,
 		FirmwareTarget: firmwareTarget,
-		SnmpEnabled: snmpEnabled, SnmpCommunity: snmpCommunity, SnmpPort: snmpPort, SnmpPollInterval: snmpInterval,
+		SnmpEnabled:    snmpEnabled, SnmpCommunity: snmpCommunity, SnmpPort: snmpPort, SnmpPollInterval: snmpInterval,
+		SSHPort: sshPort,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error")
@@ -316,11 +329,21 @@ func (s *server) handleUpdateConfigRouter(w http.ResponseWriter, r *http.Request
 		v := strings.TrimSpace(*in.SnmpCommunity)
 		snmpCommunity = &v
 	}
+	var sshPort *int
+	if in.SSHPort != nil {
+		p := *in.SSHPort
+		if p < 1 || p > 65535 {
+			writeError(w, http.StatusBadRequest, "invalid_input", "ssh_port must be between 1 and 65535")
+			return
+		}
+		sshPort = &p
+	}
 	updated, ok := routerstore.UpdateRouter(s.db.DB, id, routerstore.UpdateInput{
 		Name: name, Host: host, Type: typ,
 		IsGateway: &gw, AgentOnly: &ao,
 		FirmwareTarget: firmwareTarget,
-		SnmpEnabled: in.SnmpEnabled, SnmpCommunity: snmpCommunity, SnmpPort: snmpPort, SnmpPollInterval: snmpPollInterval,
+		SnmpEnabled:    in.SnmpEnabled, SnmpCommunity: snmpCommunity, SnmpPort: snmpPort, SnmpPollInterval: snmpPollInterval,
+		SSHPort: sshPort,
 	})
 	if !ok {
 		writeError(w, http.StatusNotFound, "not_found")

--- a/server-go/internal/httpapi/device_actions.go
+++ b/server-go/internal/httpapi/device_actions.go
@@ -41,7 +41,7 @@ func uciValue(raw string) string {
 func (s *server) gatewayHost() string {
 	for _, r := range routerstore.ListRouters(s.db.DB) {
 		if r.IsGateway && !r.AgentOnly && r.Host != "" {
-			return r.Host
+			return r.SSHAddr()
 		}
 	}
 	return ""

--- a/server-go/internal/httpapi/orchestr.go
+++ b/server-go/internal/httpapi/orchestr.go
@@ -506,7 +506,7 @@ func (s *server) gatewayInfo(routerID string) (bool, string) {
 func (s *server) hostOfRouter(routerID string) string {
 	for _, r := range routerstore.ListRouters(s.db.DB) {
 		if r.ID == routerID && !r.AgentOnly && r.Host != "" {
-			return r.Host
+			return r.SSHAddr()
 		}
 	}
 	return ""

--- a/server-go/internal/rearmer/rearmer.go
+++ b/server-go/internal/rearmer/rearmer.go
@@ -188,7 +188,7 @@ func (r *Rearmer) Rearm(slug string) (Result, error) {
 			if !nativeAgentType(rc.Type) {
 				return Result{}, ErrExternalAgent
 			}
-			host = rc.Host
+			host = rc.SSHAddr()
 			break
 		}
 	}
@@ -269,7 +269,7 @@ func (r *Rearmer) Reinstall(slug, publicURL string) (Result, error) {
 			if !nativeAgentType(rc.Type) {
 				return Result{}, ErrExternalAgent
 			}
-			host = rc.Host
+			host = rc.SSHAddr()
 			break
 		}
 	}

--- a/server-go/internal/routerstore/routerstore.go
+++ b/server-go/internal/routerstore/routerstore.go
@@ -27,7 +27,7 @@ const probeTimeout = 4 * time.Second
 // ListRouters devuelve la tabla routers ordenada is_gateway DESC,
 // created_at ASC, con is_gateway como booleano.
 func ListRouters(db *sql.DB) []adapters.RouterConfig {
-	rows, err := db.Query("SELECT id, name, host, type, is_gateway, agent_only, firmware_target, created_at, snmp_enabled, snmp_community, snmp_port, snmp_poll_interval FROM routers ORDER BY is_gateway DESC, created_at ASC")
+	rows, err := db.Query("SELECT id, name, host, type, is_gateway, agent_only, firmware_target, created_at, snmp_enabled, snmp_community, snmp_port, snmp_poll_interval, ssh_port FROM routers ORDER BY is_gateway DESC, created_at ASC")
 	if err != nil {
 		return []adapters.RouterConfig{}
 	}
@@ -35,9 +35,9 @@ func ListRouters(db *sql.DB) []adapters.RouterConfig {
 	out := []adapters.RouterConfig{}
 	for rows.Next() {
 		var r adapters.RouterConfig
-		var gw, ao, snmpEn, snmpPort, snmpInterval int
+		var gw, ao, snmpEn, snmpPort, snmpInterval, sshPort int
 		var name, ft, snmpComm sql.NullString
-		if err := rows.Scan(&r.ID, &name, &r.Host, &r.Type, &gw, &ao, &ft, &r.CreatedAt, &snmpEn, &snmpComm, &snmpPort, &snmpInterval); err != nil {
+		if err := rows.Scan(&r.ID, &name, &r.Host, &r.Type, &gw, &ao, &ft, &r.CreatedAt, &snmpEn, &snmpComm, &snmpPort, &snmpInterval, &sshPort); err != nil {
 			continue
 		}
 		r.Name = name.String
@@ -48,6 +48,7 @@ func ListRouters(db *sql.DB) []adapters.RouterConfig {
 		r.SnmpCommunity = snmpComm.String
 		r.SnmpPort = snmpPort
 		r.SnmpPollInterval = snmpInterval
+		r.SSHPort = sshPort
 		out = append(out, r)
 	}
 	return out
@@ -127,10 +128,13 @@ type AddInput struct {
 	// FirmwareTarget: versión objetivo (issue #241). "" = sin comprobar.
 	FirmwareTarget string
 	// SNMP (issue #309): credenciales para sondeo SNMP.
-	SnmpEnabled       bool
-	SnmpCommunity     string
-	SnmpPort          int
-	SnmpPollInterval  int // issue #414; 0 = default 60
+	SnmpEnabled      bool
+	SnmpCommunity    string
+	SnmpPort         int
+	SnmpPollInterval int // issue #414; 0 = default 60
+	// SSHPort (issue #605): puerto SSH del router (dropbear en puerto no
+	// estándar). 0/ausente → 22.
+	SSHPort int
 }
 
 // AddRouter inserta un router (si IsGateway, el resto pierde el flag —
@@ -175,9 +179,13 @@ func AddRouter(db *sql.DB, in AddInput) (adapters.RouterConfig, error) {
 	if snmpPort <= 0 {
 		snmpPort = 161
 	}
+	sshPort := in.SSHPort
+	if sshPort <= 0 {
+		sshPort = 22
+	}
 	if _, err := tx.Exec(
-		"INSERT INTO routers (id, name, host, type, is_gateway, agent_only, firmware_target, created_at, snmp_enabled, snmp_community, snmp_port, snmp_poll_interval) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-		id, name, in.Host, in.Type, gw, ao, in.FirmwareTarget, now, snmpEn, in.SnmpCommunity, snmpPort, snmpInterval,
+		"INSERT INTO routers (id, name, host, type, is_gateway, agent_only, firmware_target, created_at, snmp_enabled, snmp_community, snmp_port, snmp_poll_interval, ssh_port) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		id, name, in.Host, in.Type, gw, ao, in.FirmwareTarget, now, snmpEn, in.SnmpCommunity, snmpPort, snmpInterval, sshPort,
 	); err != nil {
 		return adapters.RouterConfig{}, err
 	}
@@ -213,10 +221,12 @@ type UpdateInput struct {
 	// FirmwareTarget: versión objetivo (issue #241). nil = no tocar; "" = limpiar.
 	FirmwareTarget *string
 	// SNMP (issue #309): nil = no tocar; puntero a bool/string/int = aplicar.
-	SnmpEnabled       *bool
-	SnmpCommunity     *string
-	SnmpPort          *int
-	SnmpPollInterval  *int // issue #414
+	SnmpEnabled      *bool
+	SnmpCommunity    *string
+	SnmpPort         *int
+	SnmpPollInterval *int // issue #414
+	// SSHPort (issue #605): puerto SSH; nil = no tocar.
+	SSHPort *int
 }
 
 // UpdateRouter actualiza un router existente por id. Si IsGateway pasa a true,
@@ -296,6 +306,14 @@ func UpdateRouter(db *sql.DB, id string, in UpdateInput) (adapters.RouterConfig,
 			v = 60
 		}
 		sets = append(sets, "snmp_poll_interval = ?")
+		args = append(args, v)
+	}
+	if in.SSHPort != nil {
+		v := *in.SSHPort
+		if v <= 0 {
+			v = 22
+		}
+		sets = append(sets, "ssh_port = ?")
 		args = append(args, v)
 	}
 	if len(sets) > 0 {


### PR DESCRIPTION
Closes #605

Several routers expose dropbear on a port other than 22; the server always connected to :22. Adds a per-router ssh_port (routers table + migration, RouterConfig.SSHPort/SSHAddr, routerstore, config API) and routes every SSH path through host:port:

- pool dial no longer forces :22 (addrOf keeps host:port; default 22 when absent)
- OpenWrtClient.Host uses cfg.SSHAddr()
- live.go, device actions / orchestration / rearm, agent install and gateway discovery use SSHAddr()
- Settings router add/edit form gains a 'Puerto SSH' field (ES/EN)

Back-compat: without a configured port the server keeps using 22.

Verified: fleet (all :22) stays online with SSHAddr; API create/read/delete of ssh_port (created a test router with 2222 and removed it); server + front compile and tests pass.