### PR TITLE
chore: prepare v2.28.19 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
-## [Unreleased]
+## [2.28.19] - 2026-09-10
+
+### Added
+
+- **Paquetes OpenWrt también para x86/64 (#672)**: el agente y el servidor on-router se publican ahora para x86/64 (`.ipk` 24.10 y `.apk` 25.12), y la arquitectura del `.ipk` se deriva del SDK en vez de estar fijada; instalar los paquetes en un OpenWrt x86_64 dejaba de fallar con "Unsupported architecture".
 
 ### Fixed
+
+- **El traductor del navegador ya no destroza los hostnames (#666)**: la página declaraba siempre `lang="es"` aunque la UI estuviera en inglés, así que el navegador ofrecía traducirla y el traductor reescribía también los datos (p. ej. "crowed-pixeltab" → "crowded-pixeltab"). El documento declara ahora el idioma activo y los valores de red (hostnames, IPs) van marcados `translate="no"` para que queden intactos aunque la traducción esté activada.
 
 - **Las alertas se muestran en el idioma del usuario (#671)**: los textos del feed (título, descripción y sugerencia) los generaba el servidor en español y un usuario con la app en inglés los veía mezclados. Los eventos llevan ahora el slug de su tipo y sus variables, y el frontend los traduce por clave en el idioma activo (con los literales del servidor como respaldo). Migrados los 13 tipos con slug: dispositivo desconocido, router offline, agente caído (y su variante SSH), agente desactualizado, firmware, Internet caído, velocidad WAN lenta, temperatura alta, señal débil, port flapping, ghost port y enlace degradado. Las notificaciones push de las alertas urgentes siguen en español por ahora (seguimiento aparte).
 

--- a/README.es.md
+++ b/README.es.md
@@ -97,7 +97,13 @@ enlazada al issue de GitHub que la originó.
 > Están escritas para personas, no como changelog: qué hace la función por ti,
 > no los nombres de las funciones internas.
 
-### Última (v2.28.18)
+### Última (v2.28.19)
+
+- **Las alertas (y todo lo demás) en tu idioma** ([#671](https://github.com/gnacho/netpulse/issues/671)). Títulos, descripciones y sugerencias de las alertas los generaba el servidor en español y los usuarios con la app en inglés veían el feed mezclado. Los eventos llevan ahora su tipo y sus valores, y la app los traduce al idioma activo — toda la familia, de dispositivos desconocidos a alertas de puertos.
+- **Tus hostnames sobreviven al traductor del navegador** ([#666](https://github.com/gnacho/netpulse/issues/666)). La página declaraba español incluso con la UI en inglés, así que el navegador ofrecía traducirla — y el traductor "corregía" hostnames como crowed-pixeltab a crowded-pixeltab. El idioma declarado sigue ahora a la UI y los datos de red van marcados como no traducibles.
+- **Paquetes OpenWrt para x86/64** ([#672](https://github.com/gnacho/netpulse/issues/672)). El agente y el servidor on-router se publican también para sistemas x86/64 (.ipk 24.10, .apk 25.12), con la arquitectura del paquete derivada del SDK.
+
+### Anterior (v2.28.18)
 
 - **El mapa de topología refleja ya dónde está enchufado cada equipo, y deja de saltar** ([#656](https://github.com/gnacho/netpulse/issues/656)). Los clientes por cable de un punto de acceso puente (dumb AP en la misma LAN que el router principal) aparecen bajo ese AP en vez de subir al padre; los dispositivos callados (TVs, receptores, reproductores) conservan su sitio en el mapa en lugar de caerse de su switch cada vez que se duermen; y los iconos ya no se intercambian posiciones en cada refresco.
 - **El layout lo ajustas tú** ([#656](https://github.com/gnacho/netpulse/issues/656)). Un modo de edición (solo admin) permite arrastrar routers, switches y dispositivos para acercar o alejar los satélites; al guardar, el layout queda congelado y solo cambia si vuelves a editarlo o lo restableces al automático.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,13 @@ latest improvements, each linked to the GitHub issue that drove it.
 > These are written for people, not changelogs: what the feature does for you,
 > not the function names behind it.
 
-### Latest (v2.28.18)
+### Latest (v2.28.19)
+
+- **Alerts (and everything else) render in your language** ([#671](https://github.com/gnacho/netpulse/issues/671)). Alert titles, descriptions and suggestions used to be server-generated Spanish, so English users saw a mixed feed. Events now carry their type and values and the app translates them in the active language — the full family, from unknown devices to port alerts.
+- **Your hostnames survive the browser translator** ([#666](https://github.com/gnacho/netpulse/issues/666)). The page used to declare Spanish even with an English UI, which made browsers offer to translate it — and the translator happily "corrected" hostnames like crowed-pixeltab into crowded-pixeltab. The declared language now follows the UI and network data is marked do-not-translate.
+- **OpenWrt packages for x86/64** ([#672](https://github.com/gnacho/netpulse/issues/672)). The agent and on-router server are now published for x86/64 systems (24.10 .ipk, 25.12 .apk), with the package architecture derived from the SDK.
+
+### Earlier (v2.28.18)
 
 - **The topology map now reflects where things are actually plugged, and it stops jumping around** ([#656](https://github.com/gnacho/netpulse/issues/656)). Wired clients of a bridged access point (a dumb AP on the same LAN as the main router) show under that AP instead of drifting up to the parent; quiet devices (TVs, receivers, media players) keep their place on the map instead of falling off their switch whenever they go silent; and client icons no longer swap spots on every refresh.
 - **The layout is yours to adjust** ([#656](https://github.com/gnacho/netpulse/issues/656)). A new edit mode (admin only) lets you drag routers, switches and devices to bring satellites closer or push them apart; once saved, the layout stays frozen and only changes when you edit it again or reset to the automatic arrangement.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.18",
+  "version": "2.28.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse-app",
-      "version": "2.28.18",
+      "version": "2.28.19",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.18",
+  "version": "2.28.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.18"
+var Version = "2.28.19"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Bump to 2.28.19 (package.json/lock, server Version), CHANGELOG [2.28.19] covering #672, #666 and #671, README What's new (EN/ES).