### PR TITLE
chore: prepare v2.28.21 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.28.21] - 2026-09-10
+
+### Fixed
+
+- **`/api/health` cuenta ahora los SSE de los agentes (#681)**: `sseConnections` solo reflejaba las pestañas del navegador; los agentes conectan por su propio hub y quedaban invisibles (con toda la flota empujando, el health leía 0-1). Se añade `agentSseConnections` alongside, con el mismo significado para el contador de UI.
+
 ## [2.28.20] - 2026-09-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 ### Fixed
 
-- **`/api/health` cuenta ahora los SSE de los agentes (#681)**: `sseConnections` solo reflejaba las pestañas del navegador; los agentes conectan por su propio hub y quedaban invisibles (con toda la flota empujando, el health leía 0-1). Se añade `agentSseConnections` alongside, con el mismo significado para el contador de UI.
+- **`/api/health` cuenta ahora los SSE de los agentes (#681)**: `sseConnections` solo reflejaba las pestañas del navegador; los agentes conectan por su propio hub y quedaban invisibles (con toda la flota empujando, el health leía 0-1). Se añade `agentSseConnections` (el contador de UI conserva su significado).
 
 ## [2.28.20] - 2026-09-10
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.20",
+  "version": "2.28.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse-app",
-      "version": "2.28.20",
+      "version": "2.28.21",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.20",
+  "version": "2.28.21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.20"
+var Version = "2.28.21"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Bump to 2.28.21, CHANGELOG entry for #681 (agentSseConnections in /api/health).