### PR TITLE
agent: configurable scan interval via NETPULSE_SCAN_INTERVAL

### DIFF
--- a/agent/probe/local.go
+++ b/agent/probe/local.go
@@ -49,6 +49,10 @@ type Options struct {
 	WanPingTarget string
 	// GwPingTarget: si no está vacío, ping corto al gateway (latencia) — AP.
 	GwPingTarget string
+	// ScanInterval: mínimo entre scans de vecinos (#591/#699). 0 = usar
+	// DefaultScanInterval; negativo (ScanDisabled) = sin scans periódicos,
+	// solo on-demand vía ForceScan (env NETPULSE_SCAN_INTERVAL).
+	ScanInterval time.Duration
 }
 
 // Prober sondea el equipo local y construye payloads. Mantiene el estado de
@@ -83,22 +87,34 @@ type Prober struct {
 	// scanMu protege el throttle del scan pasivo de vecinos (#591): el scan
 	// activo (`iw dev scan`) saca la radio del canal y degrada a los clientes
 	// si se repite en cada sondeo (cada ~30 s). Se ejecuta como mucho cada
-	// scanMinInterval, o antes si el server pide un refresh explícito.
-	scanMu     sync.Mutex
-	lastScanAt time.Time
-	scanForced bool
+	// scanInterval, o antes si el server pide un refresh explícito.
+	scanMu       sync.Mutex
+	lastScanAt   time.Time
+	scanForced   bool
+	scanInterval time.Duration
 }
 
 const radiosTTL = 5 * time.Minute
 
-// scanMinInterval: mínimo entre scans pasivos de vecinos. Los datos de
-// "Análisis de canales" apenas cambian; 10 minutos mantienen el mapa fresco
-// sin martillear el aire con off-channel scans (#591).
-const scanMinInterval = 10 * time.Minute
+const (
+	// ScanDisabled: sin scans periódicos (solo on-demand vía ForceScan).
+	// Lo selecciona NETPULSE_SCAN_INTERVAL=0; en un AP con clientes Intel
+	// cada off-channel gap puede costar un deauth por beacon-loss (#699).
+	ScanDisabled = -1 * time.Second
+	// DefaultScanInterval: mínimo entre scans de vecinos si no se configura
+	// NETPULSE_SCAN_INTERVAL. Los datos de "Análisis de canales" apenas
+	// cambian; 30 minutos mantienen el mapa razonablemente fresco sin
+	// martillear el aire con off-channel scans (#591/#699).
+	DefaultScanInterval = 30 * time.Minute
+)
 
 // NewProber crea el prober con el runner dado.
 func NewProber(run Runner, opts Options) *Prober {
-	return &Prober{run: run, opts: opts}
+	si := opts.ScanInterval
+	if si == 0 {
+		si = DefaultScanInterval
+	}
+	return &Prober{run: run, opts: opts, scanInterval: si}
 }
 
 // ForceScan pide un scan en el próximo Build (lo usa el runtime cuando el
@@ -110,9 +126,10 @@ func (p *Prober) ForceScan() {
 }
 
 // scanDue decide si toca lanzar CmdScan en este sondeo completo: true si hay
