### PR TITLE
feat(server): poll RTLPlayground switch console for firmware + uptime + MAC of beacon agents

### DIFF
--- a/server-go/internal/config/config.go
+++ b/server-go/internal/config/config.go
@@ -69,6 +69,13 @@ type Config struct {
 	AgentAutoenroll bool   // AGENT_AUTOENROLL=1: el responder UDP entrega token de alta y /pair lo acepta (#367)
 	Onbox           bool   // NETPULSE_ONBOX=1: modo on-box (Fase 9: config UCI, bootstrap AUTH_PASS)
 	GhostPortEnabled bool  // GHOST_PORT_ENABLED=1: activa alertas de ghost port (#419); default false
+	// RTLConsolePass (NETPULSE_RTL_PASS): contraseña web de la consola de
+	// switches RTLPlayground (KP-9000, #639) para el sondeo HTTP de firmware
+	// y uptime. Default "1234" (la que trae el firmware tras flasheo).
+	RTLConsolePass string
+	// RTLConsolePollSec (NETPULSE_RTL_POLL_S): cadencia del sondeo HTTP de la
+	// consola RTLPlayground en segundos. 0/ausente → 300 (5 min).
+	RTLConsolePollSec int
 }
 
 // LoadDotEnv parsea un .env: KEY=VALUE por línea, '#' comentarios (línea
@@ -420,6 +427,23 @@ func Load(env map[string]string, serverRoot string) (*Config, error) {
 		}
 	}
 
+	// NETPULSE_RTL_PASS / NETPULSE_RTL_POLL_S: sondeo HTTP de la consola de
+	// switches RTLPlayground (KP-9000) para firmware + uptime (#639). La pass
+	// por defecto es la del firmware tras flasheo; la cadencia 300 s (5 min).
+	rtlPass := strings.TrimSpace(env["NETPULSE_RTL_PASS"])
+	if rtlPass == "" {
+		rtlPass = "1234"
+	}
+	rtlPollSec := 300
+	if v, ok := env["NETPULSE_RTL_POLL_S"]; ok && v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			errs.issues = append(errs.issues, issue{"NETPULSE_RTL_POLL_S", "Expected a positive integer"})
+		} else {
+			rtlPollSec = n
+		}
+	}
+
 	if len(errs.issues) > 0 {
 		return nil, &errs
 	}
@@ -490,6 +514,8 @@ func Load(env map[string]string, serverRoot string) (*Config, error) {
 		AgentAutoenroll: agentAutoenroll,
 		Onbox:           onbox,
 		GhostPortEnabled: ghostPortEnabled,
+		RTLConsolePass:   rtlPass,
+		RTLConsolePollSec: rtlPollSec,
 	}, nil
 }
 

--- a/server-go/internal/httpapi/beacon.go
+++ b/server-go/internal/httpapi/beacon.go
@@ -186,6 +186,9 @@ func (s *server) ingestBeacon(src string, raw []byte) {
 			Kind: "external", Interval: beaconIntervalSec,
 			Data: probe.PayloadData{FDB: &probe.FDBData{MACs: macs, Ports: ports}},
 		}
+		// #639: conservar el System (firmware/uptime) también en el datagrama
+		// FDB dedicado, para no perderlo entre FDB y beacon periódico.
+		s.attachRTLConsole(p.Slug, src, fdbPayload)
 		s.agents.Ingest(fdbPayload)
 		s.persistAgentState(p.Slug, s.agents.Snapshot(p.Slug))
 		s.beaconSeqNote(p.Slug, p.Seq)
@@ -248,6 +251,10 @@ func (s *server) ingestBeacon(src string, raw []byte) {
 		Interval: beaconIntervalSec,
 		Data:     probe.PayloadData{FDB: &probe.FDBData{MACs: macs, Ports: ports}},
 	}
+	// #639: el beacon no lleva firmware/uptime; el server los obtiene de la
+	// consola HTTP del switch (poll cacheado) y los adjunta como System para
+	// que polledFromAgent los convierta en board/uptimeSec.
+	s.attachRTLConsole(p.Slug, src, pl)
 	// Fallback de cambios de link por delta entre beacons (#291): si el
 	// firmware no manda eventos, el cambio se detecta comparando el payload
 	// anterior. Con eventos, el título idéntico hace que el dedup del engine
