### PR TITLE
fix(i18n): keep network data out of browser translation (#666)

### DIFF
--- a/app/src/components/DeviceRow.tsx
+++ b/app/src/components/DeviceRow.tsx
@@ -134,7 +134,7 @@ export function DeviceRow({ device, variant = 'compact', className, onClick }: D
       </div>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <span className="truncate text-sm font-medium text-text-primary">{device.name}</span>
+          <span className="truncate text-sm font-medium text-text-primary" translate="no">{device.name}</span>
           {device.isNew && (
             <span className="rounded-full bg-accent-soft px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent">
               {t('devices.new')}

--- a/app/src/components/routers/RouterClients.tsx
+++ b/app/src/components/routers/RouterClients.tsx
@@ -106,12 +106,12 @@ export function RouterClients({ router }: { router: Router }) {
                         <Icon className="h-4 w-4" strokeWidth={1.75} />
                       </span>
                       <div>
-                        <div className="font-medium text-text-primary">{d.name}</div>
+                        <div className="font-medium text-text-primary" translate="no">{d.name}</div>
                         <div className="text-caption text-text-muted">{d.manufacturer}</div>
                       </div>
                     </div>
                   </td>
-                  <td className="py-3 pr-3 font-mono text-mono-sm text-text-secondary">{d.ip}</td>
+                  <td className="py-3 pr-3 font-mono text-mono-sm text-text-secondary" translate="no">{d.ip}</td>
                   <td className="py-3 pr-3 capitalize text-text-secondary">{t(`devices.types.${d.type}`)}</td>
                   <td className="py-3 pr-3">
                     <span className="rounded-full bg-elevated px-2 py-0.5 font-mono text-caption text-text-secondary">{d.band}</span>

--- a/app/src/i18n.ts
+++ b/app/src/i18n.ts
@@ -43,6 +43,18 @@ i18n
     returnNull: false,
   })
 
+// #666: el lang del documento debe seguir al idioma activo. index.html declara
+// lang="es"; si un usuario con la UI en inglés no lo actualizamos, el navegador
+// cree que la página es española y ofrece traducirla — y el traductor destroza
+// los datos (hostnames "crowed" → "crowded"). Con el lang correcto, la UI
+// traducida no dispara la oferta de traducción.
+const applyDocLang = (lng?: string) => {
+  const l = (lng ?? i18n.language ?? 'es').slice(0, 2).toLowerCase()
+  document.documentElement.lang = l === 'en' ? 'en' : 'es'
+}
+applyDocLang()
+i18n.on('languageChanged', applyDocLang)
+
 export default i18n
 
 /** Locale numérico según el idioma activo */

--- a/app/src/pages/Devices.tsx
+++ b/app/src/pages/Devices.tsx
@@ -263,7 +263,7 @@ function StatsStrip({ allDevices }: { allDevices: ClientDevice[] }) {
           <div className="pointer-events-none absolute left-0 top-full z-20 mt-2 hidden w-52 rounded-xl border border-border-strong bg-elevated p-3 group-hover:block">
             <div className="mb-1.5 text-label uppercase text-text-muted">{t('devices.stats.seenThisWeek')}</div>
             {newThisWeekDevices.map((d) => (
-              <div key={d.id} className="truncate py-0.5 text-xs text-text-secondary">
+              <div key={d.id} className="truncate py-0.5 text-xs text-text-secondary" translate="no">
                 {d.name}
                 <span className="text-text-muted"> · {d.firstSeen}</span>
               </div>
@@ -818,7 +818,7 @@ function ListRow({
           <DeviceTile device={device} />
           <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <span className="truncate text-sm font-medium text-text-primary">{device.name}</span>
+              <span className="truncate text-sm font-medium text-text-primary" translate="no">{device.name}</span>
               <button
                 type="button"
                 onClick={(e) => {
@@ -978,7 +978,7 @@ function GridCard({
           </div>
         </div>
         <div className="mt-3 flex items-center gap-2">
-          <span className="truncate text-sm font-medium text-text-primary">{device.name}</span>
+          <span className="truncate text-sm font-medium text-text-primary" translate="no">{device.name}</span>
           {infra && <InfraBadge info={infra} />}
           <TypeBadge type={device.type} />
         </div>


### PR DESCRIPTION
Closes #666

As diagnosed in the thread, the mangled hostnames were the browser's page translator rewriting DOM text: the document always declared lang="es" (even with the UI in English), so Chrome kept offering to translate, and once active it "corrected" data values like crowed-pixeltab into crowded-pixeltab.

Two changes:

- The document language now follows the active UI language (es/en), so a translated UI no longer triggers the translation offer.
- Hostnames and IPs in the clients and devices lists are marked translate="no", so they stay intact even when translation is enabled for the page.

Combined with #674 (alerts no longer forcing Spanish text into an English UI), the reasons to run a translator on NetPulse at all are mostly gone; Settings has a native language selector (auto/es/en).