### PR TITLE
feat(openwrt): build x86/64 packages and derive the .ipk arch

### DIFF
--- a/.github/workflows/openwrt-package.yml
+++ b/.github/workflows/openwrt-package.yml
@@ -4,9 +4,10 @@ name: openwrt-package
 # published release:
 #   - netpulse-agent as .ipk (24.10 SDK, mediatek/filogic) and .apk (25.12
 #     SDK, armsr/armv8 -> aarch64_generic, instalable en aarch64 genérico y
-#     en cortex-a53, cubriendo routers fuera de cortex-a53).
+#     en cortex-a53, cubriendo routers fuera de cortex-a53). Also built for
+#     x86/64 (amd64 binary) since #672.
 #   - luci-app-netpulse (arch all) as .ipk and .apk (#236).
-#   - netpulse on-box server as .ipk and .apk (#364).
+#   - netpulse on-box server as .ipk and .apk (#364), also for x86/64 (#672).
 #
 # Triggered on v* tag pushes, the SAME event that runs release.yml. It does
 # not rely on the `release` event for goreleaser-published releases: goreleaser
@@ -41,9 +42,19 @@ jobs:
           - sdk-version: 24.10.5
             sdk-target: mediatek/filogic
             format: ipk
+            goarch: arm64
           - sdk-version: 25.12.5
             sdk-target: armsr/armv8
             format: apk
+            goarch: arm64
+          - sdk-version: 24.10.5
+            sdk-target: x86/64
+            format: ipk
+            goarch: amd64
+          - sdk-version: 25.12.5
+            sdk-target: x86/64
+            format: apk
+            goarch: amd64
 
     steps:
       - uses: actions/checkout@v4
@@ -65,7 +76,7 @@ jobs:
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
           for i in $(seq 1 80); do
-            if gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null | grep -q 'netpulse-agent_.*_linux_arm64.tar.gz'; then
+            if gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null | grep -q "netpulse-agent_.*_linux_${{ matrix.goarch }}.tar.gz"; then
               echo "Agent tarballs present after $i attempts"
               exit 0
             fi
@@ -75,14 +86,14 @@ jobs:
           echo "ERROR: agent tarballs not found on $TAG after 20 min" >&2
           exit 1
 
-      - name: Download netpulse-agent arm64 binary
+      - name: Download netpulse-agent ${{ matrix.goarch }} binary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          gh release download "$TAG" -p "netpulse-agent_*_linux_arm64.tar.gz" --dir /tmp/agent
+          gh release download "$TAG" -p "netpulse-agent_*_linux_${{ matrix.goarch }}.tar.gz" --dir /tmp/agent
           cd /tmp/agent
-          tar xzf netpulse-agent_*_linux_arm64.tar.gz
+          tar xzf netpulse-agent_*_linux_${{ matrix.goarch }}.tar.gz
           ls -la netpulse-agent
           file netpulse-agent
 
@@ -183,9 +194,19 @@ jobs:
           - sdk-version: 24.10.5
             sdk-target: mediatek/filogic
             format: ipk
+            goarch: arm64
           - sdk-version: 25.12.5
             sdk-target: armsr/armv8
             format: apk
+            goarch: arm64
+          - sdk-version: 24.10.5
+            sdk-target: x86/64
+            format: ipk
+            goarch: amd64
+          - sdk-version: 25.12.5
+            sdk-target: x86/64
+            format: apk
+            goarch: amd64
 
     steps:
       - uses: actions/checkout@v4
@@ -207,7 +228,7 @@ jobs:
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
           for i in $(seq 1 80); do
-            if gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null | grep -q 'netpulse_.*_linux_arm64.tar.gz'; then
+            if gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null | grep -q "netpulse_.*_linux_${{ matrix.goarch }}.tar.gz"; then
               echo "Server tarball present after $i attempts"
               exit 0
             fi
