### PR TITLE
feat(router-detail): port traffic history as its own full-width card

### DIFF
--- a/app/src/components/routers/PortPanel.tsx
+++ b/app/src/components/routers/PortPanel.tsx
@@ -10,7 +10,6 @@ import { EMPTY_EXTRAS, useNetPulse } from '@/data/DataProvider'
 import { Activity } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import { PortSeriesChart } from '@/components/routers/PortSeriesChart'
 
 /**
  * Panel visual de puertos Ethernet - dibuja las bocas RJ45 del chasis con
@@ -314,17 +313,6 @@ export function PortPanel({ router, extras, className }: { router: Router; extra
           </span>
         )}
       </div>
-
-      {/* Per-port traffic history (issue #302) */}
-      {ports.some((p) => p.up) && !isDemo && (
-        <PortSeriesChart
-          routerId={router.id}
-          portId={ports.find((p) => p.up)!.id}
-          // #641: managed-switch/external (beacons RTLPlayground, SNMP) no
-          // reportan byte counters → la serie se muestra en frames/s.
-          unit={router.type === 'managed-switch' || router.type === 'external' ? 'fps' : 'bps'}
-        />
-      )}
     </section>
   )
 }

--- a/app/src/components/routers/PortSeriesChart.tsx
+++ b/app/src/components/routers/PortSeriesChart.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis } from 'recharts'
+import { SectionHeader } from '@/components/SectionHeader'
+import type { EthPort } from '@/components/routers/routerExtras'
+import { cn } from '@/lib/utils'
 
 interface PortPoint {
   ts: string
@@ -21,7 +24,7 @@ interface PortSeriesResponse {
 }
 
 type Range = '24h' | '7d' | '30d'
-type Unit = 'bps' | 'fps'
+export type TrafficUnit = 'bps' | 'fps'
 
 const RANGES: Range[] = ['24h', '7d', '30d']
 
@@ -34,7 +37,7 @@ function rangeToSeconds(range: Range): number {
 }
 
 /** Formatea una tasa: bps → bps/kbps/Mbps/Gbps; fps → fps/kfps. */
-export function fmtRate(unit: Unit, v: number): string {
+export function fmtRate(unit: TrafficUnit, v: number): string {
   if (unit === 'bps') {
     if (v >= 1e9) return `${(v / 1e9).toFixed(1)} Gbps`
     if (v >= 1e6) return `${(v / 1e6).toFixed(1)} Mbps`
@@ -85,7 +88,7 @@ function PortTooltip({
 }: {
   active?: boolean
   payload?: { payload?: ChartPoint }[]
-  unit: Unit
+  unit: TrafficUnit
 }) {
   if (!active || !payload?.length || !payload[0]?.payload) return null
   const p = payload[0].payload
@@ -104,22 +107,44 @@ function PortTooltip({
   )
 }
 
+/**
+ * Historial de tráfico del router (issue #302, #654): tarjeta propia del
+ * detalle a todo el ancho, con selector de puerto y de rango. NO va embebida
+ * en la tarjeta de Puertos Ethernet: cada puerto tiene su propia serie.
+ */
 export function PortSeriesChart({
   routerId,
-  portId,
+  ports,
   unit = 'bps',
+  className,
 }: {
   routerId: string
-  portId: string
+  ports: EthPort[]
   /** 'bps' para fuentes con byte counters (OpenWrt); 'fps' para beacons/SNMP sin bytes (issue #641). */
-  unit?: Unit
+  unit?: TrafficUnit
+  className?: string
 }) {
   const { t } = useTranslation()
   const [range, setRange] = useState<Range>('24h')
+  const [portId, setPortId] = useState<string | null>(null)
   const [data, setData] = useState<PortPoint[]>([])
   const [loading, setLoading] = useState(false)
 
+  // Puerto por defecto: el primero con link; si no hay ninguno up, el primero
+  // de la lista (permite ver el histórico de una boca caída).
+  useEffect(() => {
+    if (ports.length === 0) {
+      setPortId(null)
+      return
+    }
+    setPortId((prev) => {
+      if (prev && ports.some((p) => p.id === prev)) return prev
+      return (ports.find((p) => p.up) ?? ports[0])!.id
+    })
+  }, [ports])
+
   const fetchData = useCallback(async () => {
+    if (!portId) return
     setLoading(true)
     try {
       const now = Math.floor(Date.now() / 1000)
@@ -156,97 +181,130 @@ export function PortSeriesChart({
   const hasData = chartData.length > 1
   const peakRx = hasData ? Math.max(...chartData.map((p) => p.rx)) : 0
   const peakTx = hasData ? Math.max(...chartData.map((p) => p.tx)) : 0
+  const activePort = ports.find((p) => p.id === portId)
+
+  if (ports.length === 0) return null
 
   return (
-    <div className="mt-3 rounded-xl border border-border/60 bg-elevated/30 p-3">
-      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-        <div className="flex items-baseline gap-2">
-          <span className="text-caption font-medium text-text-secondary">{t('routerDetail.ports.seriesTitle')}</span>
-          <span className="hidden font-mono text-[10px] text-text-muted sm:inline">
-            ↓ {fmtRate(unit, peakRx)} · ↑ {fmtRate(unit, peakTx)}
-          </span>
-        </div>
-        <div className="flex gap-1">
-          {RANGES.map((r) => (
-            <button
-              key={r}
-              type="button"
-              onClick={() => setRange(r)}
-              className={`rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
-                range === r
-                  ? 'bg-accent/15 text-accent'
-                  : 'text-text-muted hover:bg-canvas hover:text-text-secondary'
-              }`}
-            >
-              {r}
-            </button>
-          ))}
+    <section className={cn('rounded-2xl border border-border bg-surface p-5 md:p-6', className)}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <SectionHeader title={t('routerDetail.ports.seriesTitle')} />
+        <div className="flex flex-wrap items-center gap-2">
+          {/* Selector de puerto */}
+          <div className="flex max-w-full items-center gap-1 overflow-x-auto rounded-lg border border-border bg-elevated p-0.5">
+            {ports.map((p) => (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => setPortId(p.id)}
+                title={p.connectedTo ? `${p.label} · ${p.connectedTo}` : p.label}
+                className={cn(
+                  'shrink-0 rounded-md px-2 py-0.5 font-mono text-[10px] font-medium transition-colors',
+                  portId === p.id
+                    ? 'bg-accent/15 text-accent'
+                    : 'text-text-muted hover:bg-canvas hover:text-text-secondary',
+                  !p.up && portId !== p.id && 'opacity-50',
+                )}
+              >
+                {p.label.replace(/\s+/g, '')}
+              </button>
+            ))}
+          </div>
+          {/* Selector de rango */}
+          <div className="flex gap-0.5 rounded-lg border border-border bg-elevated p-0.5">
+            {RANGES.map((r) => (
+              <button
+                key={r}
+                type="button"
+                onClick={() => setRange(r)}
+                className={cn(
+                  'rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors',
+                  range === r
+                    ? 'bg-accent/15 text-accent'
+                    : 'text-text-muted hover:bg-canvas hover:text-text-secondary',
+                )}
+              >
+                {r}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
+
+      <p className="mt-1 truncate text-caption text-text-muted" title={activePort?.connectedTo ?? activePort?.label}>
+        {activePort
+          ? activePort.connectedTo && activePort.connectedTo !== activePort.label
+            ? `${activePort.label} · ${activePort.connectedTo}`
+            : activePort.label
+          : ''}
+        {activePort?.speed ? ` · ${activePort.speed}` : ''}
+      </p>
+
+      <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-caption text-text-secondary">
+        <span className="inline-flex items-center gap-1.5">
+          <span className="h-2 w-2 rounded-full bg-[#3b82f6]" /> RX {t('routerDetail.ports.seriesRx')}
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <span className="h-2 w-2 rounded-full bg-[#10b981]" /> TX {t('routerDetail.ports.seriesTx')}
+        </span>
+        {hasData && (
+          <span className="font-mono text-[10px] text-text-muted">
+            ↓ {fmtRate(unit, peakRx)} · ↑ {fmtRate(unit, peakTx)}
+          </span>
+        )}
+      </div>
+
       {loading ? (
-        <div className="flex h-40 items-center justify-center text-caption text-text-muted">...</div>
+        <div className="mt-2 flex h-44 items-center justify-center rounded-xl border border-border/60 bg-elevated/30 text-caption text-text-muted">
+          ...
+        </div>
       ) : hasData ? (
-        <>
-          <div className="h-40 w-full" role="img" aria-label={t('routerDetail.ports.seriesTitle')}>
-            <ResponsiveContainer width="100%" height="100%">
-              <AreaChart data={chartData} margin={{ top: 4, right: 0, bottom: 0, left: 0 }}>
-                <defs>
-                  <linearGradient id="port-rx-grad" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.25} />
-                    <stop offset="100%" stopColor="#3b82f6" stopOpacity={0} />
-                  </linearGradient>
-                  <linearGradient id="port-tx-grad" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="0%" stopColor="#10b981" stopOpacity={0.22} />
-                    <stop offset="100%" stopColor="#10b981" stopOpacity={0} />
-                  </linearGradient>
-                </defs>
-                <CartesianGrid vertical={false} stroke="rgb(var(--border) / 0.5)" strokeDasharray="3 6" />
-                <XAxis dataKey="t" hide />
-                <Tooltip content={<PortTooltip unit={unit} />} cursor={{ stroke: 'rgb(var(--border-strong))', strokeWidth: 1 }} />
-                <Area
-                  type="monotone"
-                  dataKey="rx"
-                  name="RX"
-                  stroke="#3b82f6"
-                  strokeWidth={1.5}
-                  fill="url(#port-rx-grad)"
-                  dot={false}
-                  activeDot={{ r: 3, strokeWidth: 0, fill: '#3b82f6' }}
-                  animationDuration={500}
-                  animationEasing="ease-out"
-                  isAnimationActive={false}
-                />
-                <Area
-                  type="monotone"
-                  dataKey="tx"
-                  name="TX"
-                  stroke="#10b981"
-                  strokeWidth={1.5}
-                  fill="url(#port-tx-grad)"
-                  dot={false}
-                  activeDot={{ r: 3, strokeWidth: 0, fill: '#10b981' }}
-                  animationDuration={500}
-                  animationEasing="ease-out"
-                  isAnimationActive={false}
-                />
-              </AreaChart>
-            </ResponsiveContainer>
-          </div>
-          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-caption text-text-muted">
-            <span className="inline-flex items-center gap-1.5">
-              <span className="h-2 w-2 rounded-full bg-[#3b82f6]" /> RX {t('routerDetail.ports.seriesRx')}
-            </span>
-            <span className="inline-flex items-center gap-1.5">
-              <span className="h-2 w-2 rounded-full bg-[#10b981]" /> TX {t('routerDetail.ports.seriesTx')}
-            </span>
-            <span className="ml-auto hidden font-mono text-[10px] sm:inline">{chartData.length} pts</span>
-          </div>
-        </>
+        <div className="mt-2 h-44 w-full" role="img" aria-label={t('routerDetail.ports.seriesTitle')}>
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={chartData} margin={{ top: 4, right: 0, bottom: 0, left: 0 }}>
+              <defs>
+                <linearGradient id="port-rx-grad" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.25} />
+                  <stop offset="100%" stopColor="#3b82f6" stopOpacity={0} />
+                </linearGradient>
+                <linearGradient id="port-tx-grad" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="#10b981" stopOpacity={0.22} />
+                  <stop offset="100%" stopColor="#10b981" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid vertical={false} stroke="rgb(var(--border) / 0.5)" strokeDasharray="3 6" />
+              <XAxis dataKey="t" hide />
+              <Tooltip content={<PortTooltip unit={unit} />} cursor={{ stroke: 'rgb(var(--border-strong))', strokeWidth: 1 }} />
+              <Area
+                type="monotone"
+                dataKey="rx"
+                name="RX"
+                stroke="#3b82f6"
+                strokeWidth={1.5}
+                fill="url(#port-rx-grad)"
+                dot={false}
+                activeDot={{ r: 3, strokeWidth: 0, fill: '#3b82f6' }}
+                isAnimationActive={false}
+              />
+              <Area
+                type="monotone"
+                dataKey="tx"
+                name="TX"
+                stroke="#10b981"
+                strokeWidth={1.5}
+                fill="url(#port-tx-grad)"
+                dot={false}
+                activeDot={{ r: 3, strokeWidth: 0, fill: '#10b981' }}
+                isAnimationActive={false}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
       ) : (
-        <div className="flex h-40 items-center justify-center text-caption text-text-muted">
+        <div className="mt-2 flex h-44 items-center justify-center rounded-xl border border-border/60 bg-elevated/30 text-caption text-text-muted">
           {t('routerDetail.ports.seriesNoData')}
         </div>
       )}
-    </div>
+    </section>
   )
 }

--- a/app/src/pages/RouterDetail.tsx
+++ b/app/src/pages/RouterDetail.tsx
@@ -10,6 +10,7 @@ import { useAuth } from '@/data/AuthContext'
 import { AdGuardPanel } from '@/components/routers/AdGuardPanel'
 import { BackhaulPanel } from '@/components/routers/BackhaulPanel'
 import { PortPanel } from '@/components/routers/PortPanel'
+import { PortSeriesChart } from '@/components/routers/PortSeriesChart'
 import { RadiosPorts } from '@/components/routers/RadiosPorts'
 import { RouterClients } from '@/components/routers/RouterClients'
 import { RouterDetailHeader } from '@/components/routers/RouterDetailHeader'
@@ -27,7 +28,7 @@ export default function RouterDetail() {
   const reduce = useReducedMotion()
   const auth = useAuth()
   const isAdmin = auth?.role === 'admin'
-  const { routers, alerts, getRouterDetail } = useNetPulse()
+  const { routers, alerts, getRouterDetail, isDemo } = useNetPulse()
   const router = routers.find((r) => r.id === id)
   const isGateway = router?.roleBadge === 'Principal'
   const [detail, setDetail] = useState<RouterDetailData | null>(null)
@@ -198,6 +199,19 @@ export default function RouterDetail() {
         </>
       ) : (
         <RadiosPorts router={router} extras={detail?.extras} />
+      )}
+
+      {/* Historial de tráfico por puerto: tarjeta propia a todo el ancho
+          (issue #654; no va embebido en la tarjeta de Puertos Ethernet). */}
+      {!isDemo && detail?.extras?.ethPorts && detail.extras.ethPorts.length > 0 && (
+        <PortSeriesChart
+          routerId={router.id}
+          ports={detail.extras.ethPorts}
+          // #641: managed-switch/external (beacons RTLPlayground, SNMP) no
+          // reportan byte counters → la serie se muestra en frames/s.
+          unit={router.type === 'managed-switch' || router.type === 'external' ? 'fps' : 'bps'}
+          className="lg:col-span-12"
+        />
       )}
 
       {/* VLANs del bridge (issue #315, read-only) */}


### PR DESCRIPTION
## What
The port traffic history (`PortSeriesChart`) introduced in #654 is rendered **inside the "Puertos Ethernet" card** (`PortPanel`): on an AP with radios that card is narrow (col-span-5), and even full-width it competes with the RJ45 jacks below. The user wants it as its **own full-width card** in the router detail, separate from the Ethernet ports card.

## Expected
- Remove the traffic history block from `PortPanel` (keep only the RJ45 jacks).
- Render `PortSeriesChart` as its own detail card at `lg:col-span-12` (live only, when the router has ethPorts), with a **port selector** (since it no longer sits inside the ports card, the chart must show which port is being plotted; default = first port up, but any port with history is selectable) plus the existing range selector (24h/7d/30d) and RX/TX tooltip from #654.
