### PR TITLE
fix(agents): keep last-seen ticking every second

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 ### Fixed
 
+- **El "Visto" de la flota de agentes ya no oscila (#691)**: el contador de "último push" solo se recalculaba en renders esporádicos (con la llegada de snapshots), así que se congelaba entre actualizaciones y saltaba hacia atrás con cada push del agente (oscilación tipo 39-44-18-23 s). Un único reloj compartido de 1 s alimenta ahora toda la tabla: la celda avanza segundo a segundo y solo cae cuando llega un push realmente nuevo.
+
 - **El hostname de las reservas DHCP se valida y se escapa (#693)**: el `hostname` del endpoint `PUT /api/devices/{mac}/reservation` se interpolaba sin sanitizar en el comando `uci set` que corre por SSH como root en el router; una comilla simple rompía el quoting e inyectaba comandos arbitrarios. Ahora solo se aceptan hostnames DNS (letras, dígitos, guiones y puntos, hasta 253 caracteres; el resto recibe 400 `invalid_hostname`) y todos los valores interpolados en comandos uci -incluidos los rollbacks que re-leen config del router- viajan escapados. La UI manda el hostname solo cuando el nombre del dispositivo es un hostname DNS válido.
 
 ## [2.28.21] - 2026-09-10

--- a/app/src/components/routers/AgentsSection.tsx
+++ b/app/src/components/routers/AgentsSection.tsx
@@ -54,7 +54,7 @@ const TIMELINE_FAILED_S = 60
 const TIMELINE_STALLED_S = 90
 
 /** Fila de un agente con sus acciones de recuperación (estado local). */
-function AgentRow({ agent, router }: { agent?: AgentInfo; router: Router | undefined }) {
+function AgentRow({ agent, router, nowSec }: { agent?: AgentInfo; router: Router | undefined; nowSec: number }) {
   const { t } = useTranslation()
   const { reinstallAgent, uninstallAgent, createAgentInstall, refreshAgents } = useNetPulse()
   const auth = useAuth()
@@ -63,7 +63,6 @@ function AgentRow({ agent, router }: { agent?: AgentInfo; router: Router | undef
   const [uninstallState, setUninstallState] = useState<ReinstallState>('idle')
   const [uninstallMsg, setUninstallMsg] = useState('')
   const [copyState, setCopyState] = useState<CopyState>('idle')
-  const [nowSec, setNowSec] = useState(() => Math.floor(Date.now() / 1000))
 
   const isNetgrip = agent?.kind === 'netgrip'
   const isOpenWrt = isOpenWrtType(router?.type)
@@ -83,7 +82,11 @@ function AgentRow({ agent, router }: { agent?: AgentInfo; router: Router | undef
   const canUninstall = auth?.role === 'admin' && isOpenWrt && agent !== undefined && agent.kind !== 'external' && agent.kind !== 'netgrip'
 
   const slug = agent?.slug ?? router?.id ?? ''
-  const lastSeen = agent?.lastSeen ? relTimeFromTs(agent.lastSeen) ?? t('routers.agents.never') : t('routers.agents.never')
+  // #691: el relativo se calcula con el reloj compartido nowSec (prop), no con
+  // Date.now() interno; así avanza segundo a segundo y solo cae cuando llega
+  // un push realmente nuevo (antes se recalculaba en renders esporádicos y
+  // oscilaba hacia atrás con cada snapshot).
+  const lastSeen = agent?.lastSeen ? relTimeFromTs(agent.lastSeen, nowSec * 1000) ?? t('routers.agents.never') : t('routers.agents.never')
   const live = agent ? activeUpgrade(agent, nowSec) : undefined
 
   // Timeline compacta (#446): una sola línea por agente, visible mientras el
@@ -98,15 +101,6 @@ function AgentRow({ agent, router }: { agent?: AgentInfo; router: Router | undef
         : up.step === 'failed'
           ? nowSec - up.ts < TIMELINE_FAILED_S
           : up.step !== 'queued' && nowSec - up.ts < TIMELINE_STALLED_S)
-
-  // Tick de 1 s mientras la timeline es visible: progreso en vivo y cuenta
-  // atrás de la desaparición tras done/failed.
-  const ticking = showTimeline
-  useEffect(() => {
-    if (!ticking) return
-    const timer = window.setInterval(() => setNowSec(Math.floor(Date.now() / 1000)), 1000)
-    return () => window.clearInterval(timer)
-  }, [ticking])
 
   const reinstall = async () => {
     if (reinstallState === 'busy') return
@@ -547,6 +541,19 @@ export function AgentsSection() {
     return out
   }, [agents, routers])
 
+  // #691: reloj compartido de 1 s para TODA la tabla (relativos de "Visto" y
+  // progreso de timelines). Antes el ticker solo corría dentro de una fila con
+  // timeline de upgrade visible: sin upgrades en marcha la celda "Visto" se
+  // quedaba congelada entre snapshots y saltaba hacia atrás con cada push del
+  // agente (oscilación 39-44-18-23 s del reporte).
+  const [nowSec, setNowSec] = useState(() => Math.floor(Date.now() / 1000))
+  const hasRows = rows.length > 0
+  useEffect(() => {
+    if (!hasRows) return
+    const timer = window.setInterval(() => setNowSec(Math.floor(Date.now() / 1000)), 1000)
+    return () => window.clearInterval(timer)
+  }, [hasRows])
+
   const down = rows.filter(({ agent }) => (agent ? !agent.fresh : true)).length
   const total = rows.length
 
@@ -581,7 +588,7 @@ export function AgentsSection() {
             </thead>
             <tbody>
               {rows.map(({ agent, router }) => (
-                <AgentRow key={agent?.slug ?? router?.id ?? ''} agent={agent} router={router} />
+                <AgentRow key={agent?.slug ?? router?.id ?? ''} agent={agent} router={router} nowSec={nowSec} />
               ))}
             </tbody>
           </table>


### PR DESCRIPTION
## What

The last-seen cell of the agents table showed a relative time that only updated on sporadic snapshot renders: the 1s ticker that recalculated it ran only while an upgrade timeline was visible, so without upgrades in flight the value froze and jumped backwards with every agent push (oscillating like 39-44-18-23s, as in the report).

## Fix

- A single shared 1s clock now lives in `AgentsSection` (one interval for the whole table, not one per row) and is passed down to each `AgentRow`.
- The relative is derived from that clock (`relTimeFromTs(lastSeen, nowSec * 1000)`) instead of calling `Date.now()` at render time, so the cell advances one second at a time and only drops when a genuinely new push arrives.
- The old per-row ticker (which was gated on the upgrade timeline being visible) is removed.

## Verification

Measured with a MutationObserver on the agents table against a live instance:

- before: 9 text changes in 35s, 5s jumps and erratic drops (52s -> 20s);
- after: 41 changes in 40s (exactly one per second), clean +1s/s growth, resetting only on a real push.

Closes #691