-// un force pendiente (refresh del server) o si pasó scanMinInterval desde el
-// último intento. La primera Build tras arrancar también escanea (lastScanAt
-// cero). Al devolver true registra el intento para no repetirlo en el ciclo.
+// un force pendiente (refresh del server) o si pasó scanInterval desde el
+// último intento. Con ScanDisabled los periódicos no corren nunca (solo
+// force). La primera Build tras arrancar también escanea (lastScanAt cero),
+// salvo desactivado. Al devolver true registra el intento para no repetirlo.
 func (p *Prober) scanDue() bool {
 	p.scanMu.Lock()
 	defer p.scanMu.Unlock()
@@ -121,7 +138,10 @@ func (p *Prober) scanDue() bool {
 		p.lastScanAt = time.Now()
 		return true
 	}
-	if p.lastScanAt.IsZero() || time.Since(p.lastScanAt) >= scanMinInterval {
+	if p.scanInterval < 0 {
+		return false
+	}
+	if p.lastScanAt.IsZero() || time.Since(p.lastScanAt) >= p.scanInterval {
 		p.lastScanAt = time.Now()
 		return true
 	}

--- a/agent/probe/scan_throttle_test.go
+++ b/agent/probe/scan_throttle_test.go
@@ -69,13 +69,57 @@ func TestScanThrottleExpiraIntervalo(t *testing.T) {
 	ctx := context.Background()
 
 	p.Build(ctx, "rt2", "test") // arranque: 1 scan
-	// Envejece el último scan más allá de scanMinInterval.
+	// Envejece el último scan más allá del intervalo efectivo.
 	p.scanMu.Lock()
-	p.lastScanAt = time.Now().Add(-(scanMinInterval + time.Minute))
+	p.scanInterval = 10 * time.Minute
+	p.lastScanAt = time.Now().Add(-(p.scanInterval + time.Minute))
 	p.scanMu.Unlock()
 
 	p.Build(ctx, "rt2", "test")
 	if run.scanCalls != 2 {
-		t.Fatalf("pasado scanMinInterval debería volver a escanear, scanCalls=%d", run.scanCalls)
+		t.Fatalf("pasado scanInterval debería volver a escanear, scanCalls=%d", run.scanCalls)
+	}
+}
+
+// #699: ScanDisabled no escanea NUNCA por intervalo (ni siquiera al
+// arrancar); solo ForceScan dispara el scan.
+func TestScanDisabledSoloOnDemand(t *testing.T) {
+	p, run := newScanProber()
+	p.scanMu.Lock()
+	p.scanInterval = ScanDisabled
+	p.scanMu.Unlock()
+	ctx := context.Background()
+
+	p.Build(ctx, "rt2", "test")
+	if run.scanCalls != 0 {
+		t.Fatalf("ScanDisabled no debería escanear al arrancar, scanCalls=%d", run.scanCalls)
+	}
+	p.ForceScan()
+	p.Build(ctx, "rt2", "test")
+	if run.scanCalls != 1 {
+		t.Fatalf("ForceScan con ScanDisabled debería escanear, scanCalls=%d", run.scanCalls)
+	}
+	p.Build(ctx, "rt2", "test")
+	if run.scanCalls != 1 {
+		t.Fatalf("Build tras ForceScan con ScanDisabled no debería reescanear, scanCalls=%d", run.scanCalls)
+	}
+}
+
+// #699: NewProber aplica DefaultScanInterval cuando Options.ScanInterval es
+// cero (compatibilidad con quien no configura nada).
+func TestScanIntervalDefaultCuandoCero(t *testing.T) {
+	p := NewProber(&fakeRunner{}, Options{})
+	p.scanMu.Lock()
+	got := p.scanInterval
+	p.scanMu.Unlock()
+	if got != DefaultScanInterval {
+		t.Fatalf("ScanInterval 0 debería resolver a DefaultScanInterval, got=%v", got)
+	}
+	p2 := NewProber(&fakeRunner{}, Options{ScanInterval: 15 * time.Minute})
+	p2.scanMu.Lock()
+	got2 := p2.scanInterval
+	p2.scanMu.Unlock()
+	if got2 != 15*time.Minute {
+		t.Fatalf("ScanInterval configurado debería respetarse, got=%v", got2)
 	}
 }

--- a/agent/runtime/config.go
+++ b/agent/runtime/config.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gnacho/netpulse/agent/internal/tlspin"
+	"github.com/gnacho/netpulse/agent/probe"
 )
 
 // DefaultEnvFile: env file por defecto del agente standalone.
@@ -59,6 +60,21 @@ func LoadConfigFromEnv(envFile string) (Options, error) {
 			opts.Interval = d
 		} else {
 			slog.Warn("[netpulse-agent] NETPULSE_INTERVAL inválido, usando 30s", "value", v)
+		}
+	}
+	// NETPULSE_SCAN_INTERVAL (#699): mínimo entre scans de vecinos. "0" =
+	// sin scans periódicos (solo on-demand vía refresh del server); número
+	// en segundos o duración Go ("15m"). Sin valor: DefaultScanInterval.
+	opts.ScanInterval = probe.DefaultScanInterval
+	if v := get("NETPULSE_SCAN_INTERVAL"); v != "" {
+		if v == "0" {
+			opts.ScanInterval = probe.ScanDisabled
+		} else if sec, err := strconv.Atoi(v); err == nil && sec > 0 {
+			opts.ScanInterval = time.Duration(sec) * time.Second
+		} else if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			opts.ScanInterval = d
+		} else {
+			slog.Warn("[netpulse-agent] NETPULSE_SCAN_INTERVAL inválido, usando 30m", "value", v)
 		}
 	}
 	if err := opts.Validate(); err != nil {

--- a/agent/runtime/runtime.go
+++ b/agent/runtime/runtime.go
@@ -35,12 +35,16 @@ const (
 // Options configura Run. Server/Slug y Token (o PairingToken) son
 // obligatorios; Validate los comprueba antes de arrancar.
 type Options struct {
-	Server        string // URL del servidor ("https://..." o "http://...:3000")
-	Token         string // token del equipo (64 hex)
-	Slug          string // slug del equipo (agent.token.<slug> en el servidor)
-	ServerFP      string // SHA-256 del SPKI del servidor en hex (https obligatorio)
-	PairingToken  string // modo bootstrap: pairing una vez y salir
-	Interval      time.Duration
+	Server       string // URL del servidor ("https://..." o "http://...:3000")
+	Token        string // token del equipo (64 hex)
+	Slug         string // slug del equipo (agent.token.<slug> en el servidor)
+	ServerFP     string // SHA-256 del SPKI del servidor en hex (https obligatorio)
+	PairingToken string // modo bootstrap: pairing una vez y salir
+	Interval     time.Duration
+	// ScanInterval: mínimo entre scans de vecinos del prober (#699). 0 =
+	// probe.DefaultScanInterval; probe.ScanDisabled = sin scans periódicos
+	// (env NETPULSE_SCAN_INTERVAL, "0" lo desactiva).
+	ScanInterval  time.Duration
 	WanTarget     string
 	GwTarget      string
 	HeartbeatFile string
@@ -101,6 +105,7 @@ func Run(ctx context.Context, opts Options) error {
 	prober := probe.NewProber(probe.ShellRunner{}, probe.Options{
 		WanPingTarget: opts.WanTarget,
 		GwPingTarget:  opts.GwTarget,
+		ScanInterval:  opts.ScanInterval,
 	})
 
 	a := &agent{opts: opts, log: log, client: client}
@@ -110,7 +115,7 @@ func Run(ctx context.Context, opts Options) error {
 	}
 	a.hbFile = hbFile
 
-	log.Info("[netpulse-agent] agente iniciado", "version", opts.Version, "slug", opts.Slug, "server", opts.Server, "interval", opts.Interval)
+	log.Info("[netpulse-agent] agente iniciado", "version", opts.Version, "slug", opts.Slug, "server", opts.Server, "interval", opts.Interval, "scan_interval", opts.ScanInterval)
 	a.setRunning(true)
 
 	// #453: si existe un upgrade de firmware pendiente de un reboot anterior,

--- a/agent/runtime/runtime_test.go
+++ b/agent/runtime/runtime_test.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/gnacho/netpulse/agent/probe"
 )
 
 func writeFile(t *testing.T, path, content string) {
@@ -84,6 +86,48 @@ func TestLoadConfigIntervalFormats(t *testing.T) {
 	opts, err = LoadConfigFromEnv(env)
 	if err != nil || opts.Interval != DefaultInterval {
 		t.Fatalf("NETPULSE_INTERVAL inválido: %v %v (quiero default 30s)", opts.Interval, err)
+	}
+}
+
+// #699: NETPULSE_SCAN_INTERVAL acepta "0" (desactivado), segundos, duración
+// Go, inválido (default) y ausencia (default).
+func TestLoadConfigScanIntervalFormats(t *testing.T) {
+	dir := t.TempDir()
+	base := "NETPULSE_SERVER=http://s\nNETPULSE_TOKEN=t\nNETPULSE_SLUG=s\n"
+
+	env := filepath.Join(dir, "unset.env")
+	writeFile(t, env, base)
+	opts, err := LoadConfigFromEnv(env)
+	if err != nil || opts.ScanInterval != probe.DefaultScanInterval {
+		t.Fatalf("sin NETPULSE_SCAN_INTERVAL: %v %v (quiero default 30m)", opts.ScanInterval, err)
+	}
+
+	env = filepath.Join(dir, "off.env")
+	writeFile(t, env, base+"NETPULSE_SCAN_INTERVAL=0")
+	opts, err = LoadConfigFromEnv(env)
+	if err != nil || opts.ScanInterval != probe.ScanDisabled {
+		t.Fatalf("NETPULSE_SCAN_INTERVAL=0: %v %v (quiero ScanDisabled)", opts.ScanInterval, err)
+	}
+
+	env = filepath.Join(dir, "secs.env")
+	writeFile(t, env, base+"NETPULSE_SCAN_INTERVAL=900")
+	opts, err = LoadConfigFromEnv(env)
+	if err != nil || opts.ScanInterval != 15*time.Minute {
+		t.Fatalf("NETPULSE_SCAN_INTERVAL=900: %v %v", opts.ScanInterval, err)
+	}
+
+	env = filepath.Join(dir, "dur.env")
+	writeFile(t, env, base+"NETPULSE_SCAN_INTERVAL=1h")
+	opts, err = LoadConfigFromEnv(env)
+	if err != nil || opts.ScanInterval != time.Hour {
+		t.Fatalf("NETPULSE_SCAN_INTERVAL=1h: %v %v", opts.ScanInterval, err)
+	}
+
+	env = filepath.Join(dir, "bad.env")
+	writeFile(t, env, base+"NETPULSE_SCAN_INTERVAL=nada")
+	opts, err = LoadConfigFromEnv(env)
+	if err != nil || opts.ScanInterval != probe.DefaultScanInterval {
+		t.Fatalf("NETPULSE_SCAN_INTERVAL inválido: %v %v (quiero default 30m)", opts.ScanInterval, err)
 	}
 }
 


### PR DESCRIPTION
Closes #699.

## What

- New env `NETPULSE_SCAN_INTERVAL` (agent + embedded/netgrip deployments): plain seconds or Go duration; `0` disables periodic neighbor scans entirely.
- Default raised from the hardcoded 10m (#591) to 30m.
- On-demand scans are unaffected: the SSE `refresh` -> `ForceScan()` path still scans immediately (channel plan "scan now" in the UI).
- Startup log now prints the effective scan interval (e.g. `scan_interval=-1s` when disabled).

## Why

Even throttled to 10 min per agent, periodic active scans take the AP radio off channel for a few seconds. Intel clients (iwlwifi beacon-loss watchdog) self-deauthenticate on every gap (reason 4, locally generated) while mobile/IoT clients tolerate it - on multi-AP deployments someone's clients get knocked every few minutes. Issue #699 has the measured evidence chain (scan push -> beacon loss -> deauth, 30-90 s outage).

AP deployments with Intel clients should set `NETPULSE_SCAN_INTERVAL=0` and keep the feature on demand.

## Tests

- `TestScanDisabledSoloOnDemand`: disabled agents never scan periodically, only on ForceScan.
- `TestScanIntervalDefaultCuandoCero`: zero-valued probe Options resolves to the default (back-compat).
- `TestLoadConfigScanIntervalFormats`: unset / 0 / seconds / duration / invalid.
- Updated `TestScanThrottleExpiraIntervalo` to the configurable field.

`go build/vet/test` green on the agent module.