### PR TITLE
fix(server): don't persist zero port samples for external beacon agents

### DIFF
--- a/server-go/internal/adapters/agent.go
+++ b/server-go/internal/adapters/agent.go
@@ -681,7 +681,13 @@ func (l *Live) polledFromAgent(cfg RouterConfig, p *probe.Payload) *routerPolled
 	// congelados dispara alertas fantasma ("zero bytes" que solo es espera
 	// del siguiente push).
 	if freshPayload {
-		l.recordPortSamples(cfg.ID, out.ports)
+		// Los pushers external/beacon persisten sus propias series con
+		// contadores de tramas en recordBeaconPortSamples (httpapi/beacon.go);
+		// los EthPort de su payload no llevan contadores, así que pasar por
+		// recordPortSamples escribiría filas a 0 intercaladas con las buenas.
+		if out.agentKind != "external" {
+			l.recordPortSamples(cfg.ID, out.ports)
+		}
 		// #551: tráfico por cliente (nlbwmon preferente, hostapd fallback).
 		// now = ts del payload (no el reloj del server) para que el dt del
 		// delta sea el intervalo real entre pushes del agente.

--- a/server-go/internal/adapters/external_port_samples_test.go
+++ b/server-go/internal/adapters/external_port_samples_test.go
@@ -1,0 +1,54 @@
+package adapters
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/agent/probe"
+	"github.com/gnacho/netpulse/server-go/internal/db"
+)
+
+// #639/#641: los pushers external/beacon persisten sus propias series de
+// puerto con contadores de tramas (recordBeaconPortSamples en httpapi); sus
+// EthPort no llevan contadores, así que polledFromAgent NO debe pasar por
+// recordPortSamples (escribiría filas a 0 intercaladas con las buenas). Un
+// agente nativo SÍ debe persistir sus samples.
+func TestPolledFromAgentExternalNoPortSamples(t *testing.T) {
+	d := openLiveTestDB(t)
+	l := NewLive(nil, d, nil, nil)
+
+	ports := []probe.EthPort{{ID: "lan1", Label: "Port 1", Up: true, Speed: "1G"}}
+
+	// Payload external (beacon): con FDB.Ports pero sin contadores.
+	ext := &probe.Payload{
+		Router: "switch16", Ts: time.Now().Unix(), Kind: "external", Interval: 30,
+		Data: probe.PayloadData{FDB: &probe.FDBData{Ports: ports}},
+	}
+	_ = l.polledFromAgent(RouterConfig{ID: "switch16", Host: "192.168.1.6"}, ext)
+	nExt := countPortSamples(t, d, "switch16")
+	if nExt != 0 {
+		t.Fatalf("external persistió %d port samples, esperaba 0 (los persiste el beacon)", nExt)
+	}
+
+	// Payload nativo: debe persistir.
+	nat := &probe.Payload{
+		Router: "rt1", Ts: time.Now().Unix(), Kind: "native",
+		Data: probe.PayloadData{FDB: &probe.FDBData{Ports: ports}},
+	}
+	_ = l.polledFromAgent(RouterConfig{ID: "rt1", Host: "192.168.1.2"}, nat)
+	nNat := countPortSamples(t, d, "rt1")
+	if nNat == 0 {
+		t.Fatalf("agente nativo no persistió port samples, esperaba >0")
+	}
+}
+
+func countPortSamples(t *testing.T, d *db.DB, routerID string) int {
+	t.Helper()
+	var n int
+	if err := d.QueryRow(
+		"SELECT COUNT(*) FROM port_series_raw WHERE router_id = ?", routerID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count %s: %v", routerID, err)
+	}
+	return n
+}


### PR DESCRIPTION
## What

External beacon agents (RTLPlayground on the KP-9000) persist their own per-port series with frame counters in `recordBeaconPortSamples` (httpapi/beacon.go). But their payload also flows through `polledFromAgent` like a native agent, whose `recordPortSamples` wrote the beacon `EthPort`s - which carry **no** byte/frame counters - as interleaved zero rows between the good beacon samples. This flattened the port series with spurious 0 bps/fps every push (~30 s).

## Fix

Skip `recordPortSamples` when `agentKind == "external"` (beacon/scraper); keep `portMon.Observe`, which detects link changes from the same ports. Native agents keep persisting as before.

Adds `TestPolledFromAgentExternalNoPortSamples`: an external payload persists nothing through this path, a native one persists rows.

## Context

Required so the upcoming frames/s support (#641) has clean series once the firmware beacon reports real counters (the companion firmware fix reads the MIB counter from `STAT_V_LOW`).

Refs #641.