@@ -217,14 +238,14 @@ jobs:
           echo "ERROR: server tarball not found on $TAG after 20 min" >&2
           exit 1
 
-      - name: Download netpulse server arm64 binary
+      - name: Download netpulse server ${{ matrix.goarch }} binary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          gh release download "$TAG" -p "netpulse_*_linux_arm64.tar.gz" --dir /tmp/server
+          gh release download "$TAG" -p "netpulse_*_linux_${{ matrix.goarch }}.tar.gz" --dir /tmp/server
           cd /tmp/server
-          tar xzf netpulse_*_linux_arm64.tar.gz
+          tar xzf netpulse_*_linux_${{ matrix.goarch }}.tar.gz
           ls -la netpulse
           file netpulse
 

--- a/deploy/openwrt/package-server.sh
+++ b/deploy/openwrt/package-server.sh
@@ -52,6 +52,16 @@ curl -fsSL "$SDK_URL" -o sdk.tar.zst
 tar --zstd -xf sdk.tar.zst
 SDK_DIR="$WORK_DIR/${SDK_NAME%.tar.zst}"
 
+# Package architecture for the .ipk control file. OpenWrt names the staging
+# dir "target-<arch>_musl", so derive it from there instead of hardcoding a
+# single arch (mediatek/filogic -> aarch64_cortex-a53, x86/64 -> x86_64).
+PKG_ARCH="$(find "$SDK_DIR/staging_dir" -maxdepth 1 -type d -name 'target-*_musl*' -print -quit | sed -E 's#.*/target-(.*)_musl.*#\1#')"
+if [ -z "$PKG_ARCH" ]; then
+  echo "ERROR: could not determine package architecture from the SDK" >&2
+  exit 1
+fi
+echo "  Arch: $PKG_ARCH"
+
 # Stage binary and package files (package name: netpulse, like the Makefile)
 cp "$BINARY" "$WORK_DIR/netpulse"
 chmod 755 "$WORK_DIR/netpulse"
@@ -70,7 +80,7 @@ Version: ${PKG_VERSION}-${PKG_RELEASE}
 Depends: curl, ca-bundle
 License: AGPL-3.0-only
 Section: net
-Architecture: aarch64_cortex-a53
+Architecture: ${PKG_ARCH}
 Maintainer: Nacho <netpulse@cloudless.club>
 Description: NetPulse network monitor (on-box server)
  NetPulse server running on-box: serves the web app and ingests agent
@@ -167,7 +177,11 @@ MAKE
   cd "$SDK_DIR"
   make defconfig >/dev/null 2>&1 || true
   make package/netpulse/compile V=s 2>&1 | tail -15
-  find bin/packages -name "netpulse-*.apk" -exec cp {} "$OUT_DIR/" \;
+  # The apk filename carries no arch, so append it: otherwise the armv8 and
+  # x86/64 builds would collide in the release (same name, --clobber).
+  find bin/packages -name "netpulse-*.apk" | while read -r f; do
+    cp "$f" "$OUT_DIR/$(basename "$f" .apk)_${PKG_ARCH}.apk"
+  done
   echo "  APK: $(ls "$OUT_DIR"/netpulse-*.apk 2>/dev/null || echo 'NOT FOUND')"
 
 else

--- a/deploy/openwrt/package.sh
+++ b/deploy/openwrt/package.sh
@@ -62,6 +62,16 @@ curl -fsSL "$SDK_URL" -o sdk.tar.zst
 tar --zstd -xf sdk.tar.zst
 SDK_DIR="$WORK_DIR/${SDK_NAME%.tar.zst}"
 
