### PR TITLE
chore: prepare v2.28.18 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,24 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
-## [2.28.17] - 2026-09-09
+## [2.28.18] - 2026-09-10
 
 ### Added
 
 - **La topología se puede editar para ajustar las distancias (#656)**: un botón **Editar** (solo administrador) entra en modo edición que permite arrastrar routers/APs, switches o bridges inferidos y dispositivos para acercar o alejar los satélites (lo que cuelga de un nodo lo acompaña). Al guardar, las posiciones se persisten en el navegador y el layout queda **congelado** (ya no se reordena al refrescar); los nodos nuevos se colocan con el auto-layout. Un botón **Restablecer** vuelve al layout automático por defecto.
+- **Los hosts de Proxmox se muestran como nodos con sus CTs/VMs anidados (#561, #656)**: el sellado contra la API del cluster creaba los metadatos pero el mapa no anidaba los contenedores bajo su host. Ahora cada host PVE genera su nodo de hipervisor: los CTs se agrupan en grid bajo él con badge +N y enlaces host→CT, y el nodo se dibuja redondo (icono de servidor) con etiqueta "Proxmox · <nodo>"; al arrastrarlo, sus CTs lo acompañan. La tarjeta de un dispositivo gana además un botón discreto "Etiquetar" (admin) que abre el panel de overrides con la MAC precargada, y persiste ~1,2 s al viajar hacia ella para dar tiempo a pulsarlo.
 
 ### Fixed
 
+- **Los hosts por cable de un punto de acceso puente (dumb AP) ya se atribuyen al AP, no al router principal (#656)**: cuando un nodo como un dumb AP (sin WAN, `br-lan` puentado a la LAN principal) tiene clientes conectados por cable a sus bocas, el router principal también los ve en su FDB porque comparten el mismo segmento L2. La reconciliación descartaba esas MACs del satélite y las colgaba del router principal. Ahora una MAC que el satélite aprende en una boca local que no es su uplink se atribuye a ese satélite (la boca física es la evidencia más específica); el uplink sigue excluido como tránsito y los routers con agente propio conservan su fuente específica. Además, el orden de los dispositivos es ahora determinista (por MAC), lo que evita que los iconos del mapa salten de posición al refrescar.
 - **Los dispositivos callados ya no saltan del switch inferido al que están cableados (#656)**: las entradas del FDB caducan a los ~5 min sin tráfico, así que los equipos de AV (TV, receptor, shield…) perdían su evidencia de puerto entre refrescos y el mapa los re-anclaba al router principal hasta que volvían a hablar. El servidor recuerda ahora la última boca real donde se vio cada MAC (30 min de memoria, solo como respaldo del FDB actual) y conserva su atribución de puerto mientras el dispositivo siga conectado.
-- **El tráfico del tooltip de un dispositivo en la topología ya no muestra todos los decimales (#656)**: se formatea con la misma convención que el resto de la app (1 decimal a partir de 1 Mbps, 2 por debajo).
+- **El tráfico del tooltip de un dispositivo en la topología ya no muestra todos los decimales (#656)**: se formatea con la misma convención que el resto de la app (1 decimal a partir de 1 Mbps, 2 por debajo). El toggle "Flujo" del header desaparece: la animación sigue el ajuste "Reducir animaciones" (y el reduce-motion del sistema).
+
+## [2.28.17] - 2026-09-09
 
 ### Fixed
 
-- **Un router OpenWrt ya no cae en falso "host key changed" al sondearlo (#651)**: el descubrimiento (openssh con `accept-new`) registraba en `known_hosts` solo la host key que negociaba (ed25519), pero el sondeo Go negocia otra (ecdsa/rsa) con el mismo servidor; un host con varias host keys daba un falso "ssh host key changed" y exigía un re-onboard sin motivo. Ahora el descubrimiento pinas todas las host keys del router (ed25519, ecdsa y rsa), de forma que el sondeo siempre encuentra la suya sin debilitar la protección anti-MITM: si el router cambia todas sus claves (reflash), la detección de "host key changed" sigue intacta.
-- **Los hosts por cable de un punto de acceso puente (dumb AP) ya se atribuyen al AP, no al router principal (#656)**: cuando un nodo como un dumb AP (sin WAN, `br-lan` puentado a la LAN principal) tiene clientes conectados por cable a sus bocas, el router principal también los ve en su FDB porque comparten el mismo segmento L2. La reconciliación descartaba esas MACs del satélite y las colgaba del router principal. Ahora una MAC que el satélite aprende en una boca local que no es su uplink se atribuye a ese satélite (la boca física es la evidencia más específica); el uplink sigue excluido como tránsito y los routers con agente propio conservan su fuente específica. Además, el orden de los dispositivos es ahora determinista (por MAC), lo que evita que los iconos del mapa salten de posición al refrescar aunque ya no se use el bloqueo de layout.
+- **Un router OpenWrt ya no cae en falso "host key changed" al sondearlo (#651)**: el descubrimiento (openssh con `accept-new`) registraba en `known_hosts` solo la host key que negociaba (ed25519), pero el sondeo Go negocia otra (ecdsa/rsa) con el mismo servidor; un host con varias host keys daba un falso "ssh key changed" y exigía un re-onboard sin motivo. Ahora el descubrimiento pinea todas las host keys del router (ed25519, ecdsa y rsa), de forma que el sondeo siempre encuentra la suya sin debilitar la protección anti-MITM: si el router cambia todas sus claves (reflash), la detección de "host key changed" sigue intacta.
 
 ## [2.28.16] - 2026-09-09
 

--- a/README.es.md
+++ b/README.es.md
@@ -97,7 +97,13 @@ enlazada al issue de GitHub que la originó.
 > Están escritas para personas, no como changelog: qué hace la función por ti,
 > no los nombres de las funciones internas.
 
-### Última (v2.28.17)
+### Última (v2.28.18)
+
+- **El mapa de topología refleja ya dónde está enchufado cada equipo, y deja de saltar** ([#656](https://github.com/gnacho/netpulse/issues/656)). Los clientes por cable de un punto de acceso puente (dumb AP en la misma LAN que el router principal) aparecen bajo ese AP en vez de subir al padre; los dispositivos callados (TVs, receptores, reproductores) conservan su sitio en el mapa en lugar de caerse de su switch cada vez que se duermen; y los iconos ya no se intercambian posiciones en cada refresco.
+- **El layout lo ajustas tú** ([#656](https://github.com/gnacho/netpulse/issues/656)). Un modo de edición (solo admin) permite arrastrar routers, switches y dispositivos para acercar o alejar los satélites; al guardar, el layout queda congelado y solo cambia si vuelves a editarlo o lo restableces al automático.
+- **Los hosts de Proxmox se ven como nodos con sus VMs anidadas debajo** ([#561](https://github.com/gnacho/netpulse/issues/561)). Cada host PVE se dibuja como nodo redondo con su nombre, sus contenedores agrupados bajo él con badge +N, y arrastrar el host mueve a toda su familia de VMs. La tarjeta de dispositivo gana además un botón discreto "Etiquetar" para etiquetar sin teclear la MAC.
+
+### Anterior (v2.28.17)
 
 - **Un router OpenWrt ya no muestra un falso "host key changed" al sondearlo** ([#651](https://github.com/gnacho/netpulse/issues/651)). El descubrimiento (openssh con `accept-new`) solo fijaba la host key del algoritmo que negociaba (ed25519), mientras que el pool de sondeo (Go) negocia otro (ecdsa/rsa) con el mismo servidor; un router con varias host keys mostraba un "ssh host key changed" espurio y pedía un re-onboard sin motivo. El descubrimiento fija ahora **todas** las host keys del router (ed25519, ecdsa y rsa), así el sondeo siempre encuentra la suya, sin debilitar la protección anti-MITM: si un router cambia todas sus claves (reflash), la detección de "host key changed" sigue activa.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,13 @@ latest improvements, each linked to the GitHub issue that drove it.
 > These are written for people, not changelogs: what the feature does for you,
 > not the function names behind it.
 
-### Latest (v2.28.17)
+### Latest (v2.28.18)
+
+- **The topology map now reflects where things are actually plugged, and it stops jumping around** ([#656](https://github.com/gnacho/netpulse/issues/656)). Wired clients of a bridged access point (a dumb AP on the same LAN as the main router) show under that AP instead of drifting up to the parent; quiet devices (TVs, receivers, media players) keep their place on the map instead of falling off their switch whenever they go silent; and client icons no longer swap spots on every refresh.
+- **The layout is yours to adjust** ([#656](https://github.com/gnacho/netpulse/issues/656)). A new edit mode (admin only) lets you drag routers, switches and devices to bring satellites closer or push them apart; once saved, the layout stays frozen and only changes when you edit it again or reset to the automatic arrangement.
+- **Proxmox hosts show as proper nodes with their VMs nested underneath** ([#561](https://github.com/gnacho/netpulse/issues/561)). Each PVE host renders as a round node labeled with its name, its containers grouped beneath it with a +N badge, and dragging the host moves its whole VM family. The device card also gained a discreet "Tag" button so admins can label a device without typing its MAC.
+
+### Earlier (v2.28.17)
 
 - **An OpenWrt router no longer shows a false "host key changed" when polled** ([#651](https://github.com/gnacho/netpulse/issues/651)). Discovery (OpenSSH with `accept-new`) used to pin only the single host-key algorithm it negotiated (ed25519), while the polling pool (Go) negotiates another one (ecdsa/rsa) with the same server; a router with several host keys then showed a spurious "ssh host key changed" and demanded a pointless re-onboard. Discovery now pins **all** of the router's host keys (ed25519, ecdsa and rsa), so the poller always finds the one it negotiates, without weakening the anti-MITM protection: if a router changes every key (reflash), the "host key changed" detection still kicks in.
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.17",
+  "version": "2.28.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse-app",
-      "version": "2.28.17",
+      "version": "2.28.18",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.17",
+  "version": "2.28.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.17"
+var Version = "2.28.18"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Bump app version to 2.28.18, server var Version, move the #656 entries into a new CHANGELOG [2.28.18] section and refresh the README What's new summaries (EN/ES).