### PR TITLE
chore: prepare v2.28.15 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.28.15] - 2026-09-09
+
+### Added
+
+- **La gráfica de tráfico de los puertos muestra frames/s cuando el dispositivo no mide bytes (#641)**: los agentes beacon de switches RTLPlayground (KP-9000) solo reportan contadores acumulados de tramas, no bytes. El servidor deriva ahora frames/s de esos contadores en los tres niveles (raw, 5m, diario) y la tarjeta de Puertos del detalle los pinta como fps en lugar de bps para las fuentes sin contadores de bytes. Una gráfica de puerto de un switch gestionado deja de aparecer "sin datos" y muestra su tráfico real.
+- **El detalle y la flota muestran el desglose real de clientes por banda (#645)**: cada tarjeta de router (y el detalle) indica sus clientes online por banda (2.4/5/6 GHz y cable) calculado en el servidor con la misma fuente que el total. Solo se pintan las bandas con clientes, así un switch sin radios wifi ya no muestra bandas a 0.
+- **El servidor sondea la consola del switch RTLPlayground para firmware, uptime y MAC (#639)**: los agentes beacon de tipo RTLPlayground exponen ahora la versión de firmware real, el tiempo de actividad y la MAC del switch, leídos de su consola HTTP, y se muestran en la tarjeta del router.
+
+### Fixed
+
+- **El tráfico de los puertos de un switch beacon ya no se ensucia con ceros (#642)**: el push del agente intercalaba muestras a 0 con las buenas del beacon. Ahora las fuentes externas solo persisten sus contadores reales, así las series de los puertos quedan limpias.
+- **El detalle de un switch gestionado ya no pinta sus puertos dos veces (#644)**: la tarjeta de chasis con LEDs de salud (front panel) duplicaba a la de Puertos Ethernet con las bocas RJ45. Se eliminó el front panel del detalle: la tarjeta de puertos ya muestra el estado, la salud y el historial por puerto.
+- **La tarjeta de un switch sin throughput en bps ya no muestra la línea de tráfico 24h plana (#648)**: para fuentes que solo reportan tramas por puerto, el mini-gráfico de tráfico de la tarjeta se deriva ahora de los frames/s de sus puertos en lugar de la tabla de bps (que siempre estaba vacía para ellos).
+
 ## [2.28.14] - 2026-09-08
 
 ### Fixed

--- a/README.es.md
+++ b/README.es.md
@@ -97,7 +97,19 @@ enlazada al issue de GitHub que la originó.
 > Están escritas para personas, no como changelog: qué hace la función por ti,
 > no los nombres de las funciones internas.
 
-### Última (v2.28.14)
+### Última (v2.28.15)
+
+- **La gráfica de tráfico de los puertos muestra frames/s cuando el dispositivo no mide bytes** ([#641](https://github.com/gnacho/netpulse/issues/641)). Los beacons de switches RTLPlayground (KP-9000) solo reportan contadores acumulados de tramas, no bytes. El servidor deriva ahora frames/s de esos contadores (raw, 5m y diario) y la tarjeta de Puertos del detalle dibuja fps en lugar de bps para las fuentes sin contadores de bytes, así la gráfica de un puerto de switch gestionado ya no parece vacía.
+- **La flota y el detalle muestran el desglose real de clientes por banda** ([#645](https://github.com/gnacho/netpulse/issues/645)). Cada tarjeta de router indica ahora sus clientes online por banda (2.4/5/6 GHz y cable) calculado en el servidor con la misma fuente que el total, y solo pinta las bandas que tienen clientes: un switch sin radios wifi ya no muestra bandas wifi a 0.
+- **La línea de tráfico 24h de un switch sin throughput en bps ya no es plana** ([#648](https://github.com/gnacho/netpulse/issues/648)). Para las fuentes que solo reportan tramas por puerto, el mini-gráfico de tráfico de la tarjeta se deriva ahora de los frames/s de sus puertos en lugar de la tabla de bps (que para ellas siempre estaba vacía), así la tarjeta del KP-9000 muestra su actividad real.
+- **Los switches beacon RTLPlayground reportan firmware, uptime y MAC reales** ([#639](https://github.com/gnacho/netpulse/issues/639)). El servidor sondea la consola HTTP del switch de los agentes beacon, y la tarjeta del router muestra ahora la versión de firmware real, el tiempo de actividad y la MAC del switch en lugar de marcadores de posición.
+
+### Arreglado
+
+- **El detalle de un switch gestionado ya no pinta sus puertos dos veces** ([#644](https://github.com/gnacho/netpulse/issues/644)). La tarjeta de chasis con LEDs de salud duplicaba a la de Puertos Ethernet con las bocas RJ45; el front panel ha desaparecido y la tarjeta de puertos ya muestra el enlace, la salud y el historial por puerto.
+- **Las series de puertos de un switch beacon ya no se ensucian con ceros** ([#642](https://github.com/gnacho/netpulse/issues/642)). Las fuentes externas solo persisten ahora sus contadores reales, manteniendo limpias las series de los puertos.
+
+### Anterior (v2.28.14)
 
 - **El plan de canales ya no cuenta tu propia malla como interferencia ni sugiere un canal que cruce a DFS** ([#631](https://github.com/gnacho/netpulse/issues/631)). En el análisis de canales, los BSSID de tus propios puntos de acceso ya no puntúan como vecinos (se excluyen emparejando el prefijo MAC de tus routers monitorizados), y los canales candidatos se validan contra el ancho de la radio: a 40/80/160 MHz solo se ofrecen bloques que no entran en canales DFS (52-64, 100-144). Evita que NetPulse recomiende un canal que ya usan los satélites de tu malla, o un bloque de 80 MHz que cruzaría a banda DFS.
 - **El rearm ahora recupera un agente atascado en bucle de 401** ([#630](https://github.com/gnacho/netpulse/issues/630)). Si un reinicio no trae de vuelta al agente, NetPulse regenera el token del agente y lo aplica en el router (reescribe el `.env` y reinicia) sin reinstalar, así un token desincronizado se arregla en caliente. La rotación de token en un reinstall también es atómica: si el SSH falla, el servidor restaura el token anterior, para que el agente nunca se quede empujando un token que ya no se acepta.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,19 @@ latest improvements, each linked to the GitHub issue that drove it.
 > These are written for people, not changelogs: what the feature does for you,
 > not the function names behind it.
 
-### Latest (v2.28.14)
+### Latest (v2.28.15)
+
+- **Port traffic charts now show frames/s for devices that don't count bytes** ([#641](https://github.com/gnacho/netpulse/issues/641)). RTLPlayground switch beacons (KP-9000) only report cumulative frame counters, not bytes. The server now derives frames/s from those counters (raw, 5m and daily) and the port card in the detail page plots fps instead of bps for sources without byte counters, so a managed switch port chart no longer looks empty.
+- **Fleet cards and the router detail show the real per-band client split** ([#645](https://github.com/gnacho/netpulse/issues/645)). Each router card now lists its online clients by band (2.4/5/6 GHz and wired) computed server-side from the same source as the total, and only renders bands that actually have clients: a switch with no WiFi radios no longer shows WiFi bands stuck at zero.
+- **The traffic sparkline of a switch without bps throughput is no longer a flat zero line** ([#648](https://github.com/gnacho/netpulse/issues/648)). For sources that only report per-port frames, the card's 24h traffic mini-chart is now derived from its ports' frames/s instead of the bps table (which was always empty for them), so the KP-9000 card shows its real activity.
+- **RTLPlayground beacon switches report real firmware, uptime and MAC** ([#639](https://github.com/gnacho/netpulse/issues/639)). The server polls the switch's HTTP console for beacon agents, and the router card now shows the actual firmware version, uptime and MAC of the switch instead of placeholders.
+
+### Fixed
+
+- **A managed switch detail page no longer shows its ports twice** ([#644](https://github.com/gnacho/netpulse/issues/644)). The front-panel LED chassis card duplicated the Ethernet ports card with RJ45 jacks; the front panel is gone and the ports card already shows link, health and per-port history.
+- **Port series of a beacon switch are no longer polluted with zeros** ([#642](https://github.com/gnacho/netpulse/issues/642)). External sources only persist their real counters now, keeping the port series clean.
+
+### Earlier (v2.28.14)
 
 - **The channel plan no longer counts your own mesh as interference, and won't suggest a channel that crosses into DFS** ([#631](https://github.com/gnacho/netpulse/issues/631)). In the channel analysis, the BSSIDs of your own access points no longer score as neighbors (they are excluded by matching the MAC prefix of your monitored routers), and candidate channels are validated against the radio width: at 40/80/160 MHz only blocks that stay out of DFS channels (52-64, 100-144) are offered. This stops NetPulse recommending a channel your mesh satellites already use, or an 80 MHz block that would cross into a DFS band.
 - **Rearm now recovers an agent stuck in a 401 loop** ([#630](https://github.com/gnacho/netpulse/issues/630)). If a restart doesn't bring the agent back, NetPulse regenerates the agent token and applies it on the router (rewrites the env + restarts) without a reinstall, so a token that drifted out of sync is fixed in place. Token rotation on a reinstall is also atomic: if the SSH step fails, the server restores the previous token so the agent never ends up pushing a token that is no longer accepted.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.14",
+  "version": "2.28.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.28.14",
+      "version": "2.28.15",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.14",
+  "version": "2.28.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.14"
+var Version = "2.28.15"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Release v2.28.15, accumulating the beacon/switch session work merged since v2.28.14:

- #639 (PR #640) RTLPlayground beacon console: firmware, uptime, MAC
- #641 (PR #643) per-port traffic as frames/s for sources without byte counters
- #642 fix: no more interleaved zero samples for external beacon agents
- #644 (PR #647) managed-switch detail no longer shows ports twice
- #645 (PR #646) real per-band client split on fleet cards and detail
- #648 (PRs #649, #650) switch traffic sparkline derived from per-port fps (incl. modernc integer-division fix)

Bumps app + server versions to 2.28.15, turns the changelog section, updates What's new / Novedades.