+# Package architecture for the .ipk control file. OpenWrt names the staging
+# dir "target-<arch>_musl", so derive it from there instead of hardcoding a
+# single arch (mediatek/filogic -> aarch64_cortex-a53, x86/64 -> x86_64).
+PKG_ARCH="$(find "$SDK_DIR/staging_dir" -maxdepth 1 -type d -name 'target-*_musl*' -print -quit | sed -E 's#.*/target-(.*)_musl.*#\1#')"
+if [ -z "$PKG_ARCH" ]; then
+  echo "ERROR: could not determine package architecture from the SDK" >&2
+  exit 1
+fi
+echo "  Arch: $PKG_ARCH"
+
 # Stage the binary and package files
 cp "$BINARY" "$WORK_DIR/netpulse-agent"
 chmod 755 "$WORK_DIR/netpulse-agent"
@@ -81,7 +91,7 @@ Version: ${PKG_VERSION:-0.0.0}-${PKG_RELEASE:-1}
 Depends: iw
 License: AGPL-3.0-only
 Section: utils
-Architecture: aarch64_cortex-a53
+Architecture: ${PKG_ARCH}
 Maintainer: Nacho <netpulse@cloudless.club>
 Description: NetPulse native agent for OpenWrt
  Native OpenWrt agent for NetPulse network monitor. Probes the local
@@ -190,7 +200,11 @@ MAKE
   # cuanto falta .config y muere con 'Error opening terminal' en CI).
   make defconfig >/dev/null 2>&1 || true
   make package/netpulse-agent/compile V=s 2>&1 | tail -20
-  find bin/packages -name "netpulse-agent*.apk" -exec cp {} "$OUT_DIR/" \;
+  # The apk filename carries no arch, so append it: otherwise the armv8 and
+  # x86/64 builds would collide in the release (same name, --clobber).
+  find bin/packages -name "netpulse-agent*.apk" | while read -r f; do
+    cp "$f" "$OUT_DIR/$(basename "$f" .apk)_${PKG_ARCH}.apk"
+  done
   echo "  APK: $(ls "$OUT_DIR"/netpulse-agent*.apk 2>/dev/null || echo 'NOT FOUND')"
 
 else


### PR DESCRIPTION
## What

Adds the `x86/64` target to the OpenWrt package build so `netpulse-agent` and the on-box `netpulse` server are also published for x86/64 (24.10 `.ipk` and 25.12 `.apk`). It also makes the `.ipk` architecture dynamic.

Reported from the r/openwrt thread: installing the published packages on an x86/64 OpenWrt system fails with `Unsupported architecture`, while the raw `linux_amd64` binaries work fine there.

## Changes

- `.github/workflows/openwrt-package.yml`: `package-agent` and `package-server` matrices gain a `goarch` field and `x86/64` entries (24.10 ipk + 25.12 apk); the wait/download steps select the matching `arm64`/`amd64` tarball. `package-luci` is untouched (`Architecture: all`, already portable).
- `deploy/openwrt/package.sh` and `deploy/openwrt/package-server.sh`:
  - The `.ipk` control `Architecture:` is derived from the SDK (`staging_dir/target-<arch>_musl`) instead of being hardcoded to `aarch64_cortex-a53`.
  - The `.apk` output is renamed with the arch suffix. The apk filename carries no arch, so the armv8 and x86/64 builds would otherwise collide in the same release (`--clobber`).

## Verification

Built with the real OpenWrt SDKs:

- x86/64 `.ipk` (agent) -> `Architecture: x86_64`, amd64 binary inside.
- x86/64 `.apk` (agent) -> `netpulse-agent-2.28.18-r1_x86_64.apk` (`apk mkpkg --info arch:x86_64`).
- x86/64 `.ipk` (on-box server) -> `Architecture: x86_64`.
- Regression `mediatek/filogic` `.ipk` -> `aarch64_cortex-a53` (same value as the previous hardcoded one).
- `bash -n` clean; `shellcheck` introduces no new findings (only the pre-existing SC2034); workflow YAML parses.

Note: the `.apk` asset names change from `netpulse-agent-<v>-r1.apk` to `netpulse-agent-<v>-r1_<arch>.apk` (README uses a glob, no impact).

Closes #672.