### PR TITLE
chore: prepare v2.28.17 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.28.17] - 2026-09-09
+
+### Fixed
+
+- **Un router OpenWrt ya no cae en falso "host key changed" al sondearlo (#651)**: el descubrimiento (openssh con `accept-new`) registraba en `known_hosts` solo la host key que negociaba (ed25519), pero el sondeo Go negocia otra (ecdsa/rsa) con el mismo servidor; un host con varias host keys daba un falso "ssh host key changed" y exigía un re-onboard sin motivo. Ahora el descubrimiento pinas todas las host keys del router (ed25519, ecdsa y rsa), de forma que el sondeo siempre encuentra la suya sin debilitar la protección anti-MITM: si el router cambia todas sus claves (reflash), la detección de "host key changed" sigue intacta.
+
 ## [2.28.16] - 2026-09-09
 
 ### Added
@@ -15,7 +21,6 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 - **Un router OpenWrt nativo ya no aparece como "Managed switch" en la tabla de dispositivos (#660)**: la columna Role distinguía solo gateway y "solo agente", y el resto caía en "Managed switch"; ahora se basa en el tipo del dispositivo y muestra "OpenWrt" para los routers nativos (agente SSH), dejando "Managed switch"/External para los sondeados por SNMP.
 - **El switch sondeado por SNMP ya no pierde el historial de tráfico ni los dispositivos conectados (#661)**: el path SNMP calculaba los contadores de bytes y la tasa por puerto pero nunca los persistía, así que la "historia de tráfico" del switch quedaba vacía aunque el sondeo leyera los datos (vía `recordPortSamples`, la misma ruta que SSH/agente). Además, el FDB ya no descarta las MACs cuyo índice no resolvía a un puerto conocido (antes el switch mostraba 0 dispositivos pese a tener clientes) y se añade un fallback a la tabla Q-BRIDGE para los switches que solo la exponen. La tarjeta de la flota pinta ahora el tráfico agregado del switch en bps, y la gráfica de puertos de un switch SNMP usa bps (los beacons sin contadores de bytes siguen en fps).
-- **Un router OpenWrt ya no cae en falso "host key changed" al sondearlo (#651)**: el descubrimiento (openssh con `accept-new`) registraba en `known_hosts` solo la host key que negociaba (ed25519), pero el sondeo Go negocia otra (ecdsa/rsa) con el mismo servidor; un host con varias host keys daba un falso "ssh host key changed" y exigía un re-onboard sin motivo. Ahora el descubrimiento pinas todas las host keys del router (ed25519, ecdsa y rsa), de forma que el sondeo siempre encuentra la suya sin debilitar la protección anti-MITM: si el router cambia todas sus claves (reflash), la detección de "host key changed" sigue intacta.
 
 ## [2.28.15] - 2026-09-09
 

--- a/README.es.md
+++ b/README.es.md
@@ -97,7 +97,11 @@ enlazada al issue de GitHub que la originó.
 > Están escritas para personas, no como changelog: qué hace la función por ti,
 > no los nombres de las funciones internas.
 
-### Última (v2.28.16)
+### Última (v2.28.17)
+
+- **Un router OpenWrt ya no muestra un falso "host key changed" al sondearlo** ([#651](https://github.com/gnacho/netpulse/issues/651)). El descubrimiento (openssh con `accept-new`) solo fijaba la host key del algoritmo que negociaba (ed25519), mientras que el pool de sondeo (Go) negocia otro (ecdsa/rsa) con el mismo servidor; un router con varias host keys mostraba un "ssh host key changed" espurio y pedía un re-onboard sin motivo. El descubrimiento fija ahora **todas** las host keys del router (ed25519, ecdsa y rsa), así el sondeo siempre encuentra la suya, sin debilitar la protección anti-MITM: si un router cambia todas sus claves (reflash), la detección de "host key changed" sigue activa.
+
+### Anterior (v2.28.16)
 
 - **Los peers WireGuard se etiquetan por su nombre configurado en OpenWrt** ([#663](https://github.com/gnacho/netpulse/issues/663)). En la topología, los peers WireGuard que no estaban ya mapeados a un dispositivo NetPulse se muestran ahora con el nombre legible de la descripción UCI del peer (prioridad: nombre del dispositivo NetPulse → descripción UCI → IP del túnel) en lugar de la IP cruda del túnel. El sondeo lee `wg show dump` y `uci show network` en una sola sesión SSH (con marcador de separación) y conserva el estado de un túnel caído.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,11 @@ latest improvements, each linked to the GitHub issue that drove it.
 > These are written for people, not changelogs: what the feature does for you,
 > not the function names behind it.
 
-### Latest (v2.28.16)
+### Latest (v2.28.17)
+
+- **An OpenWrt router no longer shows a false "host key changed" when polled** ([#651](https://github.com/gnacho/netpulse/issues/651)). Discovery (OpenSSH with `accept-new`) used to pin only the single host-key algorithm it negotiated (ed25519), while the polling pool (Go) negotiates another one (ecdsa/rsa) with the same server; a router with several host keys then showed a spurious "ssh host key changed" and demanded a pointless re-onboard. Discovery now pins **all** of the router's host keys (ed25519, ecdsa and rsa), so the poller always finds the one it negotiates, without weakening the anti-MITM protection: if a router changes every key (reflash), the "host key changed" detection still kicks in.
+
+### Earlier (v2.28.16)
 
 - **WireGuard peers are now labeled by their OpenWrt-configured name** ([#663](https://github.com/gnacho/netpulse/issues/663)). In the topology, WireGuard peers that weren't already mapped to a NetPulse device now show the human-readable name from the peer's UCI description (priority: NetPulse device name → UCI description → tunnel IP) instead of the raw tunnel IP. The poll reads `wg show dump` and `uci show network` in a single SSH session and preserves a down tunnel's state.
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.16",
+  "version": "2.28.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "netpulse",
-      "version": "2.28.16",
+      "name": "netpulse-app",
+      "version": "2.28.17",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.16",
+  "version": "2.28.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.16"
+var Version = "2.28.17"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Bump de versión a v2.28.17: app/package.json + lock, var Version del server, CHANGELOG [2.28.17] y README (Latest/Última).