### PR TITLE
fix(server): keep quiet clients attributed to their bridge AP (#678)

### DIFF
--- a/app/src/components/topology/model.ts
+++ b/app/src/components/topology/model.ts
@@ -244,11 +244,10 @@ const PEER_COORDS = [
   { x: 140, y: 26 },
   { x: 860, y: 26 },
 ]
-/** Túneles WG canónicos peer→Internet */
-const WG_PATHS = [
-  { d: 'M 272 44 C 330 82, 410 94, 474 80', dur: 3 },
-  { d: 'M 728 44 C 670 82, 590 94, 526 80', dur: 3.4 },
-]
+/** Duración del paquete animado por peer en los túneles WG. Las curvas se
+ *  calculan SIEMPRE dinámicas (peer → posición real de Internet): las
+ *  estáticas canónicas quedaban desancladas cuando el layout cambia (#677). */
+const WG_DURS = [3, 3.4]
 /** Anillos wifi: radios ajustados para caber muchos chips (el resolver de
  *  colisiones mantiene 0 solapes). Suma de caps = topoGatewayRingCap (60) /
  *  topoAPRingCap (40) del server — deben coincidir para que GW_RING_VISIBLE
@@ -1295,12 +1294,11 @@ export function buildTopologyModel({ routers, devices, wan, wireguard, distribut
     }
   }
   peerNodes.forEach((node, i) => {
-    const p = WG_PATHS[i] ?? { d: '', dur: 3.2 }
-    const d = p.d || `M ${node.x + 7} ${node.y + 18} C ${node.x + 60} ${node.y + 56}, ${internetNode.x - 40} ${internetNode.y + 36}, ${internetNode.x - 26} ${internetNode.y + 22}`
+    const d = `M ${node.x + 7} ${node.y + 18} C ${node.x + 60} ${node.y + 56}, ${internetNode.x - 40} ${internetNode.y + 36}, ${internetNode.x - 26} ${internetNode.y + 22}`
     links.push({
       id: `wg-${node.peer.id}`, kind: 'wg',
       d, lx: 0, ly: 0, label: '',
-      width: 2, packets: 1, packetDur: p.dur,
+      width: 2, packets: 1, packetDur: WG_DURS[i] ?? 3.2,
       from: node.id, to: 'internet',
     })
   })
@@ -1378,12 +1376,11 @@ export function buildTopologyModel({ routers, devices, wan, wireguard, distribut
         case 'wg': {
           const pn = peerNodes.find((p) => p.id === sl.from)
           if (!pn) return null
-          const p = WG_PATHS[wgIdx] ?? { d: '', dur: 3.2 }
-          const d = p.d || `M ${pn.x + 7} ${pn.y + 18} C ${pn.x + 60} ${pn.y + 56}, ${internetNode.x - 40} ${internetNode.y + 36}, ${internetNode.x - 26} ${internetNode.y + 22}`
+          const d = `M ${pn.x + 7} ${pn.y + 18} C ${pn.x + 60} ${pn.y + 56}, ${internetNode.x - 40} ${internetNode.y + 36}, ${internetNode.x - 26} ${internetNode.y + 22}`
           return {
             id: `wg-${pn.peer.id}`, kind: 'wg',
             d, lx: 0, ly: 0, label: '',
-            width: 2, packets: 1, packetDur: p.dur,
+            width: 2, packets: 1, packetDur: WG_DURS[wgIdx] ?? 3.2,
             from: sl.from, to: sl.to,
           }
         }

--- a/server-go/internal/adapters/fdbsticky.go
+++ b/server-go/internal/adapters/fdbsticky.go
@@ -28,14 +28,35 @@ type fdbPortMemo struct {
 
 // updateFdbMemo refresca la memo con el FDB real de este tick y poda las
 // entradas caducadas. Devuelve el snapshot de la memo (para el overlay).
+//
+// Higiene (#678): solo se memorizan observaciones en bocas LOCALES (las que no
+// aprenden la MAC de bridge de otro router = no son uplinks). Así la memo
+// significa "dónde está enchufado el cable" y no se contamina con el tránsito
+// que ve el gateway por su uplink (que si no pisaba la observación local del AP
+// y hacía que un cliente del AP pareciera del router principal).
 func (l *Live) updateFdbMemo(polled map[string]*routerPolled, nowMs int64) map[string]fdbPortMemo {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if l.fdbMemo == nil {
 		l.fdbMemo = map[string]fdbPortMemo{}
 	}
+	brMacs := map[string]bool{}
+	for _, p := range polled {
+		if p.brMac != "" {
+			brMacs[p.brMac] = true
+		}
+	}
 	for routerID, p := range polled {
+		infraPorts := map[string]bool{}
 		for mac, port := range p.fdb {
+			if brMacs[mac] {
+				infraPorts[port] = true
+			}
+		}
+		for mac, port := range p.fdb {
+			if infraPorts[port] {
+				continue // tránsito por el uplink: no es dónde va el cable
+			}
 			l.fdbMemo[mac] = fdbPortMemo{routerID: routerID, port: port, ts: nowMs}
 		}
 	}

--- a/server-go/internal/adapters/fdbsticky_test.go
+++ b/server-go/internal/adapters/fdbsticky_test.go
@@ -3,6 +3,7 @@ package adapters
 
 import (
 	"testing"
+	"time"
 )
 
 // TestOverlayStickyFdb: las MACs recordadas (frescas) que faltan en el FDB
@@ -103,5 +104,75 @@ func TestUpdateFdbMemoRefreshAndPrune(t *testing.T) {
 	}
 	if m, ok := memo["BB:BB:BB:BB:BB:BB"]; !ok || m.port != "lan2" || m.routerID != "gateway" {
 		t.Fatalf("la entrada fresca debería estar: %+v", memo)
+	}
+}
+
+// TestUpdateFdbMemoIgnoresUplinkSightings (#678): la memo solo guarda bocas
+// LOCALES; una observación en la boca que aprende la MAC de bridge de otro
+// router (uplink = tránsito) no se memoriza ni pisa una observación local.
+func TestUpdateFdbMemoIgnoresUplinkSightings(t *testing.T) {
+	l := NewLive(nil, nil, nil, nil)
+	now := int64(1_700_000_000_000)
+	polled := map[string]*routerPolled{
+		"gateway": {cfg: RouterConfig{ID: "gateway", IsGateway: true}, brMac: "GG:GG:GG:GG:GG:GG",
+			fdb: map[string]string{
+				"GG:GG:GG:GG:GG:GG": "lan1", // bridge propio
+				"AA:AA:AA:AA:AA:AA": "lan1", // bridge del AP → lan1 = uplink (infra)
+				"44:44:44:44:44:44": "lan1", // cliente del AP, visto en tránsito
+			}},
+		"ap": {cfg: RouterConfig{ID: "ap"}, brMac: "AA:AA:AA:AA:AA:AA",
+			fdb: map[string]string{
+				"AA:AA:AA:AA:AA:AA": "lan1",
+				"44:44:44:44:44:44": "lan3", // boca LOCAL del AP
+			}},
+	}
+	memo := l.updateFdbMemo(polled, now)
+	if m, ok := memo["44:44:44:44:44:44"]; !ok || m.routerID != "ap" || m.port != "lan3" {
+		t.Fatalf("la boca local del AP debe ganar en la memo: %+v", memo["44:44:44:44:44:44"])
+	}
+	// La MAC de bridge del AP en lan1 del gateway no debe memorizarse como cliente.
+	if _, ok := memo["AA:AA:AA:AA:AA:AA"]; ok {
+		t.Fatalf("la MAC de bridge no debería estar en la memo: %+v", memo)
+	}
+}
+
+// TestBuildDevicesStickySatelliteAttribution (#678): un dispositivo callado que
+// este tick solo aparece por ARP (atribuido al gateway por orden alfabético)
+// recupera el satélite donde la memo lo vio por última vez en una boca local.
+func TestBuildDevicesStickySatelliteAttribution(t *testing.T) {
+	l := NewLive(nil, nil, []RouterConfig{{ID: "gateway", Name: "GW", IsGateway: true}}, nil)
+	now := time.Now().UnixMilli()
+	l.fdbMemo["44:44:44:44:44:44"] = fdbPortMemo{routerID: "ap", port: "lan3", ts: now}
+	polled := map[string]*routerPolled{
+		"gateway": {cfg: RouterConfig{ID: "gateway", IsGateway: true}, brMac: "GG:GG:GG:GG:GG:GG",
+			fdb: map[string]string{"GG:GG:GG:GG:GG:GG": "lan1", "AA:AA:AA:AA:AA:AA": "lan1"},
+			arp: map[string]string{"44:44:44:44:44:44": "192.168.13.123"}},
+		"ap": {cfg: RouterConfig{ID: "ap", Name: "Luizjana2"}, brMac: "AA:AA:AA:AA:AA:AA",
+			fdb: map[string]string{"AA:AA:AA:AA:AA:AA": "lan1"}},
+	}
+	devs := l.buildDevices(polled)
+	if d := mustDevice(t, devs, "44:44:44:44:44:44"); d.RouterID != "ap" {
+		t.Fatalf("RouterID=%q (want ap por la memo sticky)", d.RouterID)
+	}
+}
+
+// TestBuildDevicesGatewayLocalWinsOverSticky (#678): si el gateway ve el
+// dispositivo en una boca NO-uplink, esa evidencia fresca manda sobre la memo.
+func TestBuildDevicesGatewayLocalWinsOverSticky(t *testing.T) {
+	l := NewLive(nil, nil, []RouterConfig{{ID: "gateway", Name: "GW", IsGateway: true}}, nil)
+	now := time.Now().UnixMilli()
+	l.fdbMemo["44:44:44:44:44:44"] = fdbPortMemo{routerID: "ap", port: "lan3", ts: now}
+	polled := map[string]*routerPolled{
+		"gateway": {cfg: RouterConfig{ID: "gateway", IsGateway: true}, brMac: "GG:GG:GG:GG:GG:GG",
+			fdb: map[string]string{
+				"GG:GG:GG:GG:GG:GG": "lan1",
+				"44:44:44:44:44:44": "lan4", // boca local del gateway (no infra)
+			}},
+		"ap": {cfg: RouterConfig{ID: "ap"}, brMac: "AA:AA:AA:AA:AA:AA",
+			fdb: map[string]string{"AA:AA:AA:AA:AA:AA": "lan1"}},
+	}
+	devs := l.buildDevices(polled)
+	if d := mustDevice(t, devs, "44:44:44:44:44:44"); d.RouterID != "gateway" {
+		t.Fatalf("RouterID=%q (want gateway: boca local fresca manda)", d.RouterID)
 	}
 }

--- a/server-go/internal/adapters/live.go
+++ b/server-go/internal/adapters/live.go
@@ -2004,6 +2004,45 @@ func (l *Live) buildDevices(polled map[string]*routerPolled) []Device {
 			seen[mac] = seenInfo{routerID, "cable", nil}
 		}
 	}
+	// (5) Atribución sticky (#678): un cableado que este tick solo aparece en el
+	// FDB del gateway por su UPLINK (tránsito) o en la tabla ARP —donde gana el
+	// gateway por orden alfabético— recupera el router real donde la memo lo vio
+	// por última vez en una boca local. Solo corrige ATRIBUCIÓN: no crea
+	// presencia (el dispositivo ya estaba en `seen`). Si el gateway lo ve en una
+	// boca NO-uplink, esa evidencia fresca manda y no se toca.
+	if gwID != "" && len(l.fdbMemo) > 0 {
+		gwPolled := polled[gwID]
+		gwInfraPorts := map[string]bool{}
+		if gwPolled != nil {
+			for mac, port := range gwPolled.fdb {
+				if brMacByRouter[mac] {
+					gwInfraPorts[port] = true
+				}
+			}
+		}
+		l.mu.Lock()
+		memo := l.fdbMemo
+		l.mu.Unlock()
+		nowMs := time.Now().UnixMilli()
+		ttlMs := fdbStickyTTL.Milliseconds()
+		for mac, s := range seen {
+			if s.band != "cable" || s.routerID != gwID {
+				continue
+			}
+			m, ok := memo[mac]
+			if !ok || nowMs-m.ts > ttlMs || m.routerID == "" || m.routerID == gwID {
+				continue
+			}
+			// El gateway solo lo ve por el uplink (o no lo ve en su FDB): el
+			// cable está en el satélite según la última observación local.
+			if gwPolled != nil {
+				if port, inFdb := gwPolled.fdb[mac]; inFdb && !gwInfraPorts[port] {
+					continue // boca local del gateway: evidencia fresca, no tocar
+				}
+			}
+			seen[mac] = seenInfo{m.routerID, "cable", nil}
+		}
+	}
 
 	allMacs := map[string]bool{}
 	for mac := range leasesByMac {
@@ -2371,12 +2410,13 @@ func (l *Live) buildOverview(ctx context.Context) (*Overview, error) {
 		l.mu.Unlock()
 		routerList = append(routerList, router)
 	}
-	devices := l.buildDevices(polled)
-	// #656: overlay sticky del FDB. La memo se refresca con el FDB real y se
-	// usa SOLO para inferTopology: los dispositivos callados (entrada FDB
-	// caducada) conservan su boca y no saltan del switch inferido al gateway.
+	// #656/#678: refrescar la memo sticky ANTES de buildDevices (su paso 5 la
+	// usa para atribuir al satélite los dispositivos callados) y usarla también
+	// como overlay de inferTopology (puerto/attachTo).
 	nowMs := time.Now().UnixMilli()
-	stickyPolled := overlayStickyFdb(polled, l.updateFdbMemo(polled, nowMs), nowMs)
+	memo := l.updateFdbMemo(polled, nowMs)
+	devices := l.buildDevices(polled)
+	stickyPolled := overlayStickyFdb(polled, memo, nowMs)
 	devices, distNodes := inferTopology(stickyPolled, devices)
 	// Capa 2 manual (issue #142): overrides de topología tras el autodiscover.
 	// Sin BD (tests/demo) → no-op.
@@ -2970,11 +3010,13 @@ func (l *Live) GetDevices(context.Context) []Device {
 	l.mu.Lock()
 	polled := l.lastPolled
 	l.mu.Unlock()
-	// #656: overlay sticky del FDB (paridad con el overview) ANTES del sellado
-	// PVE, que sobreescribe attachTo con ground truth del cluster.
+	// #656/#678: memo sticky fresca ANTES de buildDevices (atribución) y como
+	// overlay de inferTopology (paridad con el overview), ANTES del sellado PVE
+	// (que sobreescribe attachTo con ground truth del cluster).
 	detailNowMs := time.Now().UnixMilli()
+	detailMemo := l.updateFdbMemo(polled, detailNowMs)
 	devices, _ := inferTopology(
-		overlayStickyFdb(polled, l.updateFdbMemo(polled, detailNowMs), detailNowMs),
+		overlayStickyFdb(polled, detailMemo, detailNowMs),
 		l.buildDevices(polled),
 	)
 	// #561: sellado de infraestructura con el inventario PVE (si configurado).


### PR DESCRIPTION
Closes #678

Follow-up on #656. The screenshots show most wired hosts now correctly sit under the dumb AP (integra32, IDom-RaspberryPi4, monitoring); only two quiet ones (ComfoConnect_LAN_C at 0.00 Mbps, and an ENC28J60) still land on the main router.

Mechanism: a quiet client stops refreshing its bridge-FDB entry on the AP; the device then falls back to the ARP step, where the gateway wins the alphabetical tie (OpenWrt-Luizjana before OpenWrt-Luizjana2) and the attribution drifts to the main router.

Two changes:

- The sticky port memory now records only **local** (non-uplink) sightings. Before it also stored the gateway's transit view (the client seen on the gateway's uplink port), which could overwrite the AP's local observation; the memory now means "where the cable actually is".
- The memory also feeds the **router attribution** (not just the port): an already-online device whose current attribution is the gateway gets restored to the AP where the memory last saw it on a local port. It never creates presence (the device was already online), and a fresh local sighting on the gateway still wins over the memory.

Tests: memo hygiene (uplink sightings ignored), sticky satellite attribution, and gateway-local-evidence-wins. Full adapters suite green.