### PR TITLE
feat(server+ui): per-band client split on fleet cards and router detail (hide empty bands)

### DIFF
--- a/app/src/components/routers/FleetCard.tsx
+++ b/app/src/components/routers/FleetCard.tsx
@@ -250,22 +250,34 @@ export function FleetCard({ router, index = 0, refreshKey = 0 }: FleetCardProps)
           </div>
         </div>
 
-        {/* Fila clientes */}
-        <div className="mt-4 flex flex-wrap items-center gap-2">
-          <span className="inline-flex items-center gap-1.5 text-caption font-medium text-text-secondary">
-            <Users className="h-3.5 w-3.5 text-text-muted" strokeWidth={1.75} />
-            {t('common.clientsCount', { count: router.clients })}
-          </span>
-          <span className="inline-flex items-center gap-1 rounded-full bg-elevated px-2 py-0.5 text-caption text-text-secondary">
-            <Wifi className="h-3 w-3 text-text-muted" strokeWidth={1.75} /> 2.4 GHz · {extras.bandSplit.band24}
-          </span>
-          <span className="inline-flex items-center gap-1 rounded-full bg-elevated px-2 py-0.5 text-caption text-text-secondary">
-            <Wifi className="h-3 w-3 text-text-muted" strokeWidth={1.75} /> 5 GHz · {extras.bandSplit.band5}
-          </span>
-          <span className="inline-flex items-center gap-1 rounded-full bg-elevated px-2 py-0.5 text-caption text-text-secondary">
-            <Cable className="h-3 w-3 text-text-muted" strokeWidth={1.75} /> {t('common.cable')} · {extras.bandSplit.cable}
-          </span>
-        </div>
+        {/* Fila clientes (#645): desglose por banda solo cuando hay clientes
+            en esa banda; un switch sin radios wifi no muestra pills de banda. */}
+        {(() => {
+          const bs = router.bandSplit ?? extras.bandSplit
+          const bands: { key: string; label: string; n: number; Icon: typeof Wifi | typeof Cable }[] = [
+            { key: '24', label: '2.4 GHz', n: bs.band24, Icon: Wifi },
+            { key: '5', label: '5 GHz', n: bs.band5, Icon: Wifi },
+            { key: '6', label: '6 GHz', n: bs.band6, Icon: Wifi },
+            { key: 'cable', label: t('common.cable'), n: bs.cable, Icon: Cable },
+          ].filter((b) => b.n > 0)
+          if (router.clients === 0 && bands.length === 0) return null
+          return (
+            <div className="mt-4 flex flex-wrap items-center gap-2">
+              <span className="inline-flex items-center gap-1.5 text-caption font-medium text-text-secondary">
+                <Users className="h-3.5 w-3.5 text-text-muted" strokeWidth={1.75} />
+                {t('common.clientsCount', { count: router.clients })}
+              </span>
+              {bands.map((b) => (
+                <span
+                  key={b.key}
+                  className="inline-flex items-center gap-1 rounded-full bg-elevated px-2 py-0.5 text-caption text-text-secondary"
+                >
+                  <b.Icon className="h-3 w-3 text-text-muted" strokeWidth={1.75} /> {b.label} · {b.n}
+                </span>
+              ))}
+            </div>
+          )
+        })()}
       </Link>
     </motion.article>
   )

--- a/app/src/components/routers/routerExtras.ts
+++ b/app/src/components/routers/routerExtras.ts
@@ -17,6 +17,8 @@ import { adguard, routers } from '@/data/mock'
 export interface BandSplit {
   band24: number
   band5: number
+  /** Clientes en 6 GHz (issue #645). 0 si el dispositivo no tiene radios 6 GHz. */
+  band6: number
   cable: number
 }
 
