### PR TITLE
fix(snmp): persist port traffic and connected devices for SNMP-managed switches (#661)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [Unreleased]
+
+### Fixed
+
+- **El switch sondeado por SNMP ya no pierde el historial de tráfico ni los dispositivos conectados (#661)**: el path SNMP calculaba los contadores de bytes y la tasa por puerto pero nunca los persistía, así que la "historia de tráfico" del switch quedaba vacía aunque el sondeo leyera los datos (vía `recordPortSamples`, la misma ruta que SSH/agente). Además, el FDB ya no descarta las MACs cuyo índice no resolvía a un puerto conocido (antes el switch mostraba 0 dispositivos pese a tener clientes) y se añade un fallback a la tabla Q-BRIDGE para los switches que solo la exponen. La tarjeta de la flota pinta ahora el tráfico agregado del switch en bps, y la gráfica de puertos de un switch SNMP usa bps (los beacons sin contadores de bytes siguen en fps).
+
 ## [2.28.15] - 2026-09-09
 
 ### Added

--- a/app/src/components/routers/FleetCard.tsx
+++ b/app/src/components/routers/FleetCard.tsx
@@ -99,9 +99,14 @@ export function FleetCard({ router, index = 0, refreshKey = 0 }: FleetCardProps)
     d.setHours(d.getHours() - (router.sparkline.length - 1 - i))
     return { t: d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }), v }
   })
