### PR TITLE
feat(server+ui): show port traffic as frames/s for beacon agents without byte counters

### DIFF
--- a/app/src/components/routers/PortPanel.tsx
+++ b/app/src/components/routers/PortPanel.tsx
@@ -317,7 +317,13 @@ export function PortPanel({ router, extras, className }: { router: Router; extra
 
       {/* Per-port traffic history (issue #302) */}
       {ports.some((p) => p.up) && !isDemo && (
-        <PortSeriesChart routerId={router.id} portId={ports.find((p) => p.up)!.id} />
+        <PortSeriesChart
+          routerId={router.id}
+          portId={ports.find((p) => p.up)!.id}
+          // #641: managed-switch/external (beacons RTLPlayground, SNMP) no
+          // reportan byte counters → la serie se muestra en frames/s.
+          unit={router.type === 'managed-switch' || router.type === 'external' ? 'fps' : 'bps'}
+        />
       )}
     </section>
   )

--- a/app/src/components/routers/PortSeriesChart.tsx
+++ b/app/src/components/routers/PortSeriesChart.tsx
@@ -9,6 +9,8 @@ interface PortPoint {
   txErrors: number
   rxBps: number
   txBps: number
+  rxFps: number
+  txFps: number
   speedMbps: number
 }
 
@@ -29,19 +31,26 @@ function rangeToSeconds(range: Range): number {
   }
 }
 
