### PR TITLE
Wire NETPULSE_SCAN_INTERVAL into install template and .ipk UCI path

### DIFF
--- a/deploy/openwrt/netpulse-agent/files/netpulse-agent.config
+++ b/deploy/openwrt/netpulse-agent/files/netpulse-agent.config
@@ -16,6 +16,11 @@ config main 'main'
 	# Intervalo de sondeo completo (default 30s)
 	option interval '30s'
 
+	# Minimo entre scans de vecinos para "Analisis de canales" (default 30m;
+	# "0" los desactiva, solo on-demand). En APs con clientes Intel cada scan
+	# saca la radio del canal ~2-5s y puede costar un deauth (#699)
+	# option scan_interval '0'
+
 	# Ping WAN (solo gateway; p. ej. 1.1.1.1)
 	# option wan_target '1.1.1.1'
 

--- a/deploy/openwrt/netpulse-agent/files/netpulse-agent.init
+++ b/deploy/openwrt/netpulse-agent/files/netpulse-agent.init
@@ -41,6 +41,12 @@ load_config() {
 	export NETPULSE_INTERVAL="$interval"
 	export NETPULSE_HEARTBEAT_FILE="$HEARTBEAT_FILE"
 
+	# Intervalo entre scans de vecinos (#699): "0" los desactiva (solo
+	# on-demand). Vacío = default del agente (30m).
+	local scan_interval
+	config_get scan_interval main scan_interval ""
+	[ -n "$scan_interval" ] && export NETPULSE_SCAN_INTERVAL="$scan_interval"
+
 	# Targets de ping (solo se usan si están definidos)
 	local wan_target gw_target
 	config_get wan_target main wan_target ""

--- a/install-agent.sh
+++ b/install-agent.sh
@@ -303,6 +303,9 @@ NETPULSE_SLUG=$SLUG
 $TOKEN_LINE
 $FP_LINE
 # NETPULSE_INTERVAL=15
+# NETPULSE_SCAN_INTERVAL=0          # min entre scans de vecinos; "0" = sin scans
+#                                   # periódicos (APs con clientes Intel: cada
+#                                   # off-channel gap puede costar un deauth)
 # NETPULSE_WAN_TARGET=1.1.1.1      # solo si este equipo es el gateway
 # NETPULSE_GW_TARGET=192.168.8.1   # ping al gateway (APs)
 EOF


### PR DESCRIPTION
Closes #701.

Docs/packaging follow-up to #699 (agent v1.2.1):

- `install-agent.sh`: the generated env-file template now documents `NETPULSE_SCAN_INTERVAL` (with the Intel-clients/AP rationale).
- `.ipk` UCI path: optional `scan_interval` option in the default config + init passthrough (mirrors `interval` and ping targets).

No behavior change for existing deployments; the UCI wiring rides along in the next release build. `sh -n` clean on both shell files.