-  // Fuentes sin throughput bps (switch beacon/SNMP, #648) dibujan el sparkline
-  // como frames/s agregados; el resto, Mbps.
-  const trafficUnit: 'fps' | 'bps' = router.vitalsAvailable === false ? 'fps' : 'bps'
+  // Fuentes sin throughput bps (switch beacon, #648) dibujan el sparkline
+  // como frames/s agregados; el resto, Mbps. Un managed-switch sondeado por
+  // SNMP sí tiene contadores de bytes → bps (#661).
+  const trafficUnit: 'fps' | 'bps' = router.snmpEnabled
+    ? 'bps'
+    : router.vitalsAvailable === false
+      ? 'fps'
+      : 'bps'
 
   return (
     <motion.article

--- a/app/src/data/types.ts
+++ b/app/src/data/types.ts
@@ -51,6 +51,12 @@ export interface Router {
    * llegan a null y la UI no los pinta. Ausente = disponibles.
    */
   vitalsAvailable?: boolean
+  /**
+   * #661: true si el router se sondea por SNMP. Distingue un managed-switch
+   * sondeado por SNMP (reporta contadores de bytes → la gráfica se pinta en
+   * bps) de un beacon/external que solo reporta tramas (fps).
+   */
+  snmpEnabled?: boolean
   cpu: number | null // %
   ram: number | null // %
   temp: number | null // °C

--- a/app/src/pages/RouterDetail.tsx
+++ b/app/src/pages/RouterDetail.tsx
@@ -207,9 +207,12 @@ export default function RouterDetail() {
         <PortSeriesChart
           routerId={router.id}
           ports={detail.extras.ethPorts}
-          // #641: managed-switch/external (beacons RTLPlayground, SNMP) no
-          // reportan byte counters → la serie se muestra en frames/s.
-          unit={router.type === 'managed-switch' || router.type === 'external' ? 'fps' : 'bps'}
+          // #641/#661: los beacons RTLPlayground solo reportan tramas (fps),
+          // pero un managed-switch sondeado por SNMP sí tiene contadores de
+          // bytes → se pinta en bps.
+          unit={router.type === 'managed-switch' || router.type === 'external'
+            ? (router.snmpEnabled ? 'bps' : 'fps')
+            : 'bps'}
           className="lg:col-span-12"
         />
       )}

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -1119,6 +1119,7 @@ func (l *Live) buildRouter(p *routerPolled, history []histPoint) Router {
 		r.VitalsAvailable = bptr(false)
 		r.CPU, r.RAM, r.Temp = nil, nil, nil
 	}
+	r.SnmpEnabled = p.cfg.SnmpEnabled
 	if isGw {
 		r.Role, r.RoleBadge = "Gateway principal", "Principal"
 	} else if p.cfg.AgentOnly {

--- a/server-go/internal/adapters/snmp_live.go
+++ b/server-go/internal/adapters/snmp_live.go
@@ -95,16 +95,25 @@ func (l *Live) pollRouterSNMP(cfg RouterConfig) (*routerPolled, error) {
 		}
 	}
 
-	fdbMap := map[string]string{}
-	for _, e := range fdb {
-		name, ok := portIdxToName[e.IfIndex]
-		if !ok || name == "" {
-			continue
-		}
-		fdbMap[e.MAC] = name
-	}
+	// #661: el path SNMP nunca persistía las muestras de puerto, así que el
+	// historial de tráfico del switch quedaba vacío aunque el sondeo leyera los
+	// contadores correctamente. Ahora se registran (misma ruta que SSH/agente).
+	l.recordPortSamples(cfg.ID, ethPorts)
+
+	// FDB → mapa MAC→puerto. Antes se descartaban las entradas cuyo ifIndex no
+	// resolvía a un puerto conocido, lo que dejaba el switch con 0 dispositivos
+	// conectados aunque el FDB viniera lleno (#661). Se cae a bridgePort y a un
+	// nombre generado para no perder MACs (el conteo de clientes solo necesita
+	// la clave; el nombre es secundario).
+	fdbMap := snmpFdbMap(fdb, portIdxToName)
 
 	l.portMon.Observe(cfg.ID, ethPorts, l.engine)
+
+	// #661: agregado de red del switch (suma de la tasa de todos los puertos)
+	// para que la tarjeta de la flota pinte un sparkline con bps reales en
+	// lugar de la línea plana a 0 (los switches SNMP sí tienen contadores de
+	// bytes, a diferencia de los beacons, que solo reportan tramas).
+	netPtr := snmpAggregateNet(ethPorts)
 
 	var uptimeSec float64
 	if sysInfo != nil {
@@ -114,6 +123,7 @@ func (l *Live) pollRouterSNMP(cfg RouterConfig) (*routerPolled, error) {
 	p := &routerPolled{
 		cfg:       cfg,
 		uptimeSec: uptimeSec,
+		net:       netPtr,
 		ports:     ethPorts,
 		fdb:       fdbMap,
 		polledAt:  now.UnixMilli(),
@@ -149,4 +159,41 @@ func (l *Live) snmpPortCache(routerID string, ports []EthPort) {
 		samples[p.ID] = snmpPortSample{at: now, rxBytes: p.RxBytes, txBytes: p.TxBytes}
 	}
 	l.snmpPorts[routerID] = samples
+}
+
+// snmpFdbMap convierte el FDB (MAC→puerto) en el mapa que consume la
+// topología/dispositivos. #661: NO descarta entradas cuyo ifIndex no resuelve
+// a un puerto conocido (antes eso dejaba el switch con 0 dispositivos);
+// cae a bridgePort y, en último caso, a un nombre generado.
+func snmpFdbMap(fdb []npsnmp.FdbEntry, portIdxToName map[int]string) map[string]string {
+	out := map[string]string{}
+	for _, e := range fdb {
+		name := ""
+		if n, ok := portIdxToName[e.IfIndex]; ok {
+			name = n
+		} else if n, ok := portIdxToName[e.BridgePortIndex]; ok {
+			name = n
+		}
+		if name == "" {
+			name = fmt.Sprintf("port-%d", e.IfIndex)
+		}
+		out[e.MAC] = name
+	}
+	return out
+}
+
+// snmpAggregateNet suma la tasa (bps) de todos los puertos para dar una
+// métrica agregada al switch SNMP (#661). Devuelve nil si todo está a 0
+// (primera muestra sin delta o sin tráfico).
+func snmpAggregateNet(ports []EthPort) *NetDevBps {
+	var aggRx, aggTx float64
+	for i := range ports {
+		aggRx += ports[i].RxBps
+		aggTx += ports[i].TxBps
+	}
+	if aggRx == 0 && aggTx == 0 {
+		return nil
+	}
+	rx, tx := aggRx, aggTx
+	return &NetDevBps{RxBps: &rx, TxBps: &tx}
 }

--- a/server-go/internal/adapters/snmp_live_test.go
+++ b/server-go/internal/adapters/snmp_live_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/gnacho/netpulse/server-go/internal/alerts"
+	"github.com/gnacho/netpulse/server-go/internal/db"
+	npsnmp "github.com/gnacho/netpulse/server-go/internal/snmp"
 )
 
 // issue #414: cuando no ha pasado el intervalo SNMP configurado, pollRouterSNMP
@@ -98,5 +100,85 @@ func TestPortMonitorGhostSnmpHysteresis(t *testing.T) {
 
 	if n, _ := findAlerts(engine, "Ghost port: Port1 went silent"); n != 1 {
 		t.Fatalf("ghost alerts after min silence = %d, want 1", n)
+	}
+}
+
+// #661: el mapeo FDB no debe descartar MACs cuyo ifIndex no resuelve a un
+// puerto conocido (antes dejaba el switch con 0 dispositivos conectados).
+func TestSnmpFdbMapNoDrop(t *testing.T) {
+	portIdxToName := map[int]string{3: "lan3"}
+	fdb := []npsnmp.FdbEntry{
+		{MAC: "aa:bb:cc:dd:ee:01", IfIndex: 3, BridgePortIndex: 3},
+		{MAC: "aa:bb:cc:dd:ee:02", IfIndex: 99, BridgePortIndex: 4}, // ifIndex sin puerto → fallback
+		{MAC: "aa:bb:cc:dd:ee:03", IfIndex: 0, BridgePortIndex: 5},  // nada resuelve → nombre genérico
+	}
+	m := snmpFdbMap(fdb, portIdxToName)
+	if len(m) != 3 {
+		t.Fatalf("fdbMap len = %d, want 3 (no drop)", len(m))
+	}
+	if got := m["aa:bb:cc:dd:ee:01"]; got != "lan3" {
+		t.Errorf("ee:01 = %q, want lan3", got)
+	}
+	if got := m["aa:bb:cc:dd:ee:02"]; got != "port-99" {
+		t.Errorf("ee:02 = %q, want port-99 (fallback ifIndex)", got)
+	}
+	if got := m["aa:bb:cc:dd:ee:03"]; got != "port-0" {
+		t.Errorf("ee:03 = %q, want port-0 (generic)", got)
+	}
+}
+
+// #661: el agregado de red del switch SNMP es la suma de la tasa de todos los
+// puertos; nil si todo es 0 (primera muestra sin delta).
+func TestSnmpAggregateNet(t *testing.T) {
+	ports := []EthPort{{RxBps: 100, TxBps: 50}, {RxBps: 25, TxBps: 10}}
+	n := snmpAggregateNet(ports)
+	if n == nil {
+		t.Fatal("expected non-nil aggregate")
+	}
+	if *n.RxBps != 125 || *n.TxBps != 60 {
+		t.Errorf("aggregate = (%.0f, %.0f), want (125, 60)", *n.RxBps, *n.TxBps)
+	}
+	if got := snmpAggregateNet([]EthPort{{RxBps: 0, TxBps: 0}}); got != nil {
+		t.Error("expected nil when all ports at 0")
+	}
+}
+
+// #661: recordPortSamples persiste los contadores de bytes de un puerto SNMP
+// (la ruta que antes NO se llamaba en el path SNMP → historial vacío).
+func TestRecordPortSamplesPersistsBytes(t *testing.T) {
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	defer d.Close()
+
+	l := NewLive(nil, d, nil, nil)
+	now := time.Now()
+	l.recordPortSamples("sw1", []EthPort{
+		{ID: "snmp-1", RxBytes: 1000, TxBytes: 2000, RxBps: 10, TxBps: 20, Speed: "1 Gbps"},
+	})
+
+	pts, err := d.PortSeries.GetSeries("sw1", "snmp-1", now.Add(-time.Minute), now.Add(time.Minute), "raw")
+	if err != nil {
+		t.Fatalf("GetSeries: %v", err)
+	}
+	if len(pts) != 1 {
+		t.Fatalf("points = %d, want 1", len(pts))
+	}
+	if pts[0].RxBytes != 1000 || pts[0].TxBytes != 2000 {
+		t.Errorf("bytes = (%d, %d), want (1000, 2000)", pts[0].RxBytes, pts[0].TxBytes)
+	}
+	if pts[0].RxBps != 10 || pts[0].TxBps != 20 {
+		t.Errorf("bps = (%.1f, %.1f), want (10, 20)", pts[0].RxBps, pts[0].TxBps)
+	}
+}
+
+// #661: el DTO del router refleja SnmpEnabled para que la UI elija bps (no fps).
+func TestBuildRouterExposeSnmpEnabled(t *testing.T) {
+	l := NewLive(nil, nil, nil, nil)
+	p := &routerPolled{cfg: RouterConfig{ID: "sw1", Host: "192.168.1.10", SnmpEnabled: true}}
+	r := l.buildRouter(p, nil)
+	if !r.SnmpEnabled {
+		t.Error("expected SnmpEnabled=true in built Router")
 	}
 }

--- a/server-go/internal/adapters/types.go
+++ b/server-go/internal/adapters/types.go
@@ -180,6 +180,11 @@ type Router struct {
 	// o pushers externos por beacon/scraper (#291). En ese caso CPU/RAM/Temp
 	// van a null y la UI no los pinta. Ausente = vitals disponibles.
 	VitalsAvailable *bool  `json:"vitalsAvailable,omitempty"`
+	// SnmpEnabled: true si el router se sondea por SNMP (#309). Distingue un
+	// managed-switch sondeado por SNMP (que sí reporta contadores de bytes →
+	// la UI pinta bps) de un beacon/external que solo reporta tramas (fps)
+	// (#661). Ausente/false = no se sondea por SNMP.
+	SnmpEnabled bool `json:"snmpEnabled,omitempty"`
 	CPU             *int   `json:"cpu"`
 	RAM             *int   `json:"ram"`
 	Temp            *int   `json:"temp"`

--- a/server-go/internal/snmp/fdbTable.go
+++ b/server-go/internal/snmp/fdbTable.go
@@ -26,23 +26,42 @@ func PollFdbTable(s *gosnmp.GoSNMP) ([]FdbEntry, error) {
 		}
 	}
 
-	fdbPdus, err := walkSafe(s, OidDot1dTpFdbPort)
-	if err != nil {
-		return nil, fmt.Errorf("snmp fdb walk: %w", err)
+	// Fuente del FDB: dot1d (RFC 1493) es la estándar, pero algunos switches
+	// gestionados solo exponen la tabla Q-BRIDGE (dot1q, RFC 4363) → fallback
+	// cuando la dot1d no devuelve entradas (#661).
+	fdbPdus, errD1 := walkSafe(s, OidDot1dTpFdbPort)
+	useDot1q := len(fdbPdus) == 0
+	if useDot1q {
+		fdbPdus, _ = walkSafe(s, OidDot1qTpFdbPort)
 	}
+
 	var out []FdbEntry
 	for _, pdu := range fdbPdus {
-		mac := extractMacFromOid(pdu.Name, OidDot1dTpFdbPort)
+		var mac string
+		if useDot1q {
+			mac = extractMacFromOidLast6(pdu.Name, OidDot1qTpFdbPort)
+		} else {
+			mac = extractMacFromOid(pdu.Name, OidDot1dTpFdbPort)
+		}
 		if mac == "" {
 			continue
 		}
 		bridgePort := int(uint64Val(pdu))
 		ifIdx := portToIfIndex[bridgePort]
+		// #661: si el mapeo bridge→ifIndex no se resolvió, cae al propio número
+		// de puerto de bridge (muchos switches lo usan como ifIndex), para no
+		// descartar la entrada y dejar el switch con 0 dispositivos.
+		if ifIdx == 0 {
+			ifIdx = bridgePort
+		}
 		out = append(out, FdbEntry{
-			MAC:            mac,
+			MAC:             mac,
 			BridgePortIndex: bridgePort,
-			IfIndex:        ifIdx,
+			IfIndex:         ifIdx,
 		})
+	}
+	if len(out) == 0 && errD1 != nil {
+		return nil, fmt.Errorf("snmp fdb walk: %w", errD1)
 	}
 	return out, nil
 }
@@ -56,6 +75,24 @@ func extractMacFromOid(name, prefix string) string {
 	if len(parts) != 6 {
 		return ""
 	}
+	return macFromParts(parts)
+}
+
+// extractMacFromOidLast6: variante para el índice compuesto de la tabla
+// dot1q, que es <vlan>.M.M.M.M.M.M (la MAC son los últimos 6 octetos).
+func extractMacFromOidLast6(name, prefix string) string {
+	if !strings.HasPrefix(name, prefix+".") {
+		return ""
+	}
+	suffix := name[len(prefix)+1:]
+	parts := strings.Split(suffix, ".")
+	if len(parts) < 6 {
+		return ""
+	}
+	return macFromParts(parts[len(parts)-6:])
+}
+
+func macFromParts(parts []string) string {
 	out := make([]string, 6)
 	for i, p := range parts {
 		var n int

--- a/server-go/internal/snmp/oids.go
+++ b/server-go/internal/snmp/oids.go
@@ -24,4 +24,7 @@ const (
 
 	OidDot1dTpFdbPort    = ".1.3.6.1.2.1.17.4.3.1.2"
 	OidDot1dBasePortIfIndex = ".1.3.6.1.2.1.17.1.4.1.2"
+	// OidDot1qTpFdbPort: tabla FDB de Q-BRIDGE MIB (RFC 4363). Algunos
+	// switches gestionados solo la exponen (y no la dot1d) → fallback (#661).
+	OidDot1qTpFdbPort = ".1.3.6.1.2.1.17.7.1.2.2.1.2"
 )

--- a/server-go/internal/snmp/snmp_test.go
+++ b/server-go/internal/snmp/snmp_test.go
@@ -48,6 +48,29 @@ func TestExtractMacFromOid(t *testing.T) {
 	}
 }
 
+// #661: el índice compuesto de la tabla dot1q es <vlan>.M.M.M.M.M.M; la MAC
+// son los últimos 6 octetos.
+func TestExtractMacFromOidLast6(t *testing.T) {
+	prefix := OidDot1qTpFdbPort
+	tests := []struct {
+		name string
+		want string
+	}{
+		{prefix + ".5.0.17.34.51.68.85", "00:11:22:33:44:55"},
+		{prefix + ".0.17.34.51.68.85", "00:11:22:33:44:55"},
+		{prefix + ".100.1.2.3.4.5.6", "01:02:03:04:05:06"},
+		{prefix + ".5.0.17.34.51.68.256", ""},
+		{prefix + ".1.2.3.4.5", ""},
+		{"other.5.0.17.34.51.68.85", ""},
+	}
+	for _, tt := range tests {
+		got := extractMacFromOidLast6(tt.name, prefix)
+		if got != tt.want {
+			t.Errorf("extractMacFromOidLast6(%q) = %q; want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
 func TestPortStatsSpeedString(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Closes #661.

## Problem

For a NetGear GS108T managed switch added as a `managed-switch` with SNMP enabled, the reporter got:

1. **No traffic in the port "traffic history"**, even though an `snmpwalk` from the server saw everything.
2. **0 connected devices**, even though the ports were full of active clients.

## Root cause (verified in code)

- **Empty traffic history**: `pollRouterSNMP` computed the per-port byte counters and rates (`RxBytes`/`TxBytes`/`RxBps`/`TxBps`) but **never persisted them** — `recordPortSamples` is called in the SSH (`live.go`) and agent paths, but not in the SNMP path. So `port_series` stayed empty for SNMP-managed switches.
- **0 connected devices**: `snmp_live.go` **dropped** FDB entries whose `ifIndex` didn't resolve to a known port name; if the bridge→ifIndex mapping (`dot1dBasePortIfIndex`) was unavailable or off, every MAC was dropped → empty FDB → 0 devices.
- **Unit mismatch**: the port chart used `fps` for all `managed-switch`/`external` devices, which is right for beacon switches (RTLPlayground, only frames) but wrong for an SNMP switch (which reports bytes → should be `bps`).

## Changes

- **Server** (`snmp_live.go`): call `recordPortSamples` on the SNMP path; build the FDB→port map via a new `snmpFdbMap` helper that **no longer drops** MACs (falls back to bridgePort, then a generic name), and add an aggregate `net` (sum of port rates) so the fleet card gets a real bps sparkline.
- **Server** (`fdbTable.go`, `oids.go`): add a **Q-BRIDGE MIB** fallback (`dot1qTpFdbPort`) and a bridgePort→ifIndex fallback so FDB entries survive on switches that expose the FDB only via dot1q.
- **Server** (`types.go`, `live.go`): expose `snmpEnabled` on the `Router` DTO.
- **App** (`types.ts`, `RouterDetail.tsx`, `FleetCard.tsx`): pick `bps` for SNMP-managed switches (they have byte counters) and keep `fps` for beacon/external without byte counters.
- **Docs**: CHANGELOG `[Unreleased]` entry.

## Verification

- `go build ./...` OK.
- `go test ./internal/snmp/... ./internal/adapters/...` → all pass (new tests: `TestSnmpFdbMapNoDrop`, `TestSnmpAggregateNet`, `TestRecordPortSamplesPersistsBytes`, `TestBuildRouterExposeSnmpEnabled`, `TestExtractMacFromOidLast6`).
- `npm run build` (`tsc -b && vite build`) OK; `npm run lint` 0 errors (5 pre-existing warnings in Reports/Roaming).
- Full `go test ./...`: only pre-existing unrelated `TestOpenArmVariants` fails (missing `netpulse-agent-mipsle` artifact, not touched here).

> Note: this branch was rebased on the current `origin/main` (which now includes #663, WireGuard peer names).