-function fmtBps(bps: number): string {
-  if (bps >= 1e9) return `${(bps / 1e9).toFixed(1)} Gbps`
-  if (bps >= 1e6) return `${(bps / 1e6).toFixed(1)} Mbps`
-  if (bps >= 1e3) return `${Math.round(bps / 1e3)} kbps`
-  return `${Math.round(bps)} bps`
+/** Formatea una tasa: bps → bps/kbps/Mbps/Gbps; fps → fps/kfps. */
+function fmtRate(unit: 'bps' | 'fps', v: number): string {
+  if (unit === 'bps') {
+    if (v >= 1e9) return `${(v / 1e9).toFixed(1)} Gbps`
+    if (v >= 1e6) return `${(v / 1e6).toFixed(1)} Mbps`
+    if (v >= 1e3) return `${Math.round(v / 1e3)} kbps`
+    return `${Math.round(v)} bps`
+  }
+  if (v >= 1e3) return `${(v / 1e3).toFixed(1)} kfps`
+  return `${Math.round(v)} fps`
 }
 
-function Sparkline({ points, colorKey }: { points: PortPoint[]; colorKey: 'rxBps' | 'txBps' }) {
+function Sparkline({ points, colorKey, unit }: { points: PortPoint[]; colorKey: 'rx' | 'tx'; unit: 'bps' | 'fps' }) {
   if (points.length < 2) return null
   const W = 200
   const H = 40
   const PAD = 2
-  const values = points.map((p) => p[colorKey])
+  const field = (colorKey === 'rx' ? 'rxBps' : 'txBps') as 'rxBps' | 'txBps'
+  const fpsField = (colorKey === 'rx' ? 'rxFps' : 'txFps') as 'rxFps' | 'txFps'
+  const values = points.map((p) => (unit === 'fps' ? p[fpsField] : p[field]))
   const max = Math.max(...values, 1)
   const stepX = (W - PAD * 2) / (values.length - 1)
   const path = values
@@ -52,8 +61,8 @@ function Sparkline({ points, colorKey }: { points: PortPoint[]; colorKey: 'rxBps
     })
     .join(' ')
   const fillPath = path + ` L${(W - PAD).toFixed(1)},${H - PAD} L${PAD},${H - PAD} Z`
-  const color = colorKey === 'rxBps' ? '#3b82f6' : '#10b981'
-  const fillColor = colorKey === 'rxBps' ? 'rgba(59,130,246,0.12)' : 'rgba(16,185,129,0.12)'
+  const color = colorKey === 'rx' ? '#3b82f6' : '#10b981'
+  const fillColor = colorKey === 'rx' ? 'rgba(59,130,246,0.12)' : 'rgba(16,185,129,0.12)'
   return (
     <svg width={W} height={H} viewBox={`0 0 ${W} ${H}`} className="block" aria-hidden="true">
       <path d={fillPath} fill={fillColor} />
@@ -62,7 +71,16 @@ function Sparkline({ points, colorKey }: { points: PortPoint[]; colorKey: 'rxBps
   )
 }
 
-export function PortSeriesChart({ routerId, portId }: { routerId: string; portId: string }) {
+export function PortSeriesChart({
+  routerId,
+  portId,
+  unit = 'bps',
+}: {
+  routerId: string
+  portId: string
+  /** 'bps' para fuentes con byte counters (OpenWrt); 'fps' para beacons/SNMP sin bytes (issue #641). */
+  unit?: 'bps' | 'fps'
+}) {
   const { t } = useTranslation()
   const [range, setRange] = useState<Range>('24h')
   const [data, setData] = useState<PortPoint[]>([])
@@ -92,8 +110,8 @@ export function PortSeriesChart({ routerId, portId }: { routerId: string; portId
   }, [fetchData])
 
   const hasData = data.length > 1
-  const peakRx = hasData ? Math.max(...data.map((p) => p.rxBps)) : 0
-  const peakTx = hasData ? Math.max(...data.map((p) => p.txBps)) : 0
+  const peakRx = hasData ? Math.max(...data.map((p) => (unit === 'fps' ? p.rxFps : p.rxBps))) : 0
+  const peakTx = hasData ? Math.max(...data.map((p) => (unit === 'fps' ? p.txFps : p.txBps))) : 0
 
   return (
     <div className="mt-3 rounded-xl border border-border/60 bg-elevated/30 p-3">
@@ -122,13 +140,13 @@ export function PortSeriesChart({ routerId, portId }: { routerId: string; portId
         <div className="space-y-1">
           <div className="flex items-center gap-2">
             <span className="w-5 text-[10px] font-medium text-blue-500">RX</span>
-            <Sparkline points={data} colorKey="rxBps" />
-            <span className="ml-auto font-mono text-[10px] text-text-muted">{fmtBps(peakRx)}</span>
+            <Sparkline points={data} colorKey="rx" unit={unit} />
+            <span className="ml-auto font-mono text-[10px] text-text-muted">{fmtRate(unit, peakRx)}</span>
           </div>
           <div className="flex items-center gap-2">
             <span className="w-5 text-[10px] font-medium text-emerald-500">TX</span>
-            <Sparkline points={data} colorKey="txBps" />
-            <span className="ml-auto font-mono text-[10px] text-text-muted">{fmtBps(peakTx)}</span>
+            <Sparkline points={data} colorKey="tx" unit={unit} />
+            <span className="ml-auto font-mono text-[10px] text-text-muted">{fmtRate(unit, peakTx)}</span>
           </div>
         </div>
       ) : (

--- a/server-go/internal/portseries/portseries.go
+++ b/server-go/internal/portseries/portseries.go
@@ -40,7 +40,16 @@ type PortPoint struct {
 	TxErrors  uint64    `json:"txErrors"`
 	RxBps     float64   `json:"rxBps"`
 	TxBps     float64   `json:"txBps"`
+	// RxFps/TxFps: frames per second derived from the cumulative frame
+	// counters (issue #641). Devices without byte counters (RTLPlayground
+	// beacon agents) report traffic this way; bps stays 0 for them.
+	RxFps     float64   `json:"rxFps"`
+	TxFps     float64   `json:"txFps"`
 	SpeedMbps int       `json:"speedMbps"`
+	// RxFrames/TxFrames: cumulative counters used to derive fps; not part of
+	// the JSON contract.
+	RxFrames uint64 `json:"-"`
+	TxFrames uint64 `json:"-"`
 }
 
 // SchemaSQL returns the DDL for the port series tables.
@@ -165,7 +174,7 @@ func (s *Store) GetSeries(routerID, portID string, from, to time.Time, resolutio
 
 func (s *Store) getRaw(routerID, portID string, fromMs, toMs int64) ([]PortPoint, error) {
 	rows, err := s.db.Query(`SELECT ts, rx_bytes, tx_bytes, rx_errors, tx_errors,
-		rx_bps, tx_bps, speed_mbps FROM port_series_raw
+		rx_frames, tx_frames, rx_bps, tx_bps, speed_mbps FROM port_series_raw
 		WHERE router_id=? AND port_id=? AND ts>=? AND ts<=?
 		ORDER BY ts`, routerID, portID, fromMs, toMs)
 	if err != nil {
@@ -177,18 +186,22 @@ func (s *Store) getRaw(routerID, portID string, fromMs, toMs int64) ([]PortPoint
 		var tsMs int64
 		var p PortPoint
 		if err := rows.Scan(&tsMs, &p.RxBytes, &p.TxBytes, &p.RxErrors, &p.TxErrors,
-			&p.RxBps, &p.TxBps, &p.SpeedMbps); err != nil {
+			&p.RxFrames, &p.TxFrames, &p.RxBps, &p.TxBps, &p.SpeedMbps); err != nil {
 			return nil, err
 		}
 		p.TS = time.UnixMilli(tsMs)
 		out = append(out, p)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	deriveFps(out)
+	return out, nil
 }
 
 func (s *Store) get5m(routerID, portID string, fromMs, toMs int64) ([]PortPoint, error) {
 	rows, err := s.db.Query(`SELECT bucket_ts, rx_bytes, tx_bytes, rx_errors, tx_errors,
-		rx_bps_avg, tx_bps_avg, speed_mbps FROM port_series_5m
+		rx_frames, tx_frames, rx_bps_avg, tx_bps_avg, speed_mbps FROM port_series_5m
 		WHERE router_id=? AND port_id=? AND bucket_ts>=? AND bucket_ts<=?
 		ORDER BY bucket_ts`, routerID, portID, fromMs, toMs)
 	if err != nil {
@@ -200,20 +213,24 @@ func (s *Store) get5m(routerID, portID string, fromMs, toMs int64) ([]PortPoint,
 		var tsMs int64
 		var p PortPoint
 		if err := rows.Scan(&tsMs, &p.RxBytes, &p.TxBytes, &p.RxErrors, &p.TxErrors,
-			&p.RxBps, &p.TxBps, &p.SpeedMbps); err != nil {
+			&p.RxFrames, &p.TxFrames, &p.RxBps, &p.TxBps, &p.SpeedMbps); err != nil {
 			return nil, err
 		}
 		p.TS = time.UnixMilli(tsMs)
 		out = append(out, p)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	deriveFps(out)
+	return out, nil
 }
 
 func (s *Store) getDaily(routerID, portID string, from, to time.Time) ([]PortPoint, error) {
 	fromDate := from.UTC().Format("2006-01-02")
 	toDate := to.UTC().Format("2006-01-02")
 	rows, err := s.db.Query(`SELECT date, rx_bytes, tx_bytes, rx_errors, tx_errors,
-		rx_bps_avg, tx_bps_avg, speed_mbps FROM port_series_daily
+		rx_frames, tx_frames, rx_bps_avg, tx_bps_avg, speed_mbps FROM port_series_daily
 		WHERE router_id=? AND port_id=? AND date>=? AND date<=?
 		ORDER BY date`, routerID, portID, fromDate, toDate)
 	if err != nil {
@@ -225,7 +242,7 @@ func (s *Store) getDaily(routerID, portID string, from, to time.Time) ([]PortPoi
 		var dateStr string
 		var p PortPoint
 		if err := rows.Scan(&dateStr, &p.RxBytes, &p.TxBytes, &p.RxErrors, &p.TxErrors,
-			&p.RxBps, &p.TxBps, &p.SpeedMbps); err != nil {
+			&p.RxFrames, &p.TxFrames, &p.RxBps, &p.TxBps, &p.SpeedMbps); err != nil {
 			return nil, err
 		}
 		t, err := time.Parse("2006-01-02", dateStr)
@@ -235,7 +252,30 @@ func (s *Store) getDaily(routerID, portID string, from, to time.Time) ([]PortPoi
 		p.TS = t
 		out = append(out, p)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	deriveFps(out)
+	return out, nil
+}
+
+// deriveFps calcula frames/segundo entre puntos consecutivos a partir de los
+// contadores acumulados (rx_frames/tx_frames). Un contador que baja indica un
+// reset del dispositivo (p.ej. reboot del switch): ese intervalo se deja a 0
+// en vez de fabricar un delta negativo. La primera muestra no tiene anterior.
+func deriveFps(pts []PortPoint) {
+	for i := 1; i < len(pts); i++ {
+		dt := pts[i].TS.Sub(pts[i-1].TS).Seconds()
+		if dt <= 0 {
+			continue
+		}
+		if pts[i].RxFrames >= pts[i-1].RxFrames {
+			pts[i].RxFps = float64(pts[i].RxFrames-pts[i-1].RxFrames) / dt
+		}
+		if pts[i].TxFrames >= pts[i-1].TxFrames {
+			pts[i].TxFps = float64(pts[i].TxFrames-pts[i-1].TxFrames) / dt
+		}
+	}
 }
 
 // RollupRawTo5m aggregates raw samples into 5-min buckets.

--- a/server-go/internal/portseries/portseries_test.go
+++ b/server-go/internal/portseries/portseries_test.go
@@ -233,3 +233,34 @@ func TestNightlyJobIntegration(t *testing.T) {
 		t.Error("expected 5m buckets after nightly job, got 0")
 	}
 }
+
+// #641: deriveFps calcula frames/s entre muestras consecutivas y deja a 0 el
+// intervalo que cruza un reset del contador (p.ej. reboot del switch).
+func TestDeriveFps(t *testing.T) {
+	base := time.Now().Truncate(time.Second)
+	pts := []PortPoint{
+		{TS: base, RxFrames: 0, TxFrames: 0},
+		{TS: base.Add(30 * time.Second), RxFrames: 3000, TxFrames: 1500}, // 100 rx, 50 tx fps
+		{TS: base.Add(60 * time.Second), RxFrames: 6000, TxFrames: 3000}, // 100 rx, 50 tx fps
+		{TS: base.Add(90 * time.Second), RxFrames: 500, TxFrames: 100},   // reset: contador bajó
+		{TS: base.Add(120 * time.Second), RxFrames: 3500, TxFrames: 2100}, // 100 rx, 66.6 tx fps
+	}
+	deriveFps(pts)
+	// primer punto sin anterior → 0
+	if pts[0].RxFps != 0 || pts[0].TxFps != 0 {
+		t.Fatalf("primer punto debería tener fps 0: %+v", pts[0])
+	}
+	if pts[1].RxFps != 100 || pts[1].TxFps != 50 {
+		t.Fatalf("punto 1: rx=%.1f tx=%.1f, esperaba 100/50", pts[1].RxFps, pts[1].TxFps)
+	}
+	if pts[2].RxFps != 100 || pts[2].TxFps != 50 {
+		t.Fatalf("punto 2: rx=%.1f tx=%.1f, esperaba 100/50", pts[2].RxFps, pts[2].TxFps)
+	}
+	// reset: intervalo a 0
+	if pts[3].RxFps != 0 || pts[3].TxFps != 0 {
+		t.Fatalf("punto 3 (reset) debería tener fps 0: %+v", pts[3])
+	}
+	if pts[4].RxFps != 100 || pts[4].TxFps < 66 || pts[4].TxFps > 67 {
+		t.Fatalf("punto 4: rx=%.1f tx=%.1f, esperaba 100/~66.6", pts[4].RxFps, pts[4].TxFps)
+	}
+}


### PR DESCRIPTION
## What

RTLPlayground beacon agents (KP-9000) only report cumulative **frame** counters; the 8051 does not track bytes, so their port series `bps` is always 0 and the traffic chart showed "no data". With the firmware now reporting real counters (#642 fix stopped the server from interleaving zero rows), derive **frames/s** from the cumulative `rx_frames`/`tx_frames` deltas and show them.

## Changes

- **`server-go/internal/portseries`**: `PortPoint` gains `rxFps`/`txFps` (JSON `rxFps`/`txFps`). `getRaw`/`get5m`/`getDaily` now also read the frame counters and derive fps between consecutive cumulative samples (`deriveFps`), skipping intervals where the counter drops (device reset/reboot).
- **Frontend** (`PortSeriesChart`): new `unit` prop (`'bps'` default, `'fps'` for sources without byte counters); formats and labels the rate accordingly. `PortPanel` passes `'fps'` when `router.type` is `managed-switch`/`external`.
- **Tests**: `deriveFps` covers normal deltas and counter resets.

## Verification

- Go tests pass (portseries/httpapi/adapters); frontend tsc + lint + build clean (only pre-existing warnings in Reports/Roaming).
- The switch16 port series now carries growing frame counters (verified after the firmware fix); this PR makes the UI render them as fps.

Closes #641.
