### PR TITLE
fix(agents): rearm recovers a 401 token desync; atomic token on reinstall

### DIFF
--- a/server-go/internal/httpapi/agent.go
+++ b/server-go/internal/httpapi/agent.go
@@ -131,6 +131,37 @@ func newAgentToken() (string, error) {
 	return hex.EncodeToString(buf), nil
 }
 
+// rotateAgentTokenAtomic instala un token nuevo en kv (el hash del server) y
+// ejecuta `apply`, que debe desplegarlo en el router. Si `apply` falla, se
+// restaura el hash previo para que el agente no se quede en 401 eterno (#630).
+// Devuelve el token en claro (la única vez que viaja).
+func (s *server) rotateAgentTokenAtomic(slug string, apply func(token string) error) (string, error) {
+	oldHash, hadOld := "", false
+	if s.db != nil {
+		if err := s.db.QueryRow("SELECT value FROM kv WHERE key = ?", agentTokenKey(slug)).Scan(&oldHash); err == nil {
+			hadOld = true
+		}
+	}
+	token, err := newAgentToken()
+	if err != nil {
+		return "", err
+	}
+	if _, err := s.db.Exec(
+		"INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+		agentTokenKey(slug), hashAgentToken(token)); err != nil {
+		return "", err
+	}
+	if err := apply(token); err != nil {
+		if hadOld {
+			_, _ = s.db.Exec("UPDATE kv SET value = ? WHERE key = ?", oldHash, agentTokenKey(slug))
+		} else {
+			_, _ = s.db.Exec("DELETE FROM kv WHERE key = ?", agentTokenKey(slug))
+		}
+		return "", err
+	}
+	return token, nil
+}
+
 // checkAgentToken: ¿el Bearer es válido para el slug? (comparación en
 // tiempo constante sobre los hashes).
 func (s *server) checkAgentToken(slug, token string) bool {
@@ -744,19 +775,6 @@ func (s *server) handleAgentReinstall(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Rotar el token (el env del router se reescribe con el nuevo).
-	token, err := newAgentToken()
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "token_error")
-		return
-	}
-	if _, err := s.db.Exec(
-		"INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
-		agentTokenKey(slug), hashAgentToken(token)); err != nil {
-		writeError(w, http.StatusInternalServerError, "token_error")
-		return
-	}
-
 	// URL base del server (para que el router descargue el binario).
 	// NETPULSE_PUBLIC_URL manda si está configurada (#457): sin ella, llamar
 	// al endpoint vía localhost haría que el router descargue de localhost.
@@ -769,9 +787,6 @@ func (s *server) handleAgentReinstall(w http.ResponseWriter, r *http.Request) {
 		serverURL = s.cfg.PublicURL
 	}
 
