### PR TITLE
docs(roadmap): plan channel-analysis chart polish in phase 14

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -176,7 +176,7 @@ OpenWrt deberían funcionar, pero el tuyo sería el primero en contarlo.
 | **11 — Paquete LuCI** | ✅ | `luci-app-netpulse`: estado local del agente (procd, UCI, logs, restart/rearm) + test connection + puente a la webapp |
 | **12 — Auditoría de seguridad** | ✅ | TRUST_PROXY, anti-replay en ingesta, body cap, password mínima 10 |
 | **13 — Auditoría de robustez** | ✅ | Single-flight GetOverview, SSE write deadline, race en sshpool.dial, %w wrapping |
-| **14 — Visibilidad WiFi/roaming** | ✅ | Matriz de señal DAWN, estado 802.11r por SSID, utilización por canal survey, feed persistente de eventos de roaming (30 días) |
+| **14 — Visibilidad WiFi/roaming** | ✅ | Matriz de señal DAWN, estado 802.11r por SSID, utilización por canal survey, feed persistente de eventos de roaming (30 días). Polish pendiente: claridad de la gráfica del análisis de canales ([#618](https://github.com/gnacho/netpulse/issues/618)) |
 | **15 — Informes** | 🔄 | Disponibilidad día/semana/mes. Pendiente: tráfico, actividad, resumen de alertas, exportación, e insights de red por cliente/VLAN ([#588](https://github.com/gnacho/netpulse/issues/588)) |
 | **16 — Alertas avanzadas** | 🔮 | Reglas custom por umbral, tipos nuevos (fallo de roaming, congestión de canal), silencio programado, email |
 | **17 — Escribir en routers** | 🔄 | Ownership UCI + apply seguro con rollback (#451), planificación de canales (#452), firmware upgrades (#453); índice completo de módulos (AdGuard full, WiFi guest, DDNS, QoS, WireGuard, OpenVPN, Tailscale, Batman, DPI) |

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ block a device):
 | **11 — LuCI package** | ✅ | `luci-app-netpulse` shipped as `.ipk`/`.apk` on every release: local agent status/view (procd, UCI, logs, restart/rearm) + bridge to the web app |
 | **12 — Security audit** | ✅ | TRUST_PROXY, anti-replay on ingest, body cap, password min 10 |
 | **13 — Robustness audit** | ✅ | Single-flight GetOverview, SSE write deadline, sshpool dial race, error wrapping |
-| **14 — WiFi/roaming visibility** | ✅ | DAWN signal matrix, 802.11r status per SSID, channel utilization survey, persistent roaming events feed (30d) |
+| **14 — WiFi/roaming visibility** | ✅ | DAWN signal matrix, 802.11r status per SSID, channel utilization survey, persistent roaming events feed (30d). Polish pending: channel-analysis chart clarity ([#618](https://github.com/gnacho/netpulse/issues/618)) |
 | **15 — Reports** | 🔄 | Daily/week/month availability. Pending: traffic, activity, alert summary, export, and per-client/VLAN network insights ([#588](https://github.com/gnacho/netpulse/issues/588)) |
 | **16 — Advanced alerts** | 🔮 | Custom threshold rules, new alert types (roaming failure, channel congestion), scheduled silence, email |
 | **17 — Write to routers** | 🔄 | UCI ownership + safe apply with rollback (#451), channel planning (#452), firmware upgrades (#453); full module index (AdGuard full, WiFi guest, DDNS, QoS, WireGuard, OpenVPN, Tailscale, Batman, DPI) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -537,6 +537,12 @@ corte) habría sido trivial con esta visibilidad.
    solapamiento de canales.
 5. **14.5 — Eventos de roaming**: timeline con assoc/disassoc/roam
    (cruzando hearing maps consecutivos + iw events ya capturados).
+6. **14.6 — Polish de la gráfica del análisis de canales**
+   ([#618](https://github.com/gnacho/netpulse/issues/618)): la vista "plan de
+   canales" (montañas) funciona, pero el polish visual se puede mejorar:
+   claridad de la montaña de la red propia, legibilidad de la curva por
+   canal y layout general. Subjetivo, sin bug funcional, baja prioridad.
+   Refinamiento sobre la vista del sub-item 14.4 (WiFi survey).
 
 **Deploy**: agentes actualizados (ya en v2.8.0). UI nueva sin tocar routers.
 


### PR DESCRIPTION
## Summary

Plan the owner feedback after #602 as tracked roadmap work: the channel-analysis (mountains) chart works but the visual can be improved (own-network mountain clarity, per-channel curve readability, overall layout). No functional bug; low priority polish.

## Choice of phase

- **Phase 14 — WiFi/roaming visibility**, sub-phase **14.6**. This view (channel planning / WiFi survey) belongs to Phase 14; this is a UI polish of it, not a new capability, so it stays there.

## Changes

- `docs/ROADMAP.md`: add sub-phase 14.6 with the rationale and the #618 link.
- `README.md` (EN) / `README.es.md` (ES): note the pending polish in the Phase 14 row.

Docs-only change, no runtime impact.
