### PR TITLE
fix(agent): drop stale buffered payloads on flush to avoid anti-replay deadlock

### DIFF
--- a/agent/internal/push/push.go
+++ b/agent/internal/push/push.go
@@ -27,6 +27,11 @@ const (
 	MaxBackoff = 5 * time.Minute
 	// BufferCap: payloads retenidos en RAM durante una caída del servidor.
 	BufferCap = 100
+	// StaleAfter: un payload buffered con más edad que esto JAMÁS superará la
+	// ventana anti-replay del server (maxTsDrift = 5 min): reintentarlo para
+	// siempre convierte una caída >5 min en un deadlock (issue #680). Se
+	// descarta en el drenado en vez de reintentarlo.
+	StaleAfter = 4 * time.Minute
 )
 
 // Client empuja payloads con token, backoff y buffer acotado.
@@ -44,6 +49,8 @@ type Client struct {
 	backoff time.Duration
 	buf     []*probe.Payload
 	dropped uint64
+
+	droppedStale uint64
 }
 
 // New crea el cliente contra serverURL (p. ej. "https://192.168.8.1:3000")
@@ -75,6 +82,13 @@ func (c *Client) Dropped() uint64 {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.dropped
+}
+
+// DroppedStale: payloads buffered descartados por superar StaleAfter (#680).
+func (c *Client) DroppedStale() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.droppedStale
 }
 
 // Buffered: payloads pendientes de envío.
@@ -142,17 +156,34 @@ func (c *Client) enqueueLocked(p *probe.Payload) {
 	c.buf = append(c.buf, p)
 }
 
-// flushLocked intenta drenar el buffer en orden; para al primer fallo.
+// flushLocked intenta drenar el buffer en orden; para al primer fallo. Los
+// heads más viejos que StaleAfter se descartan sin reintentar (#680): el
+// server los rechazaría con 401 stale_payload y bloquearían el drenado para
+// siempre.
 func (c *Client) flushLocked(ctx context.Context) error {
+	posted := false
 	for len(c.buf) > 0 {
+		if staleSince(c.buf[0], time.Now()) {
+			c.logf("[netpulse-agent] descartado payload buffered stale (ts %d, %s de edad, ventana anti-replay agotada; total descartados por stale: %d)",
+				c.buf[0].Ts, time.Since(time.Unix(c.buf[0].Ts, 0)).Round(time.Second), c.droppedStale+1)
+			c.buf = c.buf[1:]
+			c.droppedStale++
+			continue
+		}
 		if err := c.post(ctx, c.buf[0]); err != nil {
 			c.growBackoffLocked()
 			return err
 		}
+		posted = true
 		c.buf = c.buf[1:]
 	}
-	c.backoff = 0
-	c.logf("[netpulse-agent] buffer drenado tras reconexión")
+	// El backoff solo se resetea si hubo ALGÚN post con éxito: un drenado que
+	// solo descartó stales no prueba que la conectividad se haya recuperado
+	// (el siguiente post fresco decidirá).
+	if posted {
+		c.backoff = 0
+		c.logf("[netpulse-agent] buffer drenado tras reconexión")
+	}
 	return nil
 }
 
@@ -166,6 +197,15 @@ func (c *Client) growBackoffLocked() {
 	if c.backoff > c.maxBackoff {
 		c.backoff = c.maxBackoff
 	}
+}
+
+// staleSince: true si el payload lleva más de StaleAfter generado (un Ts no
+// positivo se considera siempre fresco: no hay dato para valorar).
+func staleSince(p *probe.Payload, now time.Time) bool {
+	if p.Ts <= 0 {
+		return false
+	}
+	return now.Sub(time.Unix(p.Ts, 0)) > StaleAfter
 }
 
 // hmacSign devuelve HMAC-SHA256(token, body) en hex.

