### PR TITLE
feat(ui): hover info on fleet-card traffic sparkline + full-width port history chart

### DIFF
--- a/app/src/components/routers/FleetCard.tsx
+++ b/app/src/components/routers/FleetCard.tsx
@@ -2,10 +2,11 @@ import { Link } from 'react-router'
 import { AlertTriangle, Cable, Cpu, MemoryStick, Router as RouterIcon, Thermometer, Users, Wifi } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { motion, useReducedMotion } from 'framer-motion'
-import { Area, AreaChart, ResponsiveContainer } from 'recharts'
+import { Area, AreaChart, ResponsiveContainer, Tooltip } from 'recharts'
 import { useTranslation } from 'react-i18next'
 import { fmtUptime } from '@/i18n'
 import type { Router } from '@/data/mock'
+import { fmtRate } from '@/components/routers/PortSeriesChart'
 import { HealthRing } from '@/components/HealthRing'
 import { MetricBar } from '@/components/MetricBar'
 import { StatusPill } from '@/components/StatusPill'
@@ -54,6 +55,28 @@ interface FleetCardProps {
   refreshKey?: number
 }
 
+/** Tooltip del mini-gráfico de tráfico 24h: hora + valor con su unidad. */
+function TrafficTooltip({
+  active,
+  payload,
+  unit,
+}: {
+  active?: boolean
+  payload?: { payload?: { t: string; v: number } }[]
+  unit: 'fps' | 'bps'
+}) {
+  if (!active || !payload?.length || !payload[0]?.payload) return null
+  const p = payload[0].payload
+  return (
+    <div className="rounded-[10px] border border-border-strong bg-elevated px-3 py-2 shadow-lg">
+      <div className="mb-0.5 font-mono text-caption text-text-muted">{p.t}</div>
+      <div className="font-mono text-mono-sm text-text-primary">
+        {unit === 'fps' ? fmtRate('fps', p.v) : `${p.v >= 10 ? p.v.toFixed(0) : p.v.toFixed(1)} Mbps`}
+      </div>
+    </div>
+  )
+}
+
 /** FleetCard grande de /routers (routers.md §②) */
 export function FleetCard({ router, index = 0, refreshKey = 0 }: FleetCardProps) {
   const { t } = useTranslation()
@@ -68,7 +91,17 @@ export function FleetCard({ router, index = 0, refreshKey = 0 }: FleetCardProps)
   // El gateway real lo marca el server (roleBadge 'Principal'): su tarjeta
   // lleva la pill verde "puerta de enlace", el tile en acento y su modelo.
   const isPrimary = router.roleBadge === 'Principal'
-  const traffic = router.sparkline.map((v, i) => ({ i, v }))
+  // Sparkline 24h (buckets horarios, último = hora actual). Etiqueta cada
+  // punto con su hora para el tooltip (#654).
+  const traffic = router.sparkline.map((v, i) => {
+    const d = new Date()
+    d.setMinutes(0, 0, 0)
+    d.setHours(d.getHours() - (router.sparkline.length - 1 - i))
+    return { t: d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }), v }
+  })
+  // Fuentes sin throughput bps (switch beacon/SNMP, #648) dibujan el sparkline
+  // como frames/s agregados; el resto, Mbps.
+  const trafficUnit: 'fps' | 'bps' = router.vitalsAvailable === false ? 'fps' : 'bps'
 
   return (
     <motion.article
@@ -235,6 +268,7 @@ export function FleetCard({ router, index = 0, refreshKey = 0 }: FleetCardProps)
                     <stop offset="100%" stopColor="#22D3EE" stopOpacity={0} />
                   </linearGradient>
                 </defs>
+                <Tooltip content={<TrafficTooltip unit={trafficUnit} />} cursor={{ stroke: 'rgb(var(--border-strong))', strokeWidth: 1 }} />
                 <Area
                   type="monotone"
                   dataKey="v"
@@ -242,6 +276,7 @@ export function FleetCard({ router, index = 0, refreshKey = 0 }: FleetCardProps)
                   strokeWidth={1.75}
                   fill={`url(#fleet-grad-${router.id})`}
                   dot={false}
+                  activeDot={{ r: 3, strokeWidth: 0, fill: '#22D3EE' }}
                   animationDuration={800}
                   animationEasing="ease-out"
                 />

--- a/app/src/components/routers/PortSeriesChart.tsx
+++ b/app/src/components/routers/PortSeriesChart.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis } from 'recharts'
 
 interface PortPoint {
   ts: string
@@ -20,6 +21,7 @@ interface PortSeriesResponse {
 }
 
 type Range = '24h' | '7d' | '30d'
+type Unit = 'bps' | 'fps'
 
 const RANGES: Range[] = ['24h', '7d', '30d']
 
@@ -32,7 +34,7 @@ function rangeToSeconds(range: Range): number {
 }
 
 /** Formatea una tasa: bps → bps/kbps/Mbps/Gbps; fps → fps/kfps. */
-function fmtRate(unit: 'bps' | 'fps', v: number): string {
+export function fmtRate(unit: Unit, v: number): string {
   if (unit === 'bps') {
     if (v >= 1e9) return `${(v / 1e9).toFixed(1)} Gbps`
     if (v >= 1e6) return `${(v / 1e6).toFixed(1)} Mbps`
@@ -43,31 +45,62 @@ function fmtRate(unit: 'bps' | 'fps', v: number): string {
   return `${Math.round(v)} fps`
 }
 
-function Sparkline({ points, colorKey, unit }: { points: PortPoint[]; colorKey: 'rx' | 'tx'; unit: 'bps' | 'fps' }) {
-  if (points.length < 2) return null
-  const W = 200
-  const H = 40
-  const PAD = 2
-  const field = (colorKey === 'rx' ? 'rxBps' : 'txBps') as 'rxBps' | 'txBps'
-  const fpsField = (colorKey === 'rx' ? 'rxFps' : 'txFps') as 'rxFps' | 'txFps'
-  const values = points.map((p) => (unit === 'fps' ? p[fpsField] : p[field]))
-  const max = Math.max(...values, 1)
-  const stepX = (W - PAD * 2) / (values.length - 1)
-  const path = values
-    .map((v, i) => {
-      const x = PAD + i * stepX
-      const y = H - PAD - ((v / max) * (H - PAD * 2))
-      return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`
-    })
-    .join(' ')
-  const fillPath = path + ` L${(W - PAD).toFixed(1)},${H - PAD} L${PAD},${H - PAD} Z`
-  const color = colorKey === 'rx' ? '#3b82f6' : '#10b981'
-  const fillColor = colorKey === 'rx' ? 'rgba(59,130,246,0.12)' : 'rgba(16,185,129,0.12)'
+/** Etiqueta temporal del punto según el rango (hora / día+hora / fecha). */
+function fmtTime(iso: string, range: Range): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  if (range === '24h') return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  if (range === '7d')
+    return d.toLocaleDateString([], { weekday: 'short' }) + ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return d.toLocaleDateString([], { day: 'numeric', month: 'short' })
+}
+
+interface ChartPoint {
+  t: string
+  rx: number
+  tx: number
+}
+
+/** Reduce a ≤ maxPoints conservando picos (toma el punto de mayor actividad
+ *  de cada grupo, en vez de promediar, para no aplanar los picos de tráfico). */
+function downscale(pts: ChartPoint[], maxPoints: number): ChartPoint[] {
+  if (pts.length <= maxPoints) return pts
+  const size = Math.ceil(pts.length / maxPoints)
+  const out: ChartPoint[] = []
+  for (let i = 0; i < pts.length; i += size) {
+    let best = pts[i]!
+    for (let j = i + 1; j < Math.min(i + size, pts.length); j++) {
+      if (pts[j]!.rx + pts[j]!.tx > best.rx + best.tx) best = pts[j]!
+    }
+    out.push(best)
+  }
+  return out
+}
+
+/** Tooltip del historial: hora + RX/TX formateadas con su color. */
+function PortTooltip({
+  active,
+  payload,
+  unit,
+}: {
+  active?: boolean
+  payload?: { payload?: ChartPoint }[]
+  unit: Unit
+}) {
+  if (!active || !payload?.length || !payload[0]?.payload) return null
+  const p = payload[0].payload
   return (
-    <svg width={W} height={H} viewBox={`0 0 ${W} ${H}`} className="block" aria-hidden="true">
-      <path d={fillPath} fill={fillColor} />
-      <path d={path} fill="none" stroke={color} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
+    <div className="rounded-[10px] border border-border-strong bg-elevated px-3 py-2 shadow-lg">
+      <div className="mb-1 font-mono text-caption text-text-muted">{p.t}</div>
+      <div className="flex items-center gap-2 font-mono text-mono-sm text-text-primary">
+        <span className="h-2 w-2 rounded-full bg-[#3b82f6]" />
+        RX {fmtRate(unit, p.rx)}
+      </div>
+      <div className="flex items-center gap-2 font-mono text-mono-sm text-text-primary">
+        <span className="h-2 w-2 rounded-full bg-[#10b981]" />
+        TX {fmtRate(unit, p.tx)}
+      </div>
+    </div>
   )
 }
 
@@ -79,7 +112,7 @@ export function PortSeriesChart({
   routerId: string
   portId: string
   /** 'bps' para fuentes con byte counters (OpenWrt); 'fps' para beacons/SNMP sin bytes (issue #641). */
-  unit?: 'bps' | 'fps'
+  unit?: Unit
 }) {
   const { t } = useTranslation()
   const [range, setRange] = useState<Range>('24h')
@@ -109,14 +142,30 @@ export function PortSeriesChart({
     fetchData()
   }, [fetchData])
 
-  const hasData = data.length > 1
-  const peakRx = hasData ? Math.max(...data.map((p) => (unit === 'fps' ? p.rxFps : p.rxBps))) : 0
-  const peakTx = hasData ? Math.max(...data.map((p) => (unit === 'fps' ? p.txFps : p.txBps))) : 0
+  const chartData = useMemo(() => {
+    const pts = data
+      .map((p) => ({
+        t: fmtTime(p.ts, range),
+        rx: unit === 'fps' ? p.rxFps : p.rxBps,
+        tx: unit === 'fps' ? p.txFps : p.txBps,
+      }))
+      .filter((p) => !Number.isNaN(p.rx) && !Number.isNaN(p.tx))
+    return downscale(pts, 600)
+  }, [data, range, unit])
+
+  const hasData = chartData.length > 1
+  const peakRx = hasData ? Math.max(...chartData.map((p) => p.rx)) : 0
+  const peakTx = hasData ? Math.max(...chartData.map((p) => p.tx)) : 0
 
   return (
     <div className="mt-3 rounded-xl border border-border/60 bg-elevated/30 p-3">
-      <div className="mb-2 flex items-center justify-between">
-        <span className="text-caption font-medium text-text-secondary">{t('routerDetail.ports.seriesTitle')}</span>
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-baseline gap-2">
+          <span className="text-caption font-medium text-text-secondary">{t('routerDetail.ports.seriesTitle')}</span>
+          <span className="hidden font-mono text-[10px] text-text-muted sm:inline">
+            ↓ {fmtRate(unit, peakRx)} · ↑ {fmtRate(unit, peakTx)}
+          </span>
+        </div>
         <div className="flex gap-1">
           {RANGES.map((r) => (
             <button
@@ -135,22 +184,66 @@ export function PortSeriesChart({
         </div>
       </div>
       {loading ? (
-        <div className="flex h-10 items-center justify-center text-caption text-text-muted">...</div>
+        <div className="flex h-40 items-center justify-center text-caption text-text-muted">...</div>
       ) : hasData ? (
-        <div className="space-y-1">
-          <div className="flex items-center gap-2">
-            <span className="w-5 text-[10px] font-medium text-blue-500">RX</span>
-            <Sparkline points={data} colorKey="rx" unit={unit} />
-            <span className="ml-auto font-mono text-[10px] text-text-muted">{fmtRate(unit, peakRx)}</span>
+        <>
+          <div className="h-40 w-full" role="img" aria-label={t('routerDetail.ports.seriesTitle')}>
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={chartData} margin={{ top: 4, right: 0, bottom: 0, left: 0 }}>
+                <defs>
+                  <linearGradient id="port-rx-grad" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.25} />
+                    <stop offset="100%" stopColor="#3b82f6" stopOpacity={0} />
+                  </linearGradient>
+                  <linearGradient id="port-tx-grad" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#10b981" stopOpacity={0.22} />
+                    <stop offset="100%" stopColor="#10b981" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid vertical={false} stroke="rgb(var(--border) / 0.5)" strokeDasharray="3 6" />
+                <XAxis dataKey="t" hide />
+                <Tooltip content={<PortTooltip unit={unit} />} cursor={{ stroke: 'rgb(var(--border-strong))', strokeWidth: 1 }} />
+                <Area
+                  type="monotone"
+                  dataKey="rx"
+                  name="RX"
+                  stroke="#3b82f6"
+                  strokeWidth={1.5}
+                  fill="url(#port-rx-grad)"
+                  dot={false}
+                  activeDot={{ r: 3, strokeWidth: 0, fill: '#3b82f6' }}
+                  animationDuration={500}
+                  animationEasing="ease-out"
+                  isAnimationActive={false}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="tx"
+                  name="TX"
+                  stroke="#10b981"
+                  strokeWidth={1.5}
+                  fill="url(#port-tx-grad)"
+                  dot={false}
+                  activeDot={{ r: 3, strokeWidth: 0, fill: '#10b981' }}
+                  animationDuration={500}
+                  animationEasing="ease-out"
+                  isAnimationActive={false}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
           </div>
-          <div className="flex items-center gap-2">
-            <span className="w-5 text-[10px] font-medium text-emerald-500">TX</span>
-            <Sparkline points={data} colorKey="tx" unit={unit} />
-            <span className="ml-auto font-mono text-[10px] text-text-muted">{fmtRate(unit, peakTx)}</span>
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-caption text-text-muted">
+            <span className="inline-flex items-center gap-1.5">
+              <span className="h-2 w-2 rounded-full bg-[#3b82f6]" /> RX {t('routerDetail.ports.seriesRx')}
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <span className="h-2 w-2 rounded-full bg-[#10b981]" /> TX {t('routerDetail.ports.seriesTx')}
+            </span>
+            <span className="ml-auto hidden font-mono text-[10px] sm:inline">{chartData.length} pts</span>
           </div>
-        </div>
+        </>
       ) : (
-        <div className="flex h-10 items-center justify-center text-caption text-text-muted">
+        <div className="flex h-40 items-center justify-center text-caption text-text-muted">
           {t('routerDetail.ports.seriesNoData')}
         </div>
       )}


### PR DESCRIPTION
Two traffic charts were too bare:

1. **Fleet card 24h sparkline** had no tooltip. Added a hover tooltip showing the hour and the rate with the correct unit: Mbps for routers, aggregated frames/s for sources without bps throughput (the KP-9000 switch sparkline is derived from per-port fps, #648).

2. **Port traffic history in the router detail** (PortSeriesChart) was two tiny 200 px hand-rolled SVG sparklines. Replaced with a responsive full-width recharts chart (RX/TX areas, ~160 px) with a hover tooltip (time + per-direction rate, formatted per unit bps/fps from #641). Downsampled to <= 600 points keeping peaks so 24h raw (~2880 samples) stays light.

Closes #654.