### PR TITLE
chore: release v2.28.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.28.12] - 2026-09-07
+
+### Added
+
+- **Puerto SSH configurable por router (#605)**: varios routers exponen su dropbear en un puerto distinto de 22. Ahora cada router admite un `ssh_port` (formulario de alta/edición en Ajustes) y todo el camino SSH del servidor (pool, sondeo, acciones, orquestación, rearm, instalación del agente y descubrimiento del gateway) usa `host:puerto`. Sin puerto configurado se sigue usando 22.
+- **Matriz de itinerancia agrupada por dispositivo (#600)**: en WiFi Roaming → Matriz, las columnas se agrupan por punto de acceso (nombre) con una fila de cabecera que etiqueta cada banda (2.4G/5G), en lugar de una columna suelta por AP-banda.
+
+### Changed
+
+- **802.11r: nombres y exclusión (#601)**: el título de la sección pasa de "Por router" a "Por AP", la columna "Router" a "Dispositivo", y los equipos sin radios (p. ej. el gateway) ya no aparecen en el detalle por router. Además, al añadir un router por descubrimiento ya no se usa el modelo de hardware como nombre (se usa el hostname), así la UI muestra nombres de dispositivo en lugar de modelos en toda la app.
+- **Análisis de canales: ancho del canal propio (#602)**: la fila de la red propia en la tabla muestra el ancho de canal (`· N MHz`) junto al número de canal, cruzando con el channel-plan del router.
+
+### Fixed
+
+- **La UI se quedaba en negro al conectarse un cliente WireGuard (#592)**: el servidor envía el tipo de peer como texto libre y usa `desconocido` cuando no hay tipo mapeado; la tarjeta de WireGuard de la Home construía el icono con `PEER_ICONS[peer.type]` sin fallback, así que un peer `desconocido` (o no mapeado) producía un icono `undefined` y React crasheaba ("Element type is invalid") en cuanto un cliente WireGuard se conectaba (o al abrir la UI desde él). Se añade `desconocido` a los mapas de iconos y un fallback.
+
 ## [2.28.11] - 2026-09-07
 
 ### Fixed

--- a/README.es.md
+++ b/README.es.md
@@ -86,6 +86,29 @@ visor global: analiza tu red, detecta anomalías y te avisa.
 - **Sidecar collector opcional**: sondeo de latencia TCP por router con
   sus propias series temporales de largo plazo.
 
+## Novedades
+
+Cada versión se empuja a la flota a través del actualizador automático
+incorporado. Las versiones nuevas muestran en la app un panel breve y en
+lenguaje humano de "qué ha cambiado" para que sepas qué esperar antes de
+actualizar. Aquí tienes un resumen en clave de las últimas mejoras, cada una
+enlazada al issue de GitHub que la originó.
+
+> Están escritas para personas, no como changelog: qué hace la función por ti,
+> no los nombres de las funciones internas.
+
+### Última (v2.28.12)
+
+- **Puerto SSH personalizado por router** ([#605](https://github.com/gnacho/netpulse/issues/605)). No todos los routers dejan el daemon SSH en el puerto 22: algunos lo tienen en otro. Ahora cada router admite su propio puerto SSH al darlo de alta o editarlo, y todos los caminos del servidor (sondeo, acciones, instalación del agente, descubrimiento del gateway) lo usan automáticamente. Déjalo vacío y NetPulse sigue usando el 22.
+- **Matriz de itinerancia agrupada por dispositivo** ([#600](https://github.com/gnacho/netpulse/issues/600)). En WiFi Roaming → Matriz, las columnas se agrupan ahora bajo el nombre del punto de acceso, con una fila de cabecera que etiqueta cada banda (2.4G/5G). Ya no hay una columna suelta por AP-banda.
+- **Nombres de 802.11r más claros y sin dispositivos fantasma** ([#601](https://github.com/gnacho/netpulse/issues/601)). El título de la sección pasa a "Por AP" en lugar de "Por router", la columna a "Dispositivo", y los equipos sin radios (como el gateway) ya no aparecen en el detalle por router. Los routers descubiertos automáticamente se nombran por su hostname, no por el modelo de hardware, así la UI muestra nombres de dispositivo en toda la app.
+- **Ancho de canal propio en el análisis de canales** ([#602](https://github.com/gnacho/netpulse/issues/602)). En el análisis de canales, la fila de tu propia red muestra ahora el ancho de canal (por ejemplo `1 · 20 MHz`) junto al número de canal, cruzado con el channel-plan del router.
+- **La UI ya no se queda en negro al conectarse un cliente WireGuard** ([#592](https://github.com/gnacho/netpulse/issues/592)). NetPulse envía el tipo de peer WireGuard como texto plano y usa "desconocido" cuando no encuentra tipo. La tarjeta de la Home construía el icono sin fallback, así que un peer desconocido (o no mapeado) producía un icono en blanco y React tiraba toda la página en cuanto un cliente WireGuard se conectaba (o al abrir la UI desde él). NetPulse tiene ahora un icono de respaldo para estos casos y un tipo "desconocido" conocido, así la página sigue renderizando.
+
+### Anterior (v2.28.11)
+
+- **El agente ya no degrada tu WiFi al escanear** ([#591](https://github.com/gnacho/netpulse/issues/591)). El agente por router lanzaba un escaneo WiFi activo completo en cada sondeo, es decir cada ~30-37 s por dispositivo. En puntos de acceso eso saca la radio del canal y suelta clientes IoT/débiles. Ahora escanea como mucho cada 10 minutos, tras el arranque, o de inmediato cuando el servidor pide un refresh, y la versión de agente embebida sube para que la flota se actualice sola.
+
 ### Qué se descubre
 
 NetPulse descubre dispositivos clientes a partir de tres fuentes que se ejecutan en los routers monitorizados:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,28 @@ anomalies, and warns you.
 - **Optional collector sidecar**: TCP latency probes per router with its
   own long-term time series.
 
+## What's new
+
+Each release is pushed to the fleet through the built-in auto-updater. Newer
+versions surface a short, human-readable "what changed" panel in the app so
+you know what to expect before you update. Here is a running summary of the
+latest improvements, each linked to the GitHub issue that drove it.
+
+> These are written for people, not changelogs: what the feature does for you,
+> not the function names behind it.
+
+### Latest (v2.28.12)
+
+- **Set a custom SSH port per router** ([#605](https://github.com/gnacho/netpulse/issues/605)). Not every router keeps its SSH daemon on port 22 - some run it elsewhere. Now each router can be given its own SSH port when you add or edit it, and every server-side path (probing, actions, agent install, gateway discovery) uses it automatically. Leave it empty and NetPulse keeps using 22.
+- **Roaming matrix grouped per device** ([#600](https://github.com/gnacho/netpulse/issues/600)). In WiFi Roaming → Matrix, columns are now grouped under the access point's name, with a header row that labels each band (2.4G/5G). No more a loose column per AP-band.
+- **Cleaner 802.11r wording and no phantom devices** ([#601](https://github.com/gnacho/netpulse/issues/601)). The section title is now "By AP" instead of "By router", the column is "Device", and devices without radios (like the gateway) no longer show up in the per-router detail. Routers discovered automatically are also named after their hostname, not their hardware model, so the UI shows device names across the app.
+- **Own channel width in the channel scan** ([#602](https://github.com/gnacho/netpulse/issues/602)). In the channel analysis, the row for your own network now shows the channel width (for example `1 · 20 MHz`) next to the channel number, cross-referenced with the router's channel plan.
+- **The UI no longer goes black when a WireGuard client connects** ([#592](https://github.com/gnacho/netpulse/issues/592)). NetPulse reports a WireGuard peer's type as plain text, and uses "unknown" when it cannot match a type. The Home card built the peer icon with no fallback, so an unknown (or unmatched) peer produced a blank icon and React crashed the whole page the moment a WireGuard client connected (or when you opened the UI from a connected client). NetPulse now has a fallback icon for these, plus a known "unknown" type, so the page keeps rendering.
+
+### Earlier (v2.28.11)
+
+- **The agent no longer degrades your Wi-Fi while scanning** ([#591](https://github.com/gnacho/netpulse/issues/591)). The per-router agent used to run a full active Wi-Fi scan on every probe, so ~every 30-37s per device. On access points that pulls the radio off channel and drops IoT/weak clients. It now scans at most every 10 minutes, after boot, or immediately when the server asks for a refresh - and the embedded agent version bumps so the fleet updates itself.
+
 ### What gets discovered
 
 NetPulse discovers client devices from three sources that run on the monitored routers:

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.11",
+  "version": "2.28.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.28.11",
+      "version": "2.28.12",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.11",
+  "version": "2.28.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/device_actions_test.go
+++ b/server-go/internal/httpapi/device_actions_test.go
@@ -51,7 +51,10 @@ func (f *scriptedSSH) Run(host, cmd string, _ time.Duration) (string, error) {
 	f.cmds = append(f.cmds, cmd)
 	f.hosts = append(f.hosts, host)
 	for _, r := range f.rules {
-		if r.host != "" && r.host != host {
+		// Desde #605 el pool entrega "host:puerto_ssh"; la regla puede estar
+		// escrita con el host pelado, así que consideramos ambos equivalentes
+		// cuando el puerto es el por defecto (22).
+		if r.host != "" && r.host != host && r.host+":22" != host {
 			continue
 		}
 		if strings.Contains(cmd, r.contains) {
@@ -75,11 +78,22 @@ func (f *scriptedSSH) saw(substr string) bool {
 // sawHost es como saw pero acotado a un host SSH concreto (issue #537: la
 // reserva debe escribirse en el router que sirve DHCP, no siempre en el
 // gateway).
+//
+// Desde el issue #605 el pool recibe siempre "host:puerto" (SSHAddr), así que
+// un router SSH por defecto llega como "192.168.1.2:22". Comparar solo el host
+// para que los tests escritos con el host "pelado" sigan validando.
 func (f *scriptedSSH) sawHost(host, substr string) bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	for i, c := range f.cmds {
-		if i < len(f.hosts) && f.hosts[i] == host && strings.Contains(c, substr) {
+		if i >= len(f.hosts) {
+			continue
+		}
+		seen := f.hosts[i]
+		if seen != host && seen != host+":22" {
+			continue
+		}
+		if strings.Contains(c, substr) {
 			return true
 		}
 	}

--- a/server-go/internal/httpapi/orchestr.go
+++ b/server-go/internal/httpapi/orchestr.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -596,9 +597,16 @@ func invertDesired(resource string, desired json.RawMessage) (json.RawMessage, e
 // no hay NetGrip configurado o no responde (fallback a SSE); (false, error)
 // si NetGrip devolvió error explícito.
 func (s *server) applyViaNetGrip(routerID string, planID string, ops []executor.Op) (bool, error) {
-	host := s.hostOfRouter(routerID)
-	if host == "" {
+	sshHost := s.hostOfRouter(routerID)
+	if sshHost == "" {
 		return false, nil
+	}
+	// hostOfRouter devuelve "host:puerto_ssh" (SSHAddr, issue #605); NetGrip
+	// habla por HTTP en un puerto propio (8080), así que necesitamos solo el
+	// host. Cae por si el pool ya entrega un host pelado.
+	host := sshHost
+	if h, _, err := net.SplitHostPort(sshHost); err == nil {
+		host = h
 	}
 	execToken := ""
 	if s.db != nil {

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.11"
+var Version = "2.28.12"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
## What's new

This release bundles the improvements merged since v2.28.11:

- **Per-router custom SSH port** (#605): routers that expose dropbear on a port other than 22 now get their own `ssh_port` (set it when adding/editing a router), and every SSH path uses it. Empty = 22.
- **Roaming matrix grouped per device** (#600): columns now group under the AP name with a per-band (2.4G/5G) header row.
- **Cleaner 802.11r wording + no phantom devices** (#601): "By AP" / "Device", devices without radios no longer show, auto-discovered routers are named by hostname.
- **Own channel width in the channel scan** (#602): the row for your own network shows the channel width alongside the channel number.
- **No more black UI when a WireGuard client connects** (#592): the Home card fell back to no icon for an "unknown" peer type, which crashed React. Now it has a fallback + a known "unknown" type.

## Internal

- CHANGELOG and README (EN/ES) updated: a human-readable "What's new" section links each improvement to its GitHub issue.
- Bumped version to 2.28.12 (server Version, app package.json/lock).

## Fixes needed for the release

`go test ./...` broke on main because #605 changed `hostOfRouter` to return the SSH `host:port`, and two consumers were not updated. Fixed here:

- `applyViaNetGrip` now takes only the host (NetGrip speaks HTTP on its own port, not SSH).
- The `scriptedSSH` test helper matches a bare host and `<host>:22` as equivalent, since the pool now always receives `host:port`.

All `server-go` and `collector` tests pass.