--- a/agent/internal/push/push_test.go
+++ b/agent/internal/push/push_test.go
@@ -91,7 +91,7 @@ func TestPushBackoffCreceYSeResetea(t *testing.T) {
 	s.mu.Lock()
 	s.fail = false
 	s.mu.Unlock()
-	if err := c.Push(context.Background(), mkPayload(999)); err != nil {
+	if err := c.Push(context.Background(), mkPayload(time.Now().Unix())); err != nil {
 		t.Fatalf("push tras recuperación: %v", err)
 	}
 	if d := c.Delay(interval); d != interval {
@@ -109,9 +109,14 @@ func TestPushBufferDropOldestYDrenadoFIFO(t *testing.T) {
 	c := New(srv.URL, "tok", srv.Client())
 	c.SetBufferCap(100)
 
+	// ts realistas (recientes): los payloads con edad > StaleAfter se
+	// descartarían al drenar en vez de reintentarse (#680) y aquí lo que se
+	// prueba es el FIFO, no el descarte stale.
+	base := time.Now().Unix() - 60
+
 	// Servidor caído: 105 pushes → buffer 100, 5 descartados (los más viejos)
 	for i := 1; i <= 105; i++ {
-		_ = c.Push(context.Background(), mkPayload(int64(i)))
+		_ = c.Push(context.Background(), mkPayload(base+int64(i)))
 	}
 	if c.Buffered() != 100 {
 		t.Fatalf("buffer: %d", c.Buffered())
@@ -120,12 +125,12 @@ func TestPushBufferDropOldestYDrenadoFIFO(t *testing.T) {
 		t.Fatalf("descartados: %d", c.Dropped())
 	}
 
-	// Reconexión: drenado FIFO — el primer ts recibido tras la caída es 6
+	// Reconexión: drenado FIFO — el primer ts recibido tras la caída es base+6
 	s.mu.Lock()
 	s.fail = false
 	s.payloads = nil
 	s.mu.Unlock()
-	if err := c.Push(context.Background(), mkPayload(106)); err != nil {
+	if err := c.Push(context.Background(), mkPayload(base+106)); err != nil {
 		t.Fatalf("drenado: %v", err)
 	}
 	s.mu.Lock()
@@ -133,8 +138,53 @@ func TestPushBufferDropOldestYDrenadoFIFO(t *testing.T) {
 	if len(s.payloads) != 101 {
 		t.Fatalf("drenados: %d", len(s.payloads))
 	}
-	if s.payloads[0].Ts != 6 || s.payloads[100].Ts != 106 {
+	if s.payloads[0].Ts != base+6 || s.payloads[100].Ts != base+106 {
 		t.Fatalf("orden FIFO: primero=%d último=%d", s.payloads[0].Ts, s.payloads[100].Ts)
+	}
+}
+
+// TestPushFlushDescartaStales (#680): un payload buffered con edad >
+// StaleAfter se descarta al drenar (el server lo rechazaría con 401
+// stale_payload para siempre); el drenado sigue y el payload fresco sale.
+func TestPushFlushDescartaStales(t *testing.T) {
+	s := &sink{fail: true}
+	srv := httptest.NewServer(http.HandlerFunc(s.handler))
+	defer srv.Close()
+	c := New(srv.URL, "tok", srv.Client())
+
+	now := time.Now().Unix()
+	staleA := mkPayload(now - 600)  // 10 min de edad: fuera de ventana
+	staleB := mkPayload(now - 480)  // 8 min: ídem
+	fresh := mkPayload(now)         // recién generado
+
+	// Servidor caído: A entra directo al buffer; el Push de B drena (A se
+	// descarta por stale) y B acaba también en el buffer.
+	_ = c.Push(context.Background(), staleA)
+	_ = c.Push(context.Background(), staleB)
+	if c.Buffered() != 1 {
+		t.Fatalf("buffer tras 2 fallos con A descartado: %d", c.Buffered())
+	}
+	if c.DroppedStale() != 1 {
+		t.Fatalf("descartados stale: %d", c.DroppedStale())
+	}
+
+	// Recuperación: el drenado descarta B (stale) y el push fresco sale 202.
+	s.mu.Lock()
+	s.fail = false
+	s.mu.Unlock()
+	if err := c.Push(context.Background(), fresh); err != nil {
+		t.Fatalf("push tras recuperación: %v", err)
+	}
+	if c.DroppedStale() != 2 {
+		t.Fatalf("descartados stale tras recuperación: %d", c.DroppedStale())
+	}
+	if c.Buffered() != 0 {
+		t.Fatalf("buffer debería estar vacío: %d", c.Buffered())
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.payloads) != 1 || s.payloads[0].Ts != now {
+		t.Fatalf("el server solo debería haber recibido el payload fresco: %+v", s.payloads)
 	}
 }
 


### PR DESCRIPTION
Closes #680

## Problem

Payloads carry their generation timestamp, and the server rejects anything older than `maxTsDrift` (5 min) with `401 stale_payload`. After an outage longer than that window, the FIFO buffer drain always fails on the stale head: fresh payloads queue behind it and, with push backoff capped at 5 min, the buffer takes hours to churn out (permanent deadlock when not full).

Observed in production: two agents stuck in 401 loops for 19h+ after a network flap.

## Fix

- `flushLocked` discards buffered payloads older than `StaleAfter` (4 min, below the server window) instead of retrying them, so recovery happens on the first cycle after connectivity returns. Discards are counted (`DroppedStale()`) and logged.
- Backoff only resets when a post actually succeeds: a drain that only dropped stale payloads proves nothing about connectivity (the following fresh post decides). Previously a drop-only drain reset the backoff, masking ongoing failures.

## Tests

- New `TestPushFlushDescartaStales`: stale buffered payloads are dropped, never posted; the fresh payload is delivered after recovery.
- Updated `TestPushBufferDropOldestYDrenadoFIFO` and `TestPushBackoffCreceYSeResetea` to realistic (recent) timestamps: they used unix ts `=1,2,3` which are now (correctly) treated as stale.
- `go test ./...` green in `agent/`, `go vet` clean.