### PR TITLE
fix(health): count agent SSE connections separately from UI clients (#681)

### DIFF
--- a/server-go/internal/httpapi/health.go
+++ b/server-go/internal/httpapi/health.go
@@ -28,6 +28,13 @@ func (s *server) handleAPIHealth(mode string) http.HandlerFunc {
 		if s.hub != nil {
 			sseConnections = s.hub.Size()
 		}
+		// #681: los agentes conectan por el AgentHub (SSE bidireccional),
+		// distinto del hub de UI. Sin este conteo, con toda la flota de
+		// agentes empujando el health solo refleja las pestañas abiertas.
+		agentSseConnections := 0
+		if s.agentHub != nil {
+			agentSseConnections = len(s.agentHub.ConnectedSlugs())
+		}
 		devicesTotal := 0
 		if s.lastOv != nil {
 			if ov := s.lastOv(); ov != nil {
@@ -36,14 +43,15 @@ func (s *server) handleAPIHealth(mode string) http.HandlerFunc {
 		}
 
 		writeJSON(w, http.StatusOK, map[string]any{
-			"ok":              dbOk,
-			"version":         Version,
-			"mode":            mode,
-			"uptimeSec":       int64(time.Since(s.started).Seconds()),
-			"db":              dbStatus,
-			"agentsConnected": agentsConnected,
-			"sseConnections":  sseConnections,
-			"devicesTotal":    devicesTotal,
+			"ok":                  dbOk,
+			"version":             Version,
+			"mode":                mode,
+			"uptimeSec":           int64(time.Since(s.started).Seconds()),
+			"db":                  dbStatus,
+			"agentsConnected":     agentsConnected,
+			"sseConnections":      sseConnections,
+			"agentSseConnections": agentSseConnections,
+			"devicesTotal":        devicesTotal,
 		})
 	}
 }

--- a/server-go/internal/httpapi/httpapi_test.go
+++ b/server-go/internal/httpapi/httpapi_test.go
@@ -863,7 +863,7 @@ func TestHealthEndpoints(t *testing.T) {
 	}
 	// Métricas operativas (Fase 8): los 3 campos presentes; en demo los
 	// agentes/sse son 0 y devicesTotal viene del overview del poller demo.
-	for _, k := range []string{"agentsConnected", "sseConnections", "devicesTotal"} {
+	for _, k := range []string{"agentsConnected", "sseConnections", "agentSseConnections", "devicesTotal"} {
 		if _, ok := body[k].(float64); !ok {
 			t.Fatalf("%s ausente o no numérico: %v", k, body)
 		}


### PR DESCRIPTION
Closes #681

`sseConnections` in `GET /api/health` only reflected the browser SSE hub, so with every agent connected and pushing it still read 0-1. Adds `agentSseConnections` sourced from `AgentHub.ConnectedSlugs()` (nil-safe, same pattern as the rest of the metrics); the UI counter keeps its meaning.