-	// Script de instalación canónico (compartido con el supervisor, #457).
-	script := reinstall.Script(slug, token, serverURL, reinstall.Digests())
-
 	before := time.Now()
 	var prevSeen time.Time
 	if s.agents != nil {
@@ -780,8 +795,14 @@ func (s *server) handleAgentReinstall(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Descarga + verificación + swap: margen generoso para enlaces lentos.
-	if _, err := s.pool.Run(host, script, 300*time.Second); err != nil {
+	// Rotar el token de forma ATÓMICA (#630): el script lo instala en el router
+	// y, si el SSH falla, se restaura el hash previo en kv — así el agente no
+	// se queda empujando un token que el servidor ya no acepta (401 eterno).
+	token, err := s.rotateAgentTokenAtomic(slug, func(t string) error {
+		_, runErr := s.pool.Run(host, reinstall.Script(slug, t, serverURL, reinstall.Digests()), 300*time.Second)
+		return runErr
+	})
+	if err != nil {
 		writeError(w, http.StatusBadGateway, "ssh_failed", err.Error())
 		return
 	}

--- a/server-go/internal/httpapi/rearm_api_test.go
+++ b/server-go/internal/httpapi/rearm_api_test.go
@@ -211,6 +211,35 @@ func TestRearmSinRouter409(t *testing.T) {
 	}
 }
 
+// TestReinstallRotaAtomicYRollbackHttpapi (#630): si el SSH del reinstall
+// manual falla, el hash del token en kv NO debe quedar rotado (rollback al
+// valor previo), evitando el 401 eterno del agente.
+func TestReinstallRotaAtomicYRollbackHttpapi(t *testing.T) {
+	ssh := &fakeSSH{fail: true}
+	ts := makeRearmTestServer(t, ssh, 1500*time.Millisecond)
+	if _, err := ts.db.Exec("INSERT INTO kv (key, value) VALUES (?, ?)", "agent.token.patio", "fakehash"); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+
+	req, _ := http.NewRequest("POST", ts.URL+"/api/agents/patio/reinstall", nil)
+	req.Header.Set("Cookie", "session="+ts.cookie)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post reinstall: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusBadGateway {
+		t.Fatalf("esperaba 502 ssh_failed, got %d", res.StatusCode)
+	}
+	var stored string
+	if err := ts.db.QueryRow("SELECT value FROM kv WHERE key = 'agent.token.patio'").Scan(&stored); err != nil {
+		t.Fatalf("kv rollback: %v", err)
+	}
+	if stored != "fakehash" {
+		t.Fatalf("rollback esperado al hash previo, got %q", stored)
+	}
+}
+
 func TestRearmRecuperado200(t *testing.T) {
 	ssh := &fakeSSH{}
 	ts := makeRearmTestServer(t, ssh, 1500*time.Millisecond)

--- a/server-go/internal/rearmer/rearmer.go
+++ b/server-go/internal/rearmer/rearmer.go
@@ -82,6 +82,65 @@ type Result struct {
 	Message   string
 }
 
+// --- helpers de token (atómicos, #630) ----------------------------------------
+
+// newAgentToken genera un token aleatorio de 32 bytes en hex (64 chars).
+func newAgentToken() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+func tokenHash(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+func (r *Rearmer) readKV(key string) (string, bool) {
+	if r.db == nil {
+		return "", false
+	}
+	var v string
+	if err := r.db.QueryRow("SELECT value FROM kv WHERE key = ?", key).Scan(&v); err != nil {
+		return "", false
+	}
+	return v, true
+}
+
+func (r *Rearmer) writeKV(key, value string) error {
+	_, err := r.db.Exec(
+		"INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+		key, value)
+	return err
+}
+
+// rotateTokenAtomic instala un token nuevo en el *servidor* (kv), ejecuta
+// `apply` (que debe instalarlo en el router) y, si apply falla, restaura el
+// hash previo. Así un reinstall/rearme que falle a mitad NO deja al agente
+// empujando un token que el servidor ya no acepta (401 eterno, #630).
+func (r *Rearmer) rotateTokenAtomic(slug string, apply func(token string) error) error {
+	oldHash, hadOld := r.readKV(TokenPrefix + slug)
+	token, err := newAgentToken()
+	if err != nil {
+		return err
+	}
+	if err := r.writeKV(TokenPrefix+slug, tokenHash(token)); err != nil {
+		return err
+	}
+	if err := apply(token); err != nil {
+		// Rollback: restaura el hash previo (o borra la clave si no había).
+		if hadOld {
+			_ = r.writeKV(TokenPrefix+slug, oldHash)
+		} else if r.db != nil {
+			_, _ = r.db.Exec("DELETE FROM kv WHERE key = ?", TokenPrefix+slug)
+		}
+		return err
+	}
+	return nil
+}
+
 // ErrCooldown se devuelve cuando el slug se rearmó hace poco.
 type ErrCooldown struct{ Wait time.Duration }
 
@@ -224,6 +283,25 @@ func (r *Rearmer) Rearm(slug string) (Result, error) {
 
 	recovered := r.waitForPush(slug, prevSeen, before)
 
+	// #630: si reiniciar el proceso no recuperó el agente, puede ser un 401
+	// por desincronización de token (el server rotó el token pero el .env del
+	// router lo mantiene antiguo). Solo para agentes NATIVOS (cmd = Cmd): se
+	// regenera el token y se aplica en caliente (reescribe el .env + restart),
+	// que es la vía que arregla el desync sin reinstalar. Los NetGrip se
+	// recuperan con su propio CmdNetgrip (recarga env en memoria).
+	if !recovered && cmd == Cmd {
+		before2 := time.Now()
+		prevSeen2 := prevSeen
+		if err := r.rotateTokenAtomic(slug, func(t string) error {
+			_, err := r.pool.Run(host, reinstall.TokenPushScript(slug, t), SSHWait)
+			return err
+		}); err == nil {
+			if r.waitForPush(slug, prevSeen2, before2) {
+				recovered = true
+			}
+		}
+	}
+
 	res := Result{Slug: slug, Restarted: true, Recovered: recovered}
 	if recovered {
 		res.Message = "servicio reiniciado y el agente volvió a empujar"
@@ -280,22 +358,9 @@ func (r *Rearmer) Reinstall(slug, publicURL string) (Result, error) {
 		return Result{}, ErrNoSSH
 	}
 
-	// Rotar el token: el script lo instala en el router y el hash nuevo
-	// sustituye al viejo en kv.
-	buf := make([]byte, 32)
-	if _, err := rand.Read(buf); err != nil {
-		return Result{}, fmt.Errorf("token: %w", err)
-	}
-	token := hex.EncodeToString(buf)
-	sum := sha256.Sum256([]byte(token))
-	if _, err := r.db.Exec(
-		"INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
-		TokenPrefix+slug, hex.EncodeToString(sum[:])); err != nil {
-		return Result{}, fmt.Errorf("token kv: %w", err)
-	}
-
-	script := reinstall.Script(slug, token, publicURL, reinstall.Digests())
-
+	// Rotar el token de forma ATÓMICA (#630): el script lo instala en el
+	// router; si el SSH falla se restaura el hash previo en kv, así el agente
+	// no se queda empujando un token que el servidor ya no acepta.
 	before := time.Now()
 	var prevSeen time.Time
 	if r.agents != nil {
@@ -303,8 +368,10 @@ func (r *Rearmer) Reinstall(slug, publicURL string) (Result, error) {
 			prevSeen = seen
 		}
 	}
-
-	if _, err := r.pool.Run(host, script, ReinstallSSHWait); err != nil {
+	if err := r.rotateTokenAtomic(slug, func(t string) error {
+		_, err := r.pool.Run(host, reinstall.Script(slug, t, publicURL, reinstall.Digests()), ReinstallSSHWait)
+		return err
+	}); err != nil {
 		return Result{}, fmt.Errorf("no se pudo instalar el agente en %s: %w", host, err)
 	}
 

--- a/server-go/internal/rearmer/rearmer_test.go
+++ b/server-go/internal/rearmer/rearmer_test.go
@@ -23,11 +23,15 @@ import (
 type fakeSSH struct {
 	mu   sync.Mutex
 	cmds []string
+	fail bool // devolver error en Run (simula SSH caído)
 }
 
 func (f *fakeSSH) Run(host, cmd string, _ time.Duration) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.fail {
+		return "", errors.New("ssh down")
+	}
 	f.cmds = append(f.cmds, host+":"+cmd)
 	return "", nil
 }
@@ -138,8 +142,10 @@ func TestSupervisorRearmaAgenteExpirado(t *testing.T) {
 	sup := rearmer.NewSupervisor(env.arm, env.reg, env.d.DB, env.engine, time.Hour, time.Hour)
 	sup.CheckOnce()
 
-	if env.ssh.count() != 1 {
-		t.Fatalf("quiero 1 comando SSH de rearme, tuve %d", env.ssh.count())
+	// #630: el rearm nativo incluye el push de token si el restart no
+	// recupera, así que son 2 comandos (restart + token push).
+	if env.ssh.count() != 2 {
+		t.Fatalf("quiero 2 comandos SSH de rearme (restart + token push), tuve %d", env.ssh.count())
 	}
 }
 
@@ -192,8 +198,8 @@ func TestSupervisorCooldownLargo(t *testing.T) {
 	sup.CheckOnce()
 	sup.CheckOnce() // segundo tick inmediato: cooldown largo lo frena
 
-	if env.ssh.count() != 1 {
-		t.Fatalf("cooldown del supervisor: quiero 1 rearme, tuve %d", env.ssh.count())
+	if env.ssh.count() != 2 {
+		t.Fatalf("cooldown del supervisor: quiero 2 (rearm nativo), tuve %d", env.ssh.count())
 	}
 }
 
@@ -229,8 +235,10 @@ func TestSupervisorConsolidaFallosRepetidos(t *testing.T) {
 		time.Sleep(40 * time.Millisecond) // deja pasar el cooldown del slot
 	}
 
-	if got := env.ssh.count(); got != 3 {
-		t.Fatalf("quiero 3 reintentos SSH, tuve %d", got)
+	// #630: cada rearme nativo hace restart + token push (2), así que 3
+	// intentos = 6 comandos SSH.
+	if got := env.ssh.count(); got != 6 {
+		t.Fatalf("quiero 6 reintentos SSH (3 × restart+token), tuve %d", got)
 	}
 	evs := env.engine.events()
 	fails := []alerts.AlertEvent{}
@@ -354,6 +362,55 @@ func TestRearmExternalAgentRejected(t *testing.T) {
 	}
 }
 
+// #630: si reiniciar el proceso no recupera el agente (posible 401 por token
+// desincronizado), el Rearmer NOSCALA a un push de token en caliente para un
+// agente nativo — segundo comando SSH con el TokenPushScript.
+func TestRearmEscalaTokenPushSiNoRecupera(t *testing.T) {
+	env := makeRearmEnv(t, "patio")
+	env.arm.SetPollWait(50 * time.Millisecond)
+
+	res, err := env.arm.Rearm("patio")
+	if err != nil {
+		t.Fatalf("rearm: %v", err)
+	}
+	if !res.Restarted {
+		t.Fatalf("esperaba restart: %+v", res)
+	}
+	if env.ssh.count() != 2 {
+		t.Fatalf("quiero 2 comandos SSH (restart + token push), tuve %d", env.ssh.count())
+	}
+	if !strings.Contains(env.ssh.cmds[1], "NETPULSE_TOKEN=") || !strings.Contains(env.ssh.cmds[1], `"$INIT" restart`) {
+		t.Fatalf("el segundo SSH debe ser el TokenPushScript: %q", env.ssh.cmds[1])
+	}
+	// El token rotó (intento de arreglar el 401): el hash ya no es el fakehash.
+	var stored string
+	if err := env.d.QueryRow("SELECT value FROM kv WHERE key = ?", rearmer.TokenPrefix+"patio").Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored == "fakehash" || len(stored) != 64 {
+		t.Fatalf("token no rotado tras la escalada: %q", stored)
+	}
+}
+
+// #630: si el SSH del reinstall falla, la rotación es ATÓMICA — el hash del
+// token en kv se restaura al previo (rollback), así el agente no se queda
+// empujando un token que el servidor ya no acepta.
+func TestReinstallRotaAtomicYRollbackSiSSHFalla(t *testing.T) {
+	env := makeRearmEnv(t, "patio")
+	env.ssh.fail = true
+
+	if _, err := env.arm.Reinstall("patio", "http://192.168.1.226:3000"); err == nil {
+		t.Fatal("esperaba error de SSH")
+	}
+	var stored string
+	if err := env.d.QueryRow("SELECT value FROM kv WHERE key = ?", rearmer.TokenPrefix+"patio").Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored != "fakehash" {
+		t.Fatalf("rollback esperado al hash previo, got %q", stored)
+	}
+}
+
 // #457: Reinstall directo — rota el token, ejecuta el script canónico con
 // la PUBLIC_URL y espera el push de vuelta.
 func TestReinstallInstalaYRecupera(t *testing.T) {
@@ -408,16 +465,21 @@ func TestSupervisorEscalaAReinstall(t *testing.T) {
 	sup.EnableReinstall("http://192.168.1.226:3000", time.Hour)
 	sup.CheckOnce()
 
-	if env.ssh.count() != 2 {
-		t.Fatalf("quiero 2 comandos SSH (rearm + reinstall), tuve %d", env.ssh.count())
+	// #630: la cadena de escalado es restart → token push → reinstall, así
+	// que si nada recupera hay 3 comandos SSH.
+	if env.ssh.count() != 3 {
+		t.Fatalf("quiero 3 comandos SSH (rearm + token push + reinstall), tuve %d", env.ssh.count())
 	}
-	if !strings.Contains(env.ssh.cmds[1], "selfheal_binary") {
-		t.Error("el segundo comando debería ser la reinstalación completa")
+	if !strings.Contains(env.ssh.cmds[1], "NETPULSE_TOKEN=") {
+		t.Error("el segundo comando debe ser el push de token en caliente")
+	}
+	if !strings.Contains(env.ssh.cmds[2], "selfheal_binary") {
+		t.Error("el tercer comando debería ser la reinstalación completa")
 	}
 
 	// Segunda pasada inmediata: slots ocupados → sin más comandos.
 	sup.CheckOnce()
-	if env.ssh.count() != 2 {
+	if env.ssh.count() != 3 {
 		t.Fatalf("los slots deberían frenar la segunda pasada: %d comandos", env.ssh.count())
 	}
 }
@@ -432,8 +494,10 @@ func TestSupervisorSinEscaladoQuedaEnRearm(t *testing.T) {
 
 	sup := rearmer.NewSupervisor(env.arm, env.reg, env.d.DB, env.engine, time.Hour, time.Hour)
 	sup.CheckOnce()
-	if env.ssh.count() != 1 {
-		t.Fatalf("sin escalado quiero solo el rearm, tuve %d", env.ssh.count())
+	// #630: el rearm nativo ahora incluye el push de token si el restart no
+	// recupera, así que sin escalado activo hay 2 comandos (restart + token).
+	if env.ssh.count() != 2 {
+		t.Fatalf("sin escalado quiero rearm + token push, tuve %d", env.ssh.count())
 	}
 }
 


### PR DESCRIPTION
Fixes an agent stuck in a 401 loop (#630), seen in the wild on rt2: the
server had rotated the agent token but the router's `.env` kept the old one,
so every ingest got 401 and rearm only restarted the process.

## 1. Rearm recovers a token desync
The `Rearmer` now escalates a native rearm that does not recover to a hot
token push: it regenerates the token and applies it on the router (rewrite
`/etc/netpulse-agent.env` + restart) using the lightweight `TokenPushScript`,
so a 401 desync is fixed **in place**, without a full reinstall. The
supervisor escalation chain becomes `restart -> token push -> reinstall`.

## 2. Atomic token rotation on reinstall
Both reinstall paths (`rearmer.Reinstall` and `httpapi handleAgentReinstall`)
now rotate the token atomically: the new hash is written to kv and, if the
SSH apply fails, it is rolled back to the previous value (or the key removed
if there was none). This prevents leaving an agent pushing a token the server
no longer accepts after a failed reinstall.

## Tests
- `TestRearmEscalaTokenPushSiNoRecupera`: native rearm escalates to the token
  push and rotates the token.
- `TestReinstallRotaAtomicYRollback` / `TestReinstallRotaAtomicYRollbackHttpapi`:
  reinstall reverts the hash on SSH failure.
- Existing rearmer/httpapi suites updated for the new escalation chain; all
  pass.

Closes #630.