@@ -474,6 +481,12 @@ func (s *server) beaconSeqNote(slug string, seq uint32) {
 	// boot, así que un salto a 1 (o 0) desde uno mayor = reinicio del
 	// switch. El wrap de uint32 daría el mismo salto una vez cada 136 años.
 	if had && seq <= 1 && old > 1 {
+		// #639: un reboot invalida el bootUnix cacheado de la consola (el
+		// contador de segundos del switch volvió a 0); el próximo beacon
+		// re-sincroniza con un poll nuevo.
+		if s.rtlConsole != nil {
+			s.rtlConsole.invalidate(slug)
+		}
 		if eng := s.alertsEngine(); eng != nil {
 			eng.Emit(alerts.AlertEvent{
 				ID:       fmt.Sprintf("beacon-reboot-%s-%d", slug, time.Now().UnixMilli()),

--- a/server-go/internal/httpapi/rtlconsole.go
+++ b/server-go/internal/httpapi/rtlconsole.go
@@ -1,0 +1,248 @@
+// rtlconsole.go — #639: sondeo HTTP de la consola de switches RTLPlayground
+// (Keephome KP-9000 con firmware FreeSwitchOS/RTLPlayground) para poblar
+// firmware + uptime en routers cuyo agente es external (beacon UDP, #291).
+//
+// El datagrama del beacon no puede crecer (el banco de código del 8051 está
+// lleno), así que el server consulta la consola web del propio switch con
+// cadencia lenta. La web sirve UNA petición a la vez (uIP/8051), por eso el
+// poll es serial por switch y nunca en paralelo (InFlight).
+//
+// El resultado se cachea por slug con {firmware, bootUnix}: a partir del
+// bootUnix el uptime se deriva del reloj del server entre polls (no hace
+// falta re-consultar cada 30 s), y el poll solo re-sincroniza bootUnix con
+// la cadencia configurada (NETPULSE_RTL_POLL_S, default 300).
+package httpapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gnacho/netpulse/agent/probe"
+)
+
+// rtlConsoleEntry: resultado del último poll OK de la consola del switch.
+type rtlConsoleEntry struct {
+	Firmware  string    // sw_ver de /information.json ("v0.1.0-e1fa080-dirty")
+	Model     string    // hw_ver ("keepLink KP-9000-9XHML-X V3.1")
+	BootUnix  time.Time // now - uptimeSec del poll; el uptime se deriva de aquí
+	PolledAt  time.Time // cuándo se hizo el poll (para la cadencia)
+	InFlight  bool      // hay un poll en curso (serial por slug)
+	FailedAt  time.Time // último fallo (backoff para no martillear un host no-RTL)
+	FailCount int
+}
+
+// rtlConsoleInfo es la respuesta de /information.json del firmware (solo los
+// campos que necesitamos; el JSON tiene más).
+type rtlConsoleInfo struct {
+	SwVer string `json:"sw_ver"`
+	HwVer string `json:"hw_ver"`
+}
+
+// rtlConsoleCache: estado del sondeo por slug. Protegido por su mutex.
+type rtlConsoleCache struct {
+	mu   sync.Mutex
+	pass string
+	sec  int // cadencia en segundos
+	byID map[string]*rtlConsoleEntry
+}
+
+func newRtlConsoleCache(pass string, pollSec int) *rtlConsoleCache {
+	if pollSec <= 0 {
+		pollSec = 300
+	}
+	if pass == "" {
+		pass = "1234"
+	}
+	return &rtlConsoleCache{pass: pass, sec: pollSec, byID: map[string]*rtlConsoleEntry{}}
+}
+
+// snapshot devuelve la entrada cacheada para adjuntar System al payload del
+// beacon. Si la entrada es vieja o no existe y no hay poll en curso, lanza el
+// poll en background (no bloquea el handler del beacon). Devuelve nil hasta
+// que el primer poll tenga éxito (el beacon de turno no lleva System).
+func (c *rtlConsoleCache) snapshot(slug, host string) *rtlConsoleEntry {
+	now := time.Now()
+	c.mu.Lock()
+	e := c.byID[slug]
+	if e == nil {
+		e = &rtlConsoleEntry{}
+		c.byID[slug] = e
+	}
+	needPoll := e.Firmware == "" || now.Sub(e.PolledAt) >= time.Duration(c.sec)*time.Second
+	// Backoff tras fallos: reintentar como mucho cada max(sec, 15 min) si el
+	// host no habla el protocolo (login fallido), para no martillearlo.
+	if needPoll && e.FailCount > 0 && now.Sub(e.FailedAt) < 15*time.Minute {
+		needPoll = false
+	}
+	if needPoll && !e.InFlight {
+		e.InFlight = true
+		c.mu.Unlock()
+		go c.poll(slug, host)
+		c.mu.Lock()
+	}
+	out := e
+	c.mu.Unlock()
+	if out.Firmware == "" {
+		return nil
+	}
+	return out
+}
+
+// invalidate marca la entrada para re-poll inmediato (reboot detectado por el
+// seq del beacon: el bootUnix cacheado ya no es válido).
+func (c *rtlConsoleCache) invalidate(slug string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if e := c.byID[slug]; e != nil {
+		e.PolledAt = time.Time{}
+	}
+}
+
+// poll consulta la consola del switch (login + /information.json + /cmd time)
+// y guarda el resultado. Serial por slug (InFlight) y con timeouts cortos:
+// la web del firmware atiende una conexión cada vez.
+func (c *rtlConsoleCache) poll(slug, host string) {
+	entry, err := c.fetch(host)
+	c.mu.Lock()
+	e := c.byID[slug]
+	if e == nil {
+		e = &rtlConsoleEntry{}
+		c.byID[slug] = e
+	}
+	e.InFlight = false
+	if err != nil {
+		e.FailCount++
+		e.FailedAt = time.Now()
+		c.mu.Unlock()
+		log.Printf("[netpulse:rtl] poll %s (%s) falló: %v", slug, host, err)
+		return
+	}
+	e.Firmware = entry.Firmware
+	e.Model = entry.Model
+	e.BootUnix = entry.BootUnix
+	e.PolledAt = time.Now()
+	e.FailCount = 0
+	c.mu.Unlock()
+}
+
+// fetch hace login en la consola y lee /information.json (sw_ver/hw_ver) y el
+// uptime por POST /cmd "time". Devuelve bootUnix = now - uptimeSec.
+func (c *rtlConsoleCache) fetch(host string) (*rtlConsoleEntry, error) {
+	base := "http://" + host
+	// No seguir el 302 del login (Location: index.html): necesitamos la
+	// cookie del Set-Cookie y la respuesta es el propio redirect.
+	client := &http.Client{
+		Timeout: 8 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	// 1) login: POST /login pwd=<pass> → 302 + Set-Cookie: session=...
+	form := url.Values{"pwd": {c.pass}}
+	req, err := http.NewRequest(http.MethodPost, base+"/login", strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	cookie := ""
+	for _, ck := range resp.Cookies() {
+		if ck.Name == "session" && ck.Value != "" {
+			cookie = ck.Name + "=" + ck.Value
+			break
+		}
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusFound && resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("login HTTP %d", resp.StatusCode)
+	}
+	if cookie == "" {
+		return nil, fmt.Errorf("login sin cookie de sesión")
+	}
+
+	// 2) /information.json → sw_ver + hw_ver
+	infoReq, err := http.NewRequest(http.MethodGet, base+"/information.json", nil)
+	if err != nil {
+		return nil, err
+	}
+	infoReq.Header.Set("Cookie", cookie)
+	infoResp, err := client.Do(infoReq)
+	if err != nil {
+		return nil, err
+	}
+	infoBody, _ := io.ReadAll(io.LimitReader(infoResp.Body, 4096))
+	infoResp.Body.Close()
+	if infoResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("information.json HTTP %d", infoResp.StatusCode)
+	}
+	var info rtlConsoleInfo
+	if err := json.Unmarshal(infoBody, &info); err != nil {
+		return nil, fmt.Errorf("information.json inválido: %w", err)
+	}
+
+	// 3) POST /cmd "time" → uptime en segundos (hex, p. ej. "0x00028e9d").
+	cmdReq, err := http.NewRequest(http.MethodPost, base+"/cmd", strings.NewReader("time"))
+	if err != nil {
+		return nil, err
+	}
+	cmdReq.Header.Set("Cookie", cookie)
+	cmdResp, err := client.Do(cmdReq)
+	if err != nil {
+		return nil, err
+	}
+	cmdBody, _ := io.ReadAll(io.LimitReader(cmdResp.Body, 256))
+	cmdResp.Body.Close()
+	if cmdResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("/cmd time HTTP %d", cmdResp.StatusCode)
+	}
+	upHex := strings.TrimSpace(string(cmdBody))
+	upHex = strings.TrimPrefix(upHex, "0x")
+	upHex = strings.TrimPrefix(upHex, "0X")
+	upSec, err := strconv.ParseUint(upHex, 16, 32)
+	if err != nil {
+		return nil, fmt.Errorf("/cmd time no es un contador hex (%q): %w", strings.TrimSpace(string(cmdBody)), err)
+	}
+
+	now := time.Now()
+	return &rtlConsoleEntry{
+		Firmware: info.SwVer, Model: info.HwVer,
+		BootUnix: now.Add(-time.Duration(upSec) * time.Second),
+	}, nil
+}
+
+// attachSystem adjunta la sección System (board + uptime) al payload de un
+// beacon periódico si hay datos de consola cacheados. Es el punto de
+// inyección: polledFromAgent mapea System.Board→board y SysInfo.Uptime→
+// uptimeSec, y buildRouter pinta Firmware/Uptime sin cambios en el front.
+func (s *server) attachRTLConsole(slug, host string, pl *probe.Payload) {
+	if s.rtlConsole == nil || pl == nil {
+		return
+	}
+	e := s.rtlConsole.snapshot(slug, host)
+	if e == nil {
+		return
+	}
+	// Board.Release es un struct anónimo; se rellena campo a campo igual que
+	// boardWithDesc en los tests de buildRouter.
+	b := &probe.BoardInfo{}
+	b.Model = e.Model
+	b.Release.Description = "RTLPlayground " + e.Firmware
+	sd := &probe.SystemData{
+		Board:   b,
+		SysInfo: &probe.SysInfo{Uptime: time.Since(e.BootUnix).Seconds()},
+	}
+	pl.Data.System = sd
+}

--- a/server-go/internal/httpapi/rtlconsole.go
+++ b/server-go/internal/httpapi/rtlconsole.go
@@ -194,10 +194,12 @@ func (c *rtlConsoleCache) fetch(host string) (*rtlConsoleEntry, error) {
 	}
 
 	// 3) POST /cmd "time" → uptime en segundos (hex, p. ej. "0x00028e9d").
+	// El firmware exige Content-Type en todo POST (sin él responde 404).
 	cmdReq, err := http.NewRequest(http.MethodPost, base+"/cmd", strings.NewReader("time"))
 	if err != nil {
 		return nil, err
 	}
+	cmdReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	cmdReq.Header.Set("Cookie", cookie)
 	cmdResp, err := client.Do(cmdReq)
 	if err != nil {

--- a/server-go/internal/httpapi/rtlconsole.go
+++ b/server-go/internal/httpapi/rtlconsole.go
@@ -32,6 +32,7 @@ import (
 type rtlConsoleEntry struct {
 	Firmware  string    // sw_ver de /information.json ("v0.1.0-e1fa080-dirty")
 	Model     string    // hw_ver ("keepLink KP-9000-9XHML-X V3.1")
+	MAC       string    // mac_address (la que el switch usa en runtime)
 	BootUnix  time.Time // now - uptimeSec del poll; el uptime se deriva de aquí
 	PolledAt  time.Time // cuándo se hizo el poll (para la cadencia)
 	InFlight  bool      // hay un poll en curso (serial por slug)
@@ -44,6 +45,7 @@ type rtlConsoleEntry struct {
 type rtlConsoleInfo struct {
 	SwVer string `json:"sw_ver"`
 	HwVer string `json:"hw_ver"`
+	Mac   string `json:"mac_address"`
 }
 
 // rtlConsoleCache: estado del sondeo por slug. Protegido por su mutex.
@@ -127,6 +129,7 @@ func (c *rtlConsoleCache) poll(slug, host string) {
 	}
 	e.Firmware = entry.Firmware
 	e.Model = entry.Model
+	e.MAC = entry.MAC
 	e.BootUnix = entry.BootUnix
 	e.PolledAt = time.Now()
 	e.FailCount = 0
@@ -220,15 +223,16 @@ func (c *rtlConsoleCache) fetch(host string) (*rtlConsoleEntry, error) {
 
 	now := time.Now()
 	return &rtlConsoleEntry{
-		Firmware: info.SwVer, Model: info.HwVer,
+		Firmware: info.SwVer, Model: info.HwVer, MAC: info.Mac,
 		BootUnix: now.Add(-time.Duration(upSec) * time.Second),
 	}, nil
 }
 
-// attachSystem adjunta la sección System (board + uptime) al payload de un
-// beacon periódico si hay datos de consola cacheados. Es el punto de
-// inyección: polledFromAgent mapea System.Board→board y SysInfo.Uptime→
-// uptimeSec, y buildRouter pinta Firmware/Uptime sin cambios en el front.
+// attachSystem adjunta la sección System (board + uptime + MAC) al payload de
+// un beacon periódico si hay datos de consola cacheados. Es el punto de
+// inyección: polledFromAgent mapea System.Board→board, SysInfo.Uptime→
+// uptimeSec y BridgeMAC→brMac, y buildRouter pinta Firmware/Uptime/MAC sin
+// cambios en el front.
 func (s *server) attachRTLConsole(slug, host string, pl *probe.Payload) {
 	if s.rtlConsole == nil || pl == nil {
 		return
@@ -243,8 +247,9 @@ func (s *server) attachRTLConsole(slug, host string, pl *probe.Payload) {
 	b.Model = e.Model
 	b.Release.Description = "RTLPlayground " + e.Firmware
 	sd := &probe.SystemData{
-		Board:   b,
-		SysInfo: &probe.SysInfo{Uptime: time.Since(e.BootUnix).Seconds()},
+		Board:      b,
+		SysInfo:    &probe.SysInfo{Uptime: time.Since(e.BootUnix).Seconds()},
+		BridgeMAC:  strings.ToUpper(e.MAC),
 	}
 	pl.Data.System = sd
 }

--- a/server-go/internal/httpapi/rtlconsole_test.go
+++ b/server-go/internal/httpapi/rtlconsole_test.go
@@ -1,0 +1,154 @@
+// rtlconsole_test.go — #639: sondeo HTTP de la consola RTLPlayground.
+// El test levanta un httptest que emula el firmware (login por POST /login
+// con Set-Cookie session, /information.json con sw_ver/hw_ver, /cmd time con
+// el contador en hex) y verifica fetch/snapshot/attach contra él.
+package httpapi
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/agent/probe"
+)
+
+// newRTLConsoleServer: emula la consola RTLPlayground. uptimeSec es el valor
+// que devuelve /cmd time (en segundos); el servidor lo convierte a "0x…".
+func newRTLConsoleServer(t *testing.T, uptimeSec uint64) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil || r.Form.Get("pwd") != "1234" {
+			http.Error(w, "bad", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Set-Cookie", "session=test-session-abc; SameSite=Strict")
+		w.Header().Set("Location", "index.html")
+		w.WriteHeader(http.StatusFound)
+	})
+	mux.HandleFunc("/information.json", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.Header.Get("Cookie"), "session=") {
+			http.Error(w, "no auth", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"sw_ver":"v0.1.0-e1fa080-dirty","hw_ver":"keepLink KP-9000-9XHML-X V3.1"}`)
+	})
+	mux.HandleFunc("/cmd", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.Header.Get("Cookie"), "session=") {
+			http.Error(w, "no auth", http.StatusUnauthorized)
+			return
+		}
+		body := make([]byte, 32)
+		n, _ := r.Body.Read(body)
+		if strings.TrimSpace(string(body[:n])) != "time" {
+			http.Error(w, "unknown command", http.StatusBadRequest)
+			return
+		}
+		fmt.Fprintf(w, "0x%08x\n", uptimeSec)
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestRtlConsoleFetch(t *testing.T) {
+	srv := newRTLConsoleServer(t, 167581) // ~46.5 h
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	c := newRtlConsoleCache("1234", 300)
+	e, err := c.fetch(host)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if e.Firmware != "v0.1.0-e1fa080-dirty" {
+		t.Fatalf("Firmware = %q, esperaba v0.1.0-e1fa080-dirty", e.Firmware)
+	}
+	if e.Model != "keepLink KP-9000-9XHML-X V3.1" {
+		t.Fatalf("Model = %q", e.Model)
+	}
+	// bootUnix ≈ now - 167581s
+	age := time.Since(e.BootUnix)
+	if age < 167580*time.Second || age > 167582*time.Second {
+		t.Fatalf("BootUnix no cuadra con uptime 167581s: age=%v", age)
+	}
+}
+
+func TestRtlConsoleSnapshotAttachesSystem(t *testing.T) {
+	srv := newRTLConsoleServer(t, 3600)
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	c := newRtlConsoleCache("1234", 300)
+	// snapshot dispara el poll en background; esperamos a que haya datos.
+	var e *rtlConsoleEntry
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		e = c.snapshot("switch16", host)
+		if e != nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if e == nil {
+		t.Fatal("snapshot no produjo datos en 3 s")
+	}
+
+	// attach sobre un payload de beacon: System debe llevar board+uptime.
+	s := &server{rtlConsole: c}
+	pl := &probe.Payload{Data: probe.PayloadData{}}
+	s.attachRTLConsole("switch16", host, pl)
+	if pl.Data.System == nil {
+		t.Fatal("attach no adjuntó System")
+	}
+	if pl.Data.System.Board == nil || pl.Data.System.Board.Release.Description != "RTLPlayground v0.1.0-e1fa080-dirty" {
+		t.Fatalf("Board inesperado: %+v", pl.Data.System.Board)
+	}
+	// uptime derivado ≈ 1h (3600 s) ± margen del poll.
+	if pl.Data.System.SysInfo == nil || pl.Data.System.SysInfo.Uptime < 3590 || pl.Data.System.SysInfo.Uptime > 3700 {
+		t.Fatalf("Uptime inesperado: %+v", pl.Data.System.SysInfo)
+	}
+}
+
+func TestRtlConsoleInvalidaTrasReboot(t *testing.T) {
+	srv := newRTLConsoleServer(t, 3600)
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	c := newRtlConsoleCache("1234", 300)
+	var e *rtlConsoleEntry
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		e = c.snapshot("switch16", host)
+		if e != nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if e == nil {
+		t.Fatal("snapshot inicial sin datos")
+	}
+	c.invalidate("switch16")
+	c.mu.Lock()
+	polledAt := c.byID["switch16"].PolledAt
+	c.mu.Unlock()
+	if !polledAt.IsZero() {
+		t.Fatalf("invalidate no reseteó PolledAt: %v", polledAt)
+	}
+}
+
+func TestRtlConsoleFetchLoginFalloNoAdjunta(t *testing.T) {
+	// El servidor rechaza el login (pass distinta): fetch devuelve error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	c := newRtlConsoleCache("1234", 300)
+	if _, err := c.fetch(host); err == nil {
+		t.Fatal("fetch debería fallar con login 401")
+	}
+}

--- a/server-go/internal/httpapi/rtlconsole_test.go
+++ b/server-go/internal/httpapi/rtlconsole_test.go
@@ -42,6 +42,11 @@ func newRTLConsoleServer(t *testing.T, uptimeSec uint64) *httptest.Server {
 			http.Error(w, "no auth", http.StatusUnauthorized)
 			return
 		}
+		// El firmware exige Content-Type en todo POST (sin él responde 404).
+		if r.Header.Get("Content-Type") == "" {
+			http.Error(w, "no content type", http.StatusNotFound)
+			return
+		}
 		body := make([]byte, 32)
 		n, _ := r.Body.Read(body)
 		if strings.TrimSpace(string(body[:n])) != "time" {

--- a/server-go/internal/httpapi/rtlconsole_test.go
+++ b/server-go/internal/httpapi/rtlconsole_test.go
@@ -35,7 +35,7 @@ func newRTLConsoleServer(t *testing.T, uptimeSec uint64) *httptest.Server {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"sw_ver":"v0.1.0-e1fa080-dirty","hw_ver":"keepLink KP-9000-9XHML-X V3.1"}`)
+		fmt.Fprintf(w, `{"sw_ver":"v0.1.0-e1fa080-dirty","hw_ver":"keepLink KP-9000-9XHML-X V3.1","mac_address":"78:d8:00:32:31:49"}`)
 	})
 	mux.HandleFunc("/cmd", func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.Header.Get("Cookie"), "session=") {
@@ -73,6 +73,9 @@ func TestRtlConsoleFetch(t *testing.T) {
 	}
 	if e.Model != "keepLink KP-9000-9XHML-X V3.1" {
 		t.Fatalf("Model = %q", e.Model)
+	}
+	if e.MAC != "78:d8:00:32:31:49" {
+		t.Fatalf("MAC = %q, esperaba 78:d8:00:32:31:49", e.MAC)
 	}
 	// bootUnix ≈ now - 167581s
 	age := time.Since(e.BootUnix)
@@ -114,6 +117,10 @@ func TestRtlConsoleSnapshotAttachesSystem(t *testing.T) {
 	// uptime derivado ≈ 1h (3600 s) ± margen del poll.
 	if pl.Data.System.SysInfo == nil || pl.Data.System.SysInfo.Uptime < 3590 || pl.Data.System.SysInfo.Uptime > 3700 {
 		t.Fatalf("Uptime inesperado: %+v", pl.Data.System.SysInfo)
+	}
+	// BridgeMAC normalizada a mayúsculas (formato canónico del resto de la app).
+	if pl.Data.System.BridgeMAC != "78:D8:00:32:31:49" {
+		t.Fatalf("BridgeMAC = %q, esperaba 78:D8:00:32:31:49", pl.Data.System.BridgeMAC)
 	}
 }
 

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -155,6 +155,10 @@ type server struct {
 	beaconCandMu sync.Mutex
 	beaconCand   map[string]beaconCandidate
 
+	// rtlConsole (#639): sondeo HTTP de la consola de switches RTLPlayground
+	// (firmware + uptime) para agentes external/beacon. nil si desactivado.
+	rtlConsole *rtlConsoleCache
+
 	// Ventana de frescura del `ts` del agente (anti-replay, auditoría #2).
 	maxTsDrift time.Duration
 
@@ -257,6 +261,12 @@ func NewHandler(d Deps) http.Handler {
 		} else {
 			log.Printf("[netpulse] beacon UDP escuchando en %s", la)
 		}
+	}
+	// #639: sondeo HTTP de consola RTLPlayground para beacons external. El
+	// caché se crea siempre que haya config (pass/cadencia con defaults);
+	// solo hace red cuando un beacon de un slug sin datos (o caducado) llega.
+	if d.Config != nil {
+		s.rtlConsole = newRtlConsoleCache(d.Config.RTLConsolePass, d.Config.RTLConsolePollSec)
 	}
 	mode := d.Adapter.Mode()
 


### PR DESCRIPTION
## What

External beacon agents (RTLPlayground on a Keephome KP-9000, #291) report port/FDB state every 30 s but never carry firmware, uptime or MAC, so those routers showed no firmware, `0d 0h` uptime and no MAC in the UI even though the switch answers over its web console.

This adds a server-side poll of the switch HTTP console that attaches a `System` section to the periodic beacon payload. `polledFromAgent` already maps `System.Board`/`SysInfo.Uptime`/`BridgeMAC` to the router fields, and `buildRouter` renders them - no frontend change needed (RouterInfo already shows Firmware/Uptime/MAC rows).

## How

- **`internal/config`**: `NETPULSE_RTL_PASS` (default `1234`, the firmware's web password) and `NETPULSE_RTL_POLL_S` (default 300).
- **`internal/httpapi/rtlconsole.go`**: cached per-slug console poll (login cookie → `/information.json` for `sw_ver`/`hw_ver`/`mac_address` → `POST /cmd time` for the uptime counter). Stores `{firmware, model, mac, bootUnix}` and derives uptime from the clock between polls, so no extra HTTP per beacon. Polls are serial per switch (the firmware serves one request at a time) and skipped silently on hosts that do not speak the protocol (backoff on failures).
- **`internal/httpapi/beacon.go`**: attaches the cached console info as `System` when building the periodic and FDB-dedicated beacon payloads; a beacon `seq` reset invalidates the cache so the next poll re-syncs after a reboot.
- MAC is uppercased to the canonical format used across the app.

## Verification

- Unit tests cover the console client (login/cookie, `information.json`, hex uptime), cache snapshot/invalidate, and the System attachment (`rtlconsole_test.go`).
- Verified against the real switch16: `/api/routers` returns `firmware: "RTLPlayground v0.1.0-e1fa080-dirty"`, `uptime` growing from `bootUnix`, and `mac` populated. No frontend change required.

Closes #639.
