### PR TITLE
chore: prepare v2.28.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.28.13] - 2026-09-08
+
+### Added
+
+- **Botón de desinstalación del agente (#624)**: en routers con poco espacio libre (p. ej. UniFi 6 Lite) el `reinstall` no cabía; ahora hay una acción "Desinstalar" que retira el agente limpio (detiene/deshabilita el init, borra binario, `.env`, watchdog y cron).
+- **Rotación del token del agente en caliente**: al regenerar el token de un dispositivo en Ajustes, NetPulse ahora lo aplica en el propio router por SSH (reescribe `/etc/netpulse-agent.env` y reinicia el servicio), así el dispositivo sigue reportando **sin reinstalar**. El one-liner de instalación solo se necesita cuando el router no es alcanzable por SSH.
+- **Autodetección de la imagen de firmware (#629)**: en Actualizaciones, NetPulse resuelve la imagen del router a partir de su propio firmware (`board_name` + `target` + `version`) consultando el índice de descargas de OpenWrt y **prerrellena** la URL y el checksum, con un botón "Autodetectar imagen". Si no se puede resolver, se mantiene la entrada manual.
+
+### Changed
+
+- **Ajustes rediseñados a una columna (#627)**: la página de Ajustes pasa a una columna única con un índice fijo que te sigue al hacer scroll (scroll-spy); cada tarjeta (Apariencia, Datos y umbrales, Servicios, Red, Integraciones, Administración, Cuenta, Acerca de) ocupa el ancho completo y es más manejable. La tarjeta Apariencia muestra previews reales del tema (claro/oscuro/sistema) y la paleta en dos columnas; el test de velocidad WAN se ejecuta real desde el servidor y rellena descarga/subida en su sitio. Los toggles de Laboratorio se muestran individuales (Orquestación, Canales, Actualizaciones) al activar Labs.
+
+### Fixed
+
+- **Los botones de copiar mostraban la clave i18n cruda (#628)**: los botones de copiar token/huella de la tarjeta de adopción usaban `common.copy`, una clave inexistente, así que el tooltip mostraba literalmente `common.copy`. Añadida la clave `common.copy` ("Copiar"/"Copy").
+
 ## [2.28.12] - 2026-09-07
 
 ### Added

--- a/README.es.md
+++ b/README.es.md
@@ -97,7 +97,18 @@ enlazada al issue de GitHub que la originó.
 > Están escritas para personas, no como changelog: qué hace la función por ti,
 > no los nombres de las funciones internas.
 
-### Última (v2.28.12)
+### Última (v2.28.13)
+
+- **Una página de Ajustes más limpia, a una columna** ([#627](https://github.com/gnacho/netpulse/issues/627)). La página de Ajustes pasa a una columna única con un índice fijo que te sigue al hacer scroll, así cada tarjeta (Apariencia, Datos y umbrales, Servicios, Red, Integraciones, Administración, Cuenta, Acerca de) ocupa el ancho completo y es más manejable. La tarjeta Apariencia muestra previews reales del tema (claro/oscuro/sistema) y la paleta en dos columnas; el test de velocidad WAN se ejecuta real desde el servidor y rellena descarga/subida en su sitio. Los toggles de Laboratorio aparecen individuales (Orquestación, Canales, Actualizaciones) al activar Labs.
+- **Regenerar el token de un agente sin reinstalar** ([#627](https://github.com/gnacho/netpulse/issues/627)). Al regenerar el token de un dispositivo desde Ajustes, NetPulse ahora lo aplica en el propio router por SSH y reinicia el agente, así el dispositivo sigue reportando **sin reinstalar**. El one-liner de instalación solo hace falta cuando el router no es alcanzable por SSH.
+- **Actualizaciones: autodetecta la imagen de firmware** ([#629](https://github.com/gnacho/netpulse/issues/629)). En la página de actualizaciones de firmware, NetPulse resuelve la imagen del router a partir de su propio firmware (board + target + version) en el índice de descargas de OpenWrt y **prerrellena** la URL y el checksum, con un botón "Autodetectar imagen". La entrada manual se mantiene cuando no se puede resolver.
+- **Desinstalar el agente en routers justos** ([#624](https://github.com/gnacho/netpulse/issues/624)). En routers con poco espacio libre (como el UniFi 6 Lite) no cabía un reinstall; ahora hay una acción "Desinstalar" limpia que detiene y retira el agente.
+
+### Arreglado
+
+- **Los botones de copiar mostraban la clave i18n cruda** ([#628](https://github.com/gnacho/netpulse/issues/628)). Los botones de copiar de la tarjeta de adopción usaban una clave `common.copy` inexistente, así que el tooltip mostraba `common.copy`; la clave ya existe y traduce a "Copy"/"Copiar".
+
+### Anterior (v2.28.12)
 
 - **Puerto SSH personalizado por router** ([#605](https://github.com/gnacho/netpulse/issues/605)). No todos los routers dejan el daemon SSH en el puerto 22: algunos lo tienen en otro. Ahora cada router admite su propio puerto SSH al darlo de alta o editarlo, y todos los caminos del servidor (sondeo, acciones, instalación del agente, descubrimiento del gateway) lo usan automáticamente. Déjalo vacío y NetPulse sigue usando el 22.
 - **Matriz de itinerancia agrupada por dispositivo** ([#600](https://github.com/gnacho/netpulse/issues/600)). En WiFi Roaming → Matriz, las columnas se agrupan ahora bajo el nombre del punto de acceso, con una fila de cabecera que etiqueta cada banda (2.4G/5G). Ya no hay una columna suelta por AP-banda.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,18 @@ latest improvements, each linked to the GitHub issue that drove it.
 > These are written for people, not changelogs: what the feature does for you,
 > not the function names behind it.
 
-### Latest (v2.28.12)
+### Latest (v2.28.13)
+
+- **A cleaner Settings page, one column at a time** ([#627](https://github.com/gnacho/netpulse/issues/627)). The Settings page is now a single column with a sticky index that follows you as you scroll, so each card (Appearance, Data & thresholds, Services, Network, Integrations, Administration, Account, About) is full-width and easier to use. The Appearance card shows real theme previews (light/dark/system) and a two-column palette; the WAN speed test runs a real test from the server and fills download/up in place. Labs toggles appear individually (Orchestration, Channels, Upgrades) once Labs is on.
+- **Regenerate an agent token without reinstalling** ([#627](https://github.com/gnacho/netpulse/issues/627)). When you regenerate a router's agent token from Settings, NetPulse now pushes the new token to the router and restarts the agent in place, so the device keeps reporting without a reinstall. The install one-liner is only needed when the router can't be reached over SSH.
+- **Actualizaciones: autodetect the firmware image** ([#629](https://github.com/gnacho/netpulse/issues/629)). On the firmware upgrades page, NetPulse looks up the router's image from its own firmware (board + target + version) on the OpenWrt download index and prefills the URL and checksum, with an "Autodetect image" button. Manual entry stays available when it can't be resolved.
+- **Uninstall the agent on tight routers** ([#624](https://github.com/gnacho/netpulse/issues/624)). Routers with little free space (like the UniFi 6 Lite) couldn't fit a reinstall; there's now a clean "Uninstall" action that stops and removes the agent.
+
+### Fixed
+
+- **Copy buttons show the raw i18n key** ([#628](https://github.com/gnacho/netpulse/issues/628)). The copy buttons in the adoption card used a missing `common.copy` key, so their tooltip showed `common.copy`; the key now exists and translates to "Copy"/"Copiar".
+
+### Earlier (v2.28.12)
 
 - **Set a custom SSH port per router** ([#605](https://github.com/gnacho/netpulse/issues/605)). Not every router keeps its SSH daemon on port 22 - some run it elsewhere. Now each router can be given its own SSH port when you add or edit it, and every server-side path (probing, actions, agent install, gateway discovery) uses it automatically. Leave it empty and NetPulse keeps using 22.
 - **Roaming matrix grouped per device** ([#600](https://github.com/gnacho/netpulse/issues/600)). In WiFi Roaming → Matrix, columns are now grouped under the access point's name, with a header row that labels each band (2.4G/5G). No more a loose column per AP-band.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.12",
+  "version": "2.28.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.28.12",
+      "version": "2.28.13",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.12",
+  "version": "2.28.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.12"
+var Version = "2.28.13"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Bump versions to 2.28.13 and update CHANGELOG + README (What's new / Novedades) with the features accumulated since v2.28.12: settings redesign (#627), hot agent token rotation, firmware image autodetect (#629), uninstall agent (#624) and the i18n tooltip fix (#628).