### PR TITLE
fix(wg): don't crash rendering a WireGuard peer with an unmapped type

### DIFF
--- a/app/src/components/routers/WireGuardPanel.tsx
+++ b/app/src/components/routers/WireGuardPanel.tsx
@@ -15,6 +15,7 @@ const PEER_ICONS: Record<PeerType, LucideIcon> = {
   portatil: Laptop,
   tablet: Tablet,
   sitio: Network,
+  desconocido: Network,
 }
 
 function PeerRow({ peer, index }: { peer: WGPeer; index: number }) {

--- a/app/src/data/types.ts
+++ b/app/src/data/types.ts
@@ -131,7 +131,7 @@ export interface AdGuardStats {
   rules: number
 }
 
-export type PeerType = 'movil' | 'portatil' | 'tablet' | 'sitio'
+export type PeerType = 'movil' | 'portatil' | 'tablet' | 'sitio' | 'desconocido'
 
 /**
  * Rol de infraestructura sellado server-side (SPEC-65 D65-2):

--- a/app/src/sections/GatewayServices.tsx
+++ b/app/src/sections/GatewayServices.tsx
@@ -53,11 +53,15 @@ const PEER_ICONS: Record<PeerType, LucideIcon> = {
   portatil: Laptop,
   tablet: Tablet,
   sitio: Waypoints,
+  desconocido: Waypoints,
 }
 
 function PeerRow({ peer, index }: { peer: WGPeer; index: number }) {
   const { t } = useTranslation()
-  const Icon = PEER_ICONS[peer.type]
+  // #592: el servidor puede enviar un tipo no mapeado ("desconocido"/otro);
+  // sin fallback el <Icon/> sería undefined y React crasheaba ("Element type
+  // is invalid") con un cliente WireGuard activo, dejando la UI en negro.
+  const Icon = PEER_ICONS[peer.type] ?? Waypoints
   return (
     <motion.div
       initial={{ opacity: 0, y: 12 }}


### PR DESCRIPTION
Closes #592

Root cause: the server emits the WireGuard peer type as a free string and uses 'desconocido' when no type is mapped (adapters/wireguard.go). The Home's GatewayServices built the peer icon as PEER_ICONS[peer.type] with no fallback, so a peer of type 'desconocido' (or any unmapped value) produced an undefined icon and React crashed with 'Element type is invalid', blacking out the UI the moment a WireGuard client connected (or when opening the UI from a connected client). The RouterDetail WireGuardPanel already had a fallback; the Home card did not.

Fix: add 'desconocido' to PeerType and to both PEER_ICONS maps, and keep a fallback icon in the PeerRow just in case.

Verified: in our fleet all 7 peers are type 'desconocido'; simulating one as active (server payload) the Home now renders the peer without a black screen (before the fix this path crashed).