### PR TITLE
chore: prepare v2.28.20 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.28.20] - 2026-09-10
+
+### Fixed
+
+- **Los clientes callados de un AP puente ya no se cuelgan del router principal (#678)**: cuando un cliente cableado de un dumb AP deja de hablar, su entrada en el FDB del AP caduca y caía al fallback ARP, donde el gateway gana por orden alfabético. La memoria sticky de puerto ahora solo registra bocas locales (nunca el tránsito que el gateway ve por su uplink) y corrige también el router de un dispositivo ya online, sin fabricar presencia; la evidencia fresca de una boca local del gateway sigue mandando.
+- **Las curvas de los túneles WireGuard siguen a los nodos (#677)**: las dos primeras curvas peer→Internet estaban fijadas para la posición canónica de Internet, así que al reordenar el mapa (modo edición o el reposicionamiento automático) dejaban de aterrizar en el nodo y cruzaban lo que hubiera cerca. Ahora la curva se calcula siempre con las posiciones reales del peer y de Internet.
+- **El agente ya no se atasca con payloads viejos en el buffer (#680)**: tras un corte más largo que la ventana anti-replay, la cabeza de la cola no se podía entregar (401 `stale_payload`) y bloqueaba todo lo que venía detrás durante horas. El agente descarta los payloads caducados en el flush y se recupera en el primer ciclo con conectividad.
+
 ## [2.28.19] - 2026-09-10
 
 ### Added

--- a/README.es.md
+++ b/README.es.md
@@ -97,7 +97,13 @@ enlazada al issue de GitHub que la originó.
 > Están escritas para personas, no como changelog: qué hace la función por ti,
 > no los nombres de las funciones internas.
 
-### Última (v2.28.19)
+### Última (v2.28.20)
+
+- **Los clientes callados se quedan en su AP** ([#678](https://github.com/gnacho/netpulse/issues/678)): un dispositivo cableado tras un AP puente que enmudece ya no se va al router principal — el servidor recuerda dónde está el cable de verdad y solo cuentan las observaciones locales.
+- **Las líneas de los túneles VPN siguen a los nodos** ([#677](https://github.com/gnacho/netpulse/issues/677)): reordenar el mapa ya no deja las curvas WireGuard apuntando al vacío; se trazan del peer a donde está Internet realmente.
+- **El agente se recupera solo tras un corte largo** ([#680](https://github.com/gnacho/netpulse/issues/680)): los payloads caducados del buffer se descartan en vez de bloquear la cola con 401 anti-replay.
+
+### Anterior (v2.28.19)
 
 - **Las alertas (y todo lo demás) en tu idioma** ([#671](https://github.com/gnacho/netpulse/issues/671)). Títulos, descripciones y sugerencias de las alertas los generaba el servidor en español y los usuarios con la app en inglés veían el feed mezclado. Los eventos llevan ahora su tipo y sus valores, y la app los traduce al idioma activo — toda la familia, de dispositivos desconocidos a alertas de puertos.
 - **Tus hostnames sobreviven al traductor del navegador** ([#666](https://github.com/gnacho/netpulse/issues/666)). La página declaraba español incluso con la UI en inglés, así que el navegador ofrecía traducirla — y el traductor "corregía" hostnames como crowed-pixeltab a crowded-pixeltab. El idioma declarado sigue ahora a la UI y los datos de red van marcados como no traducibles.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,13 @@ latest improvements, each linked to the GitHub issue that drove it.
 > These are written for people, not changelogs: what the feature does for you,
 > not the function names behind it.
 
-### Latest (v2.28.19)
+### Latest (v2.28.20)
+
+- **Quiet clients stay on their AP** ([#678](https://github.com/gnacho/netpulse/issues/678)): a wired device behind a bridged AP that goes silent no longer drifts to the main router — the server remembers where the cable actually is, and only local sightings count.
+- **VPN tunnel lines follow the nodes** ([#677](https://github.com/gnacho/netpulse/issues/677)): rearranging the map no longer leaves WireGuard curves pointing at empty space; they are drawn from the peer to wherever Internet actually is.
+- **The agent recovers on its own after a long outage** ([#680](https://github.com/gnacho/netpulse/issues/680)): stale buffered payloads are discarded instead of deadlocking the queue with anti-replay 401s.
+
+### Earlier (v2.28.19)
 
 - **Alerts (and everything else) render in your language** ([#671](https://github.com/gnacho/netpulse/issues/671)). Alert titles, descriptions and suggestions used to be server-generated Spanish, so English users saw a mixed feed. Events now carry their type and values and the app translates them in the active language — the full family, from unknown devices to port alerts.
 - **Your hostnames survive the browser translator** ([#666](https://github.com/gnacho/netpulse/issues/666)). The page used to declare Spanish even with an English UI, which made browsers offer to translate it — and the translator happily "corrected" hostnames like crowed-pixeltab into crowded-pixeltab. The declared language now follows the UI and network data is marked do-not-translate.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.19",
+  "version": "2.28.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse-app",
-      "version": "2.28.19",
+      "version": "2.28.20",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.19",
+  "version": "2.28.20",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.19"
+var Version = "2.28.20"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Bump to 2.28.20 (package.json/lock, server Version), CHANGELOG [2.28.20] (#678, #677, #680) and README What's new (EN/ES).