@@ -124,7 +126,7 @@ export const routerExtras: Record<string, RouterExtras> = {
     soc: 'MediaTek MT7986A',
     flash: '8 GB eMMC',
     ramMb: 512,
-    bandSplit: { band24: 4, band5: 10, cable: 3 },
+    bandSplit: { band24: 4, band5: 10, band6: 0, cable: 3 },
     trafficNow: 84.2,
     gatewayLatencySpark: [],
     backhaulSignal: [],
@@ -150,7 +152,7 @@ export const routerExtras: Record<string, RouterExtras> = {
     soc: 'MediaTek MT7981B',
     flash: '128 MB NAND',
     ramMb: 256,
-    bandSplit: { band24: 6, band5: 10, cable: 2 },
+    bandSplit: { band24: 6, band5: 10, band6: 0, cable: 2 },
     trafficNow: 51.7,
     gatewayLatencyMs: 1,
     gatewayLatencySpark: [1, 1, 2, 1, 1, 1, 2, 1, 1, 1, 1, 2, 1, 1, 1, 2, 1, 2, 2, 1, 1, 1, 1, 1],
@@ -185,7 +187,7 @@ export const routerExtras: Record<string, RouterExtras> = {
     soc: 'Rockchip RK3399',
     flash: '32 GB microSD',
     ramMb: 1024,
-    bandSplit: { band24: 4, band5: 4, cable: 1 },
+    bandSplit: { band24: 4, band5: 4, band6: 0, cable: 1 },
     trafficNow: 9.4,
     gatewayLatencyMs: 1,
     gatewayLatencySpark: [1, 1, 1, 2, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 2, 1, 1, 1, 1],
@@ -218,7 +220,7 @@ export const routerExtras: Record<string, RouterExtras> = {
     soc: 'Qualcomm QCA9563',
     flash: '16 MB SPI',
     ramMb: 128,
-    bandSplit: { band24: 5, band5: 1, cable: 0 },
+    bandSplit: { band24: 5, band5: 1, band6: 0, cable: 0 },
     trafficNow: 1.8,
     gatewayLatencyMs: 2,
     gatewayLatencySpark: [2, 2, 3, 2, 2, 2, 3, 2, 2, 3, 2, 2, 3, 3, 2, 2, 3, 4, 3, 2, 2, 2, 2, 2],

--- a/app/src/data/DataProvider.tsx
+++ b/app/src/data/DataProvider.tsx
@@ -336,7 +336,7 @@ export const EMPTY_EXTRAS: RouterExtras = {
   soc: '—',
   flash: '—',
   ramMb: 0,
-  bandSplit: { band24: 0, band5: 0, cable: 0 },
+  bandSplit: { band24: 0, band5: 0, band6: 0, cable: 0 },
   trafficNow: 0,
   gatewayLatencySpark: [],
   backhaulSignal: [],

--- a/app/src/data/types.ts
+++ b/app/src/data/types.ts
@@ -56,6 +56,11 @@ export interface Router {
   temp: number | null // °C
   uptime: string
   clients: number
+  /**
+   * Clientes online por banda (2.4/5/6 GHz + cable), issue #645. Live lo envía
+   * el server (misma fuente que `clients`); en demo no viaja en el Router.
+   */
+  bandSplit?: { band24: number; band5: number; band6: number; cable: number }
   /** Métrica en umbral (se pinta --warn), p. ej. 'temp' en Patio */
   hotMetric?: 'cpu' | 'ram' | 'temp'
   /**

--- a/server-go/internal/adapters/demo_extras.go
+++ b/server-go/internal/adapters/demo_extras.go
@@ -8,10 +8,13 @@ import (
 	"time"
 )
 
-// demoBandSplit es el {band24, band5, cable} de los extras demo.
+// demoBandSplit es el {band24, band5, band6, cable} de los extras demo y del
+// desglose de clientes live por router (issue #645). Band6 existe para cuando
+// un dispositivo reporte clientes en 6 GHz.
 type demoBandSplit struct {
 	Band24 int `json:"band24"`
 	Band5  int `json:"band5"`
+	Band6  int `json:"band6"`
 	Cable  int `json:"cable"`
 }
 

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -1030,6 +1030,21 @@ func firmwareOutdated(installed, target string) bool {
 }
 
 // buildRouter construye el Router del contrato (index.js:221-249).
+// countBand acumula un cliente en la banda del desglose (issue #645). La
+// banda "—" (desconocida) no cae en ninguna: suma ≤ total de clientes.
+func countBand(split *demoBandSplit, band string) {
+	switch {
+	case strings.HasPrefix(band, "2.4"):
+		split.Band24++
+	case strings.HasPrefix(band, "5"):
+		split.Band5++
+	case strings.HasPrefix(band, "6"):
+		split.Band6++
+	case band == "cable":
+		split.Cable++
+	}
+}
+
 func (l *Live) buildRouter(p *routerPolled, history []histPoint) Router {
 	l.mu.Lock()
 	gw := l.gatewayCfg
@@ -2363,12 +2378,15 @@ func (l *Live) buildOverview(ctx context.Context) (*Overview, error) {
 	// Clientes reales por router (atribución wireless/FDB, no leases)
 	for i := range routerList {
 		n := 0
+		var split demoBandSplit
 		for _, d := range devices {
 			if d.RouterID == routerList[i].ID && d.Online {
 				n++
+				countBand(&split, d.Band)
 			}
 		}
 		routerList[i].Clients = n
+		routerList[i].BandSplit = &split
 	}
 	adguard := l.pollAdGuard(ctx)
 	wireguard := l.pollWireGuard(devices)
@@ -2800,10 +2818,18 @@ func (l *Live) GetRouterDetail(ctx context.Context, id string) (*RouterDetail, e
 			clients = append(clients, d)
 		}
 	}
+	// Desglose por banda de los clientes online (issue #645): mismo criterio
+	// que la tarjeta de la flota (solo online; "—" no cae en ninguna banda).
+	var bandSplit demoBandSplit
+	for _, d := range clients {
+		if d.Online {
+			countBand(&bandSplit, d.Band)
+		}
+	}
 	extras := liveExtras{
 		MAC: "—", Firmware: "—", FirmwareUpdated: true, LastReboot: "—",
 		Soc: "—", Flash: "—", RamMb: 0,
-		BandSplit:           demoBandSplit{},
+		BandSplit:           bandSplit,
 		GatewayLatencySpark: []float64{},
 		BackhaulSignal:      []float64{},
 		Radios:              radios,

--- a/server-go/internal/adapters/types.go
+++ b/server-go/internal/adapters/types.go
@@ -179,14 +179,18 @@ type Router struct {
 	// reportar métricas de sistema (#441): switches sondeados por SNMP (#309)
 	// o pushers externos por beacon/scraper (#291). En ese caso CPU/RAM/Temp
 	// van a null y la UI no los pinta. Ausente = vitals disponibles.
-	VitalsAvailable *bool     `json:"vitalsAvailable,omitempty"`
-	CPU             *int      `json:"cpu"`
-	RAM             *int      `json:"ram"`
-	Temp            *int      `json:"temp"`
-	Uptime          string    `json:"uptime"` // "<d>d <h>h" | "—"
-	Clients         int       `json:"clients"`
-	HotMetric       string    `json:"hotMetric,omitempty"` // "temp" solo si temp>65
-	Sparkline       []float64 `json:"sparkline"`
+	VitalsAvailable *bool  `json:"vitalsAvailable,omitempty"`
+	CPU             *int   `json:"cpu"`
+	RAM             *int   `json:"ram"`
+	Temp            *int   `json:"temp"`
+	Uptime          string `json:"uptime"` // "<d>d <h>h" | "—"
+	Clients         int    `json:"clients"`
+	// BandSplit: clientes online por banda (2.4/5/6 GHz + cable) — issue #645.
+	// Misma fuente que Clients (mismo recuento), suma ≤ Clients (los clientes
+	// con banda desconocida "—" no caen en ninguna banda).
+	BandSplit *demoBandSplit `json:"bandSplit,omitempty"`
+	HotMetric string         `json:"hotMetric,omitempty"` // "temp" solo si temp>65
+	Sparkline []float64      `json:"sparkline"`
 	// Backhaul: medio del uplink del router ("cable"|"wifi"). Ausente =
 	// cable/desconocido (router sin wifi o sonda no disponible).
 	Backhaul string `json:"backhaul,omitempty"`


### PR DESCRIPTION
The fleet card always rendered three band pills (2.4 GHz / 5 GHz / Cable) fed from extras.bandSplit, which in live mode is EMPTY_EXTRAS: every card showed 0 for every band while the total client pill was correct. Devices without radios (the KP-9000 switch) showed WiFi bands they do not have.

- Server: compute the online-per-band split (band24/band5/band6/cable) in the same loop that counts router clients and ship it on the router payload (buildOverview) and on router detail extras (GetRouterDetail), same data source so totals stay consistent.
- FleetCard: render a band pill only when that band has clients > 0 (6 GHz appears automatically if a device ever reports it); hide the row for a device with no clients; the switch shows only its cable clients.
- Frontend types grow band6 in BandSplit (demo literals + EMPTY_EXTRAS) and Router.bandSplit (live only, absent in demo).

Closes #645.
