### PR TITLE
fix(settings): restore native OpenWrt role in devices table (#660)

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1148,7 +1148,8 @@
       "snmpPort": "Port",
       "snmpPollInterval": "Interval (s)",
       "sshPort": "SSH port",
-      "sshPortHint": "SSH port of the router (default 22)"
+      "sshPortHint": "SSH port of the router (default 22)",
+      "openWrtBadge": "OpenWrt"
     },
     "overrides": {
       "title": "Topology — manual tagging",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1148,7 +1148,8 @@
       "snmpPort": "Puerto",
       "snmpPollInterval": "Intervalo (s)",
       "sshPort": "Puerto SSH",
-      "sshPortHint": "Puerto SSH del router (22 por defecto)"
+      "sshPortHint": "Puerto SSH del router (22 por defecto)",
+      "openWrtBadge": "OpenWrt"
     },
     "overrides": {
       "title": "Topología — etiquetado manual",

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -660,9 +660,17 @@ function RoutersManager({ reduce, onSaved }: { reduce: boolean; onSaved: () => v
                       <span className="rounded bg-elevated px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-text-muted ring-1 ring-inset ring-border">
                         {t('settings.routers.agentOnlyBadge')}
                       </span>
-                    ) : (
+                    ) : r.type === 'managed-switch' ? (
                       <span className="rounded bg-elevated px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-text-muted ring-1 ring-inset ring-border">
                         {t('settings.routers.typeManaged')}
+                      </span>
+                    ) : r.type === 'external' ? (
+                      <span className="rounded bg-elevated px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-text-muted ring-1 ring-inset ring-border">
+                        {t('settings.routers.typeExternal')}
+                      </span>
+                    ) : (
+                      <span className="rounded bg-elevated px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-text-primary ring-1 ring-inset ring-border">
+                        {t('settings.routers.openWrtBadge')}
                       </span>
                     )}
                   </td>


### PR DESCRIPTION
## Summary

The Role column in Settings > Devices was refactored during the Settings redesign (#627) into a three-state pill (Gateway / Agent only / Managed switch) and lost the native **OpenWrt** type. A regular OpenWrt router running the SSH-based agent fell into the fallback branch and rendered as "Managed switch", which is wrong.

## Change

Branch the role label on the device type instead of only on gateway/agent_only:

| Type | Label |
|---|---|
| gateway | Main |
| agent_only | Agent only |
| `managed-switch` | Managed switch |
| `external` | External |
| `openwrt` / `glinet` | **OpenWrt** (new) |

Adds the `openWrtBadge` i18n key to the `es` and `en` locale files.

## Verification

- `npm run build` (tsc + vite) passes.
- `npm run lint` passes with 0 errors (5 pre-existing warnings in Reports/Roaming, unrelated).

Cosmetic fix, no API contract change.

Closes #660