### PR TITLE
docs(roadmap): plan network insights per client/VLAN

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -177,7 +177,7 @@ OpenWrt deberían funcionar, pero el tuyo sería el primero en contarlo.
 | **12 — Auditoría de seguridad** | ✅ | TRUST_PROXY, anti-replay en ingesta, body cap, password mínima 10 |
 | **13 — Auditoría de robustez** | ✅ | Single-flight GetOverview, SSE write deadline, race en sshpool.dial, %w wrapping |
 | **14 — Visibilidad WiFi/roaming** | ✅ | Matriz de señal DAWN, estado 802.11r por SSID, utilización por canal survey, feed persistente de eventos de roaming (30 días) |
-| **15 — Informes** | 🔄 | Disponibilidad día/semana/mes. Pendiente: tráfico, actividad, resumen de alertas, exportación |
+| **15 — Informes** | 🔄 | Disponibilidad día/semana/mes. Pendiente: tráfico, actividad, resumen de alertas, exportación, e insights de red por cliente/VLAN ([#588](https://github.com/gnacho/netpulse/issues/588)) |
 | **16 — Alertas avanzadas** | 🔮 | Reglas custom por umbral, tipos nuevos (fallo de roaming, congestión de canal), silencio programado, email |
 | **17 — Escribir en routers** | 🔄 | Ownership UCI + apply seguro con rollback (#451), planificación de canales (#452), firmware upgrades (#453); índice completo de módulos (AdGuard full, WiFi guest, DDNS, QoS, WireGuard, OpenVPN, Tailscale, Batman, DPI) |
 | **18-20 — Programa de beta-testing** | 🔮 | Grupos de módulos por riesgo (bajo / medio / alto) con canales stable + unstable y beta-testers externos |

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ block a device):
 | **12 — Security audit** | ✅ | TRUST_PROXY, anti-replay on ingest, body cap, password min 10 |
 | **13 — Robustness audit** | ✅ | Single-flight GetOverview, SSE write deadline, sshpool dial race, error wrapping |
 | **14 — WiFi/roaming visibility** | ✅ | DAWN signal matrix, 802.11r status per SSID, channel utilization survey, persistent roaming events feed (30d) |
-| **15 — Reports** | 🔄 | Daily/week/month availability. Pending: traffic, activity, alert summary, export |
+| **15 — Reports** | 🔄 | Daily/week/month availability. Pending: traffic, activity, alert summary, export, and per-client/VLAN network insights ([#588](https://github.com/gnacho/netpulse/issues/588)) |
 | **16 — Advanced alerts** | 🔮 | Custom threshold rules, new alert types (roaming failure, channel congestion), scheduled silence, email |
 | **17 — Write to routers** | 🔄 | UCI ownership + safe apply with rollback (#451), channel planning (#452), firmware upgrades (#453); full module index (AdGuard full, WiFi guest, DDNS, QoS, WireGuard, OpenVPN, Tailscale, Batman, DPI) |
 | **18-20 — Beta-testing program** | 🔮 | Module groups by risk (low / medium / high) with stable + unstable release channels and external beta-testers |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -557,6 +557,15 @@ en informes accionables.
 4. **15.4 — Resumen de alertas**: conteo por categoría/severidad/tiempo.
    Tendencia (¿va mejorando la red?).
 5. **15.5 — Exportación**: CSV de tablas, PNG de gráficas.
+6. **15.6 — Insights de red (por cliente/VLAN)** ([#588](https://github.com/gnacho/netpulse/issues/588)):
+   respuesta del foro que pide "más insights de red": protocolos, conexiones,
+   tráfico, broadcasts, agrupados por cliente y por VLAN. Histórico a largo
+   plazo (sobre los datos ya colectados por `metrics_buckets`/`metrics_daily`)
+   + inspección en vivo de flujos (conversaciones por cliente/VLAN). La parte
+   de "live flows" es un complemento: se apoya en el **[DPI/ntopng
+   (17.11)**](#fase-17--escribir-en-los-routers-en-progreso-v260) una vez que
+   ese módulo exista, pero el núcleo (histórico por cliente/VLAN) se puede
+   abordar sin tocar los routers.
 
 **Deploy**: sin cambios en routers (los datos ya se colectan).
 


### PR DESCRIPTION
## Summary

Plan the forum request for richer network insights (#588) on the roadmap, so it is tracked publicly and the issue can be linked.

The request: protocols, connections, traffic and broadcasts grouped per client and per VLAN, with long-term history plus live flow inspection.

## Choice of phase

- **Phase 15 - Reports & analytics**, sub-phase **15.6**. This is read/analytics work (turning collected data into actionable reports), not "write to routers", so it does not belong to Phase 17.
- The **live-flows** part is noted as leaning on the future **DPI/ntopng (17.11)** module; the core (per-client/VLAN history) can be delivered without touching routers, since it builds on data already collected.

## Changes

- `docs/ROADMAP.md`: add sub-phase 15.6 with the rationale and the #588 link.
- `README.md` (EN) / `README.es.md` (ES): reference #588 in the Phase 15 row.

Docs-only change, no runtime impact.
