### PR TITLE
fix(topology): place router and peer labels below their nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 ### Fixed
 
+- **Los nombres de la topología ya no se montan sobre los iconos (#692)**: los labels de los APs se dibujaban a los lados y chocaban con el abanico de clientes cableados (que sale al oeste) y con los chips wifi; los de los peers WireGuard se montaban sobre su propio icono y el del peer vecino. Ahora ambos van centrados bajo el nodo: el modelo ya excluye el ángulo del label al repartir los chips wifi, así que ese sector queda libre por construcción.
 - **El resumen de alertas de la Home ya no muestra "ahora mismo" para todo (#698)**: `AlertItem` (y el aviso de temperatura del detalle de router) pintaban el campo `time` legacy, que el backend rellena con "ahora mismo" fijo en las alertas en vivo; una alerta de ayer seguía diciendo "ahora mismo". Ahora usan `alertRelTime`, que calcula el relativo real desde `ts` y solo cae al string legacy si falta el timestamp.
 - **El "Visto" de la flota de agentes ya no oscila (#691)**: el contador de "último push" solo se recalculaba en renders esporádicos (con la llegada de snapshots), así que se congelaba entre actualizaciones y saltaba hacia atrás con cada push del agente (oscilación tipo 39-44-18-23 s). Un único reloj compartido de 1 s alimenta ahora toda la tabla: la celda avanza segundo a segundo y solo cae cuando llega un push realmente nuevo.
 

--- a/app/src/components/topology/TopologyMap.tsx
+++ b/app/src/components/topology/TopologyMap.tsx
@@ -1438,7 +1438,9 @@ export function TopologyMap({
           })}
           {/* Peers */}
           {peerNodes.map((node, i) => (
-            <LabelText key={node.id} x={node.x + (i % 2 ? -26 : 26)} y={node.y - 4} anchor={i % 2 ? 'end' : 'start'}
+            // #692: label DEBAJO del icono (anchor middle); a los lados el
+            // texto se montaba sobre el propio icono y sobre el peer vecino.
+            <LabelText key={node.id} x={node.x} y={node.y + 34} anchor="middle"
               delay={(2.2 + i * 0.03) * T} reduce={reduce ?? false}
               title={node.peer.name} sub={t('topology.peerVia')} subColor={COLOR.tunnel} />
           ))}

--- a/app/src/components/topology/model.ts
+++ b/app/src/components/topology/model.ts
@@ -222,7 +222,7 @@ const AP_ARC_CENTER = 90
 const AP_ARC_HALF = 70
 const AP_BASE_Y = 545
 
-function apCoords(n: number, total: number): { x: number; y: number; r: number; label: { x: number; y: number; anchor: 'end' | 'start' } } {
+function apCoords(n: number, total: number): { x: number; y: number; r: number; label: { x: number; y: number; anchor: 'end' | 'start' | 'middle' } } {
   let angle: number
   if (total === 1) {
     angle = AP_ARC_CENTER
@@ -231,10 +231,13 @@ function apCoords(n: number, total: number): { x: number; y: number; r: number; 
   }
   const x = Math.round(GATEWAY_COORD.x + 280 * Math.cos(rad(angle)))
   const y = Math.round(AP_BASE_Y + 25 * Math.sin(rad(angle - AP_ARC_CENTER)))
-  const isLeft = x < GATEWAY_COORD.x
   return {
     x, y, r: AP_RADIUS,
-    label: { x: isLeft ? x - AP_RADIUS - 6 : x + AP_RADIUS + 6, y: y - 6, anchor: isLeft ? 'end' as const : 'start' as const },
+    // #692: label DEBAJO del nodo (anchor middle). A los lados chocaba con el
+    // abanico cableado (150-210°, oeste) en los APs de la izquierda y con los
+    // chips wifi; el modelo ya excluye el ángulo del label al repartir los
+    // chips wifi, así que colocándolo abajo ese sector queda libre solo.
+    label: { x, y: y + AP_RADIUS + 20, anchor: 'middle' as const },
   }
 }
 const INTERNET_COORD = { x: 500, y: 26 }


### PR DESCRIPTION
## What

Hostnames in the topology overlapped with device icons:

- AP labels were drawn beside the node. On left-side APs that side is also where the wired fan lives (150-210 degrees), and on the right they landed on top of the wifi chips.
- WireGuard peer labels sat at the icon mid-height (y - 4, x +/- 26), so the text started inside the icon and collided with the neighbouring peer.

## Fix

Both labels are now anchored middle below the node. The model already excludes the label angle when distributing wifi chips, so placing the label at the bottom keeps that sector clear by construction instead of fighting the fan.

## Verification

Screenshots of a live instance before/after: AP labels now sit centred under each node, clear of the chips. Build and lint pass.

Closes #692