### PR TITLE
chore: prepare v2.28.14 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
-## [Unreleased]
+## [2.28.14] - 2026-09-08
 
 ### Fixed
 

--- a/README.es.md
+++ b/README.es.md
@@ -97,7 +97,12 @@ enlazada al issue de GitHub que la originó.
 > Están escritas para personas, no como changelog: qué hace la función por ti,
 > no los nombres de las funciones internas.
 
-### Última (v2.28.13)
+### Última (v2.28.14)
+
+- **El plan de canales ya no cuenta tu propia malla como interferencia ni sugiere un canal que cruce a DFS** ([#631](https://github.com/gnacho/netpulse/issues/631)). En el análisis de canales, los BSSID de tus propios puntos de acceso ya no puntúan como vecinos (se excluyen emparejando el prefijo MAC de tus routers monitorizados), y los canales candidatos se validan contra el ancho de la radio: a 40/80/160 MHz solo se ofrecen bloques que no entran en canales DFS (52-64, 100-144). Evita que NetPulse recomiende un canal que ya usan los satélites de tu malla, o un bloque de 80 MHz que cruzaría a banda DFS.
+- **El rearm ahora recupera un agente atascado en bucle de 401** ([#630](https://github.com/gnacho/netpulse/issues/630)). Si un reinicio no trae de vuelta al agente, NetPulse regenera el token del agente y lo aplica en el router (reescribe el `.env` y reinicia) sin reinstalar, así un token desincronizado se arregla en caliente. La rotación de token en un reinstall también es atómica: si el SSH falla, el servidor restaura el token anterior, para que el agente nunca se quede empujando un token que ya no se acepta.
+
+### Anterior (v2.28.13)
 
 - **Una página de Ajustes más limpia, a una columna** ([#627](https://github.com/gnacho/netpulse/issues/627)). La página de Ajustes pasa a una columna única con un índice fijo que te sigue al hacer scroll, así cada tarjeta (Apariencia, Datos y umbrales, Servicios, Red, Integraciones, Administración, Cuenta, Acerca de) ocupa el ancho completo y es más manejable. La tarjeta Apariencia muestra previews reales del tema (claro/oscuro/sistema) y la paleta en dos columnas; el test de velocidad WAN se ejecuta real desde el servidor y rellena descarga/subida en su sitio. Los toggles de Laboratorio aparecen individuales (Orquestación, Canales, Actualizaciones) al activar Labs.
 - **Regenerar el token de un agente sin reinstalar** ([#627](https://github.com/gnacho/netpulse/issues/627)). Al regenerar el token de un dispositivo desde Ajustes, NetPulse ahora lo aplica en el propio router por SSH y reinicia el agente, así el dispositivo sigue reportando **sin reinstalar**. El one-liner de instalación solo hace falta cuando el router no es alcanzable por SSH.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,12 @@ latest improvements, each linked to the GitHub issue that drove it.
 > These are written for people, not changelogs: what the feature does for you,
 > not the function names behind it.
 
-### Latest (v2.28.13)
+### Latest (v2.28.14)
+
+- **The channel plan no longer counts your own mesh as interference, and won't suggest a channel that crosses into DFS** ([#631](https://github.com/gnacho/netpulse/issues/631)). In the channel analysis, the BSSIDs of your own access points no longer score as neighbors (they are excluded by matching the MAC prefix of your monitored routers), and candidate channels are validated against the radio width: at 40/80/160 MHz only blocks that stay out of DFS channels (52-64, 100-144) are offered. This stops NetPulse recommending a channel your mesh satellites already use, or an 80 MHz block that would cross into a DFS band.
+- **Rearm now recovers an agent stuck in a 401 loop** ([#630](https://github.com/gnacho/netpulse/issues/630)). If a restart doesn't bring the agent back, NetPulse regenerates the agent token and applies it on the router (rewrites the env + restarts) without a reinstall, so a token that drifted out of sync is fixed in place. Token rotation on a reinstall is also atomic: if the SSH step fails, the server restores the previous token so the agent never ends up pushing a token that is no longer accepted.
+
+### Earlier (v2.28.13)
 
 - **A cleaner Settings page, one column at a time** ([#627](https://github.com/gnacho/netpulse/issues/627)). The Settings page is now a single column with a sticky index that follows you as you scroll, so each card (Appearance, Data & thresholds, Services, Network, Integrations, Administration, Account, About) is full-width and easier to use. The Appearance card shows real theme previews (light/dark/system) and a two-column palette; the WAN speed test runs a real test from the server and fills download/up in place. Labs toggles appear individually (Orchestration, Channels, Upgrades) once Labs is on.
 - **Regenerate an agent token without reinstalling** ([#627](https://github.com/gnacho/netpulse/issues/627)). When you regenerate a router's agent token from Settings, NetPulse now pushes the new token to the router and restarts the agent in place, so the device keeps reporting without a reinstall. The install one-liner is only needed when the router can't be reached over SSH.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.13",
+  "version": "2.28.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.28.13",
+      "version": "2.28.14",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.13",
+  "version": "2.28.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.13"
+var Version = "2.28.14"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Bump versions to 2.28.14 and update CHANGELOG + README (What's new / Novedades) with the fixes merged since v2.28.13: channel plan own-mesh/DFS (#631) and rearm 401 recovery with atomic token rotation (#630).