### PR TITLE
chore: prepare v2.28.16 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
-## [Unreleased]
+## [2.28.16] - 2026-09-09
+
+### Added
+
+- **Los peers WireGuard se etiquetan por su nombre configurado en OpenWrt (#663)**: en la topología, los peers WireGuard que no estaban ya mapeados a un dispositivo NetPulse se muestran ahora con el nombre legible de la descripción UCI del peer (prioridad: nombre del dispositivo NetPulse → descripción UCI → IP del túnel), en lugar de la IP cruda del túnel. El sondeo lee `wg show dump` y `uci show network` en una sola sesión SSH (con marcador de separación) y conserva el estado de un túnel caído.
 
 ### Fixed
 
+- **Un router OpenWrt nativo ya no aparece como "Managed switch" en la tabla de dispositivos (#660)**: la columna Role distinguía solo gateway y "solo agente", y el resto caía en "Managed switch"; ahora se basa en el tipo del dispositivo y muestra "OpenWrt" para los routers nativos (agente SSH), dejando "Managed switch"/External para los sondeados por SNMP.
 - **El switch sondeado por SNMP ya no pierde el historial de tráfico ni los dispositivos conectados (#661)**: el path SNMP calculaba los contadores de bytes y la tasa por puerto pero nunca los persistía, así que la "historia de tráfico" del switch quedaba vacía aunque el sondeo leyera los datos (vía `recordPortSamples`, la misma ruta que SSH/agente). Además, el FDB ya no descarta las MACs cuyo índice no resolvía a un puerto conocido (antes el switch mostraba 0 dispositivos pese a tener clientes) y se añade un fallback a la tabla Q-BRIDGE para los switches que solo la exponen. La tarjeta de la flota pinta ahora el tráfico agregado del switch en bps, y la gráfica de puertos de un switch SNMP usa bps (los beacons sin contadores de bytes siguen en fps).
 
 ## [2.28.15] - 2026-09-09

--- a/README.es.md
+++ b/README.es.md
@@ -97,7 +97,16 @@ enlazada al issue de GitHub que la originó.
 > Están escritas para personas, no como changelog: qué hace la función por ti,
 > no los nombres de las funciones internas.
 
-### Última (v2.28.15)
+### Última (v2.28.16)
+
+- **Los peers WireGuard se etiquetan por su nombre configurado en OpenWrt** ([#663](https://github.com/gnacho/netpulse/issues/663)). En la topología, los peers WireGuard que no estaban ya mapeados a un dispositivo NetPulse se muestran ahora con el nombre legible de la descripción UCI del peer (prioridad: nombre del dispositivo NetPulse → descripción UCI → IP del túnel) en lugar de la IP cruda del túnel. El sondeo lee `wg show dump` y `uci show network` en una sola sesión SSH (con marcador de separación) y conserva el estado de un túnel caído.
+
+### Arreglado
+
+- **Un router OpenWrt nativo ya no aparece como "Managed switch" en la tabla de dispositivos** ([#660](https://github.com/gnacho/netpulse/issues/660)). La columna Role distinguía solo gateway y "solo agente", y el resto caía en "Managed switch"; ahora se basa en el tipo del dispositivo y muestra "OpenWrt" para los routers nativos (agente SSH), dejando "Managed switch"/External para los sondeados por SNMP.
+- **El switch sondeado por SNMP ya no pierde el historial de tráfico ni los dispositivos conectados** ([#661](https://github.com/gnacho/netpulse/issues/661)). El sondeo SNMP calculaba los contadores de bytes y la tasa por puerto pero nunca los persistía, así que la "historia de tráfico" del switch quedaba vacía aunque leyera los datos (ahora vía `recordPortSamples`, la misma ruta que SSH/agente). El FDB ya no descarta las MACs cuyo índice no resolvía a un puerto conocido (antes el switch mostraba 0 dispositivos pese a tener clientes) y hay un fallback a la tabla Q-BRIDGE para los switches que solo la exponen. La tarjeta de la flota pinta ahora el tráfico agregado del switch en bps, y la gráfica de puertos de un switch SNMP usa bps (los beacons sin contadores de bytes siguen en fps).
+
+### Anterior (v2.28.15)
 
 - **La gráfica de tráfico de los puertos muestra frames/s cuando el dispositivo no mide bytes** ([#641](https://github.com/gnacho/netpulse/issues/641)). Los beacons de switches RTLPlayground (KP-9000) solo reportan contadores acumulados de tramas, no bytes. El servidor deriva ahora frames/s de esos contadores (raw, 5m y diario) y la tarjeta de Puertos del detalle dibuja fps en lugar de bps para las fuentes sin contadores de bytes, así la gráfica de un puerto de switch gestionado ya no parece vacía.
 - **La flota y el detalle muestran el desglose real de clientes por banda** ([#645](https://github.com/gnacho/netpulse/issues/645)). Cada tarjeta de router indica ahora sus clientes online por banda (2.4/5/6 GHz y cable) calculado en el servidor con la misma fuente que el total, y solo pinta las bandas que tienen clientes: un switch sin radios wifi ya no muestra bandas wifi a 0.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,16 @@ latest improvements, each linked to the GitHub issue that drove it.
 > These are written for people, not changelogs: what the feature does for you,
 > not the function names behind it.
 
-### Latest (v2.28.15)
+### Latest (v2.28.16)
+
+- **WireGuard peers are now labeled by their OpenWrt-configured name** ([#663](https://github.com/gnacho/netpulse/issues/663)). In the topology, WireGuard peers that weren't already mapped to a NetPulse device now show the human-readable name from the peer's UCI description (priority: NetPulse device name → UCI description → tunnel IP) instead of the raw tunnel IP. The poll reads `wg show dump` and `uci show network` in a single SSH session and preserves a down tunnel's state.
+
+### Fixed
+
+- **A native OpenWrt router no longer shows as "Managed switch" in the devices table** ([#660](https://github.com/gnacho/netpulse/issues/660)). The Role column only distinguished gateway and "agent only", and everything else fell into "Managed switch"; it now switches on the device type and shows "OpenWrt" for native (SSH agent) routers, leaving "Managed switch"/External for SNMP-polled ones.
+- **An SNMP-polled switch no longer loses its traffic history or connected devices** ([#661](https://github.com/gnacho/netpulse/issues/661)). The SNMP path computed the per-port byte counters and rates but never persisted them, so the switch's traffic history was empty even though the poll read the data (now via `recordPortSamples`, the same path as the SSH/agent flows). The FDB also no longer drops MACs whose index didn't resolve to a known port (before, the switch showed 0 devices despite having clients) and there's a Q-BRIDGE MIB fallback for switches that only expose it that way. The fleet card now plots the switch's aggregate traffic in bps, and the port chart of an SNMP switch uses bps (beacons without byte counters keep using fps).
+
+### Earlier (v2.28.15)
 
 - **Port traffic charts now show frames/s for devices that don't count bytes** ([#641](https://github.com/gnacho/netpulse/issues/641)). RTLPlayground switch beacons (KP-9000) only report cumulative frame counters, not bytes. The server now derives frames/s from those counters (raw, 5m and daily) and the port card in the detail page plots fps instead of bps for sources without byte counters, so a managed switch port chart no longer looks empty.
 - **Fleet cards and the router detail show the real per-band client split** ([#645](https://github.com/gnacho/netpulse/issues/645)). Each router card now lists its online clients by band (2.4/5/6 GHz and wired) computed server-side from the same source as the total, and only renders bands that actually have clients: a switch with no WiFi radios no longer shows WiFi bands stuck at zero.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.15",
+  "version": "2.28.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse",
-      "version": "2.28.15",
+      "version": "2.28.16",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.15",
+  "version": "2.28.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.15"
+var Version = "2.28.16"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Release prepare for **v2.28.16**, accumulating the changes merged to `main` since v2.28.15:

- **#663** (feature) WireGuard peers labeled by their OpenWrt-configured name in the topology.
- **#660** (fix) native OpenWrt routers no longer show as "Managed switch" in the devices table.
- **#661** (fix) SNMP-polled switches keep their traffic history and connected devices.

Bumps `app/package.json`/`package-lock.json` and the server `var Version` to `2.28.16`, moves the CHANGELOG `[Unreleased]` into `[2.28.16]` (Added/Fixed) and updates the README What's new / Novedades.