### PR TITLE
docs(readme): lead with the demo and website, add quickstart tutorial, move release notes out

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -14,7 +14,16 @@
   <a href="https://ko-fi.com/gnacho"><img alt="Apóyame en Ko-fi" src="https://img.shields.io/badge/Ko--fi-Donate-ff5e5b?logo=ko-fi&logoColor=white"></a>
 </p>
 
-<p align="center"><a href="https://demo.netpulse.cloudless.club"><strong>Prueba la demo en vivo</strong></a> en <code>demo.netpulse.cloudless.club</code></p>
+<p align="center">
+  <strong>El pulso de tu red doméstica. En tiempo real. Sin nube.</strong><br>
+  Vigila tus routers, dibuja la topología, puntúa la salud de la red y recibe
+  alertas, desde un único binario autoalojado. Nada sale de tu LAN.
+</p>
+
+<p align="center">
+  <a href="https://demo.netpulse.cloudless.club"><strong>Prueba la demo en vivo</strong></a> ·
+  <a href="https://netpulse.cloudless.club/features"><strong>Tour completo de funciones</strong></a>
+</p>
 
 <p align="center">
   <picture>
@@ -24,257 +33,251 @@
   </picture>
 </p>
 
-NetPulse es una PWA de solo lectura para monitorizar una red doméstica
-construida con routers OpenWrt/GL.iNet: estado de la flota, salud por
-router, dispositivos conectados, mapa de topología en vivo, peers
-WireGuard, estadísticas de AdGuard Home y alertas, en tiempo real. Un
-único binario Go estático con el frontend embebido, autoalojado en una
-caja Linux pequeña.
+## Míralo antes de instalar nada
 
-> **Prueba la demo en vivo**
->
-> Mírala en funcionamiento sin instalar nada. Entra en **[demo.netpulse.cloudless.club](https://demo.netpulse.cloudless.club)** — una red de ejemplo completa, sin registro. En modo de solo lectura, para que explores sin riesgo.
+No necesitas un solo router para ver NetPulse funcionando:
 
-## ¿Por qué existe?
+- **[demo.netpulse.cloudless.club](https://demo.netpulse.cloudless.club)** es la app
+  real con una red de ejemplo completa cargada, en modo de solo lectura y sin
+  registro. Navega, cambia el tema, cambia de idioma, mira las
+  actualizaciones en vivo.
+- **[netpulse.cloudless.club/features](https://netpulse.cloudless.club/features)**
+  recorre cada pantalla y cada función, con las decisiones técnicas y el
+  alcance honesto de cada una.
 
-Siempre he creído en la soberanía digital: si un dispositivo te hace
-depender de su cloud, de su firmware o de su fabricante, no es 100% tuyo.
-Por eso siempre he priorizado hardware que se pueda flashear o rootear.
-La distribución de mi casa acabó con cuatro routers: un Flint 2 como
-principal y tres puntos de acceso Xiaomi AX6 comprados de segunda mano a
-30 euros cada uno. Baratos, potentes, y todos corriendo OpenWrt. Esa
-soberanía me permitió orquestar y personalizar la red a mi antojo (no sin
-ciertos desafíos), pero siempre eché en falta una vista unificada de lo
-que pasaba: qué se conecta dónde, qué va bien, qué no. No había nada, o
-no supe encontrarlo, así que me puse manos a la obra. NetPulse es ese
-visor global: analiza tu red, detecta anomalías y te avisa.
+## ¿Por qué NetPulse?
 
-## ¿Por qué este stack?
+Si usas OpenWrt, tu red ya es tuya. Pero que sea tuya implica *conocerla*:
+qué se conecta dónde, qué va bien, qué cambió anoche. LuCI te muestra un
+router cada vez; las suites NMS tipo Zabbix o LibreNMS están pensadas para
+un datacenter. Lo que faltaba es lo intermedio: un NOC doméstico que se
+instala en minutos y simplemente te enseña tu red.
 
-- **Go, un único binario estático**: un monitor 24/7 en un LXC pequeño.
-  ServeMux de `net/http` de la stdlib, sin framework, `go:embed` para el
-  frontend. Actualizar es cambiar un fichero.
-- **`modernc.org/sqlite`, CGO off**: totalmente estático, sin toolchain C
-  en el destino. Series temporales, usuarios y sesiones en un único
-  fichero SQLite embebido (WAL).
-- **Solo lectura por diseño**: el servidor genera su propio par de claves
-  ed25519; autorizas la clave pública en cada router y solo lee (ubus,
+NetPulse es esa pieza. Nació de mi propia red: un GL.iNet Flint 2 como
+gateway y tres puntos de acceso Xiaomi AX6 de segunda mano, todos con
+OpenWrt, cada uno con su LuCI. Quería una sola pantalla que me dijera la
+verdad sobre el conjunto, así que la construí y la uso cada mañana.
+
+Tres reglas dan forma a todo lo que hace:
+
+- **Solo lectura por diseño.** El servidor genera su propio par de claves
+  SSH; autorizas la pública en cada router y NetPulse solo *lee* (ubus,
   `/proc`, iwinfo, `bridge fdb`, `wg show`). No puede cambiar tu red.
-- **PWA React 19 + Vite + Tailwind**: instalable, en vivo por SSE (5 s),
-  la misma shell de UI que mis otras apps.
-- **systemd, sin Docker**: monitoriza una red; no necesita un contenedor
-  para hacerlo.
+- **Sin nube, sin cuentas, sin telemetría.** Un único binario Go estático con
+  la web embebida, corriendo en una caja pequeña dentro de tu LAN. SQLite
+  para las series temporales, modo WAL, sin servicios externos.
+- **Libre de verdad, para siempre.** AGPL-3.0, sin versión premium esperando
+  detrás de un pago. Si te sirve, [Ko-fi](https://ko-fi.com/gnacho) es la
+  forma de dar las gracias, nunca una suscripción.
 
-## Características
+## Qué te llevas
 
-- **Resumen de flota**: puntuación de salud, tráfico en vivo, latencia,
-  estado por router (CPU, memoria, temperatura, uptime).
-- **Mapa de topología en vivo**: inferido del FDB del bridge (y LLDP
-  cuando está disponible), con clientes cableados e inalámbricos, switches
-  e hipervisores detectados, y túneles WireGuard dibujados de peer a
-  Internet.
-- **Dispositivos**: cada cliente con clasificación por tipo (patrones de
-  hostname + OUI), primer visto, banda, señal.
-- **WireGuard**: peers, últimos handshakes, transferencia por peer.
-- **AdGuard Home**: estadísticas de consultas y dominios más bloqueados.
-- **Alertas**: temperatura, firmware disponible, nuevo dispositivo,
-  handshake, con feed en la campana.
-- **Auth multiusuario**: contraseñas bcrypt, idioma por usuario (ES/EN),
-  roles admin y viewer.
-- **Modo demo** (`DEMO_MODE=1`): una red de muestra de 67 dispositivos,
-  sin necesidad de routers.
-- **Sidecar collector opcional**: sondeo de latencia TCP por router con
-  sus propias series temporales de largo plazo.
+**Resumen de flota y una puntuación de salud que significa algo.** Un único
+valor 0-100 condensa latencia, pérdidas, uptime y temperatura por router y
+para toda la red, actualizado en vivo cada 5 segundos por SSE. Tráfico WAN
+en vivo contra tu plan contratado, feed de alertas, estadísticas de AdGuard
+Home y peers WireGuard en la misma pantalla (es la captura de arriba).
 
-## Novedades
+**Un mapa de topología que se dibuja solo.** Inferido en vivo del FDB del
+bridge (y de LLDP donde está disponible): clientes cableados e inalámbricos
+bajo el router y el puerto por los que hablan de verdad, switches
+gestionados e inferidos, hosts de Proxmox con sus VMs anidadas y túneles
+WireGuard trazados del peer a Internet. Los dispositivos callados conservan
+su sitio; nada salta al refrescar. Arrastra los nodos a tu gusto y el layout
+queda congelado para ti.
 
-Cada versión se empuja a la flota a través del actualizador automático
-incorporado. Las versiones nuevas muestran en la app un panel breve y en
-lenguaje humano de "qué ha cambiado" para que sepas qué esperar antes de
-actualizar. Aquí tienes un resumen en clave de las últimas mejoras, cada una
-enlazada al issue de GitHub que la originó.
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/screenshot-topology-es-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="assets/screenshot-topology-es-light.png">
+    <img alt="Mapa de topología con el gateway en el centro, tres puntos de acceso, clientes cableados e inalámbricos, un switch inferido y el túnel WireGuard a Internet" src="assets/screenshot-topology-es-light.png" width="800">
+  </picture>
+</p>
 
-> Están escritas para personas, no como changelog: qué hace la función por ti,
-> no los nombres de las funciones internas.
+**Cada dispositivo, clasificado.** Hostnames, IPs, detección de tipo
+(patrones de hostname + OUI), primer visto, banda y señal para clientes Wi-Fi,
+y el router al que está asociado cada uno. Etiqueta dispositivos, reserva IPs
+y entérate cuando aparece algo nuevo.
 
-### Última (v2.28.20)
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/screenshot-devices-es-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="assets/screenshot-devices-es-light.png">
+    <img alt="Lista de dispositivos con iconos por tipo, hostname, IP, banda, intensidad de señal y el router al que está asociado cada cliente" src="assets/screenshot-devices-es-light.png" width="800">
+  </picture>
+</p>
 
-- **Los clientes callados se quedan en su AP** ([#678](https://github.com/gnacho/netpulse/issues/678)): un dispositivo cableado tras un AP puente que enmudece ya no se va al router principal — el servidor recuerda dónde está el cable de verdad y solo cuentan las observaciones locales.
-- **Las líneas de los túneles VPN siguen a los nodos** ([#677](https://github.com/gnacho/netpulse/issues/677)): reordenar el mapa ya no deja las curvas WireGuard apuntando al vacío; se trazan del peer a donde está Internet realmente.
-- **El agente se recupera solo tras un corte largo** ([#680](https://github.com/gnacho/netpulse/issues/680)): los payloads caducados del buffer se descartan en vez de bloquear la cola con 401 anti-replay.
+**Salud por router, de un vistazo.** Modelo, firmware, CPU, memoria,
+temperatura, uptime y tráfico en vivo de cada router, con historial por
+puerto y desglose de clientes por banda. Los switches gestionados sondeados
+por SNMP también son ciudadanos de primera.
 
-### Anterior (v2.28.19)
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/screenshot-router-es-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="assets/screenshot-router-es-light.png">
+    <img alt="Vista de routers con tarjetas por router mostrando modelo, firmware, CPU, memoria, temperatura y uptime" src="assets/screenshot-router-es-light.png" width="800">
+  </picture>
+</p>
 
-- **Las alertas (y todo lo demás) en tu idioma** ([#671](https://github.com/gnacho/netpulse/issues/671)). Títulos, descripciones y sugerencias de las alertas los generaba el servidor en español y los usuarios con la app en inglés veían el feed mezclado. Los eventos llevan ahora su tipo y sus valores, y la app los traduce al idioma activo — toda la familia, de dispositivos desconocidos a alertas de puertos.
-- **Tus hostnames sobreviven al traductor del navegador** ([#666](https://github.com/gnacho/netpulse/issues/666)). La página declaraba español incluso con la UI en inglés, así que el navegador ofrecía traducirla — y el traductor "corregía" hostnames como crowed-pixeltab a crowded-pixeltab. El idioma declarado sigue ahora a la UI y los datos de red van marcados como no traducibles.
-- **Paquetes OpenWrt para x86/64** ([#672](https://github.com/gnacho/netpulse/issues/672)). El agente y el servidor on-router se publican también para sistemas x86/64 (.ipk 24.10, .apk 25.12), con la arquitectura del paquete derivada del SDK.
+**Y el resto del tour:**
 
-### Anterior (v2.28.18)
+- **WireGuard**: peers con sus nombres reales, últimos handshakes,
+  transferencia por peer.
+- **AdGuard Home**: estadísticas de consultas, porcentaje bloqueado, dominios
+  más bloqueados.
+- **Wi-Fi y roaming**: matriz de señal por AP, estado 802.11r, utilización
+  por canal, eventos de roaming persistentes.
+- **Alertas que te encuentran**: temperatura, dispositivo nuevo, firmware
+  disponible, WAN caída, problemas de agente; feed en la campana más Web Push
+  nativo en el móvil.
+- **Multiusuario**: contraseñas bcrypt, roles admin y viewer, idioma por
+  usuario (ES/EN).
+- **PWA instalable**: móvil o escritorio, en vivo por SSE, temas claro/oscuro.
+- **Ciudadano OpenWrt de primera**: paquetes nativos `netpulse-agent`
+  (`.ipk`/`.apk`), página `luci-app-netpulse`, config UCI, init procd y
+  watchdog. O el servidor entero en modo on-box.
+- **Se actualiza solo**: el updater integrado comprueba releases y las aplica
+  con swap atómico.
 
-- **El mapa de topología refleja ya dónde está enchufado cada equipo, y deja de saltar** ([#656](https://github.com/gnacho/netpulse/issues/656)). Los clientes por cable de un punto de acceso puente (dumb AP en la misma LAN que el router principal) aparecen bajo ese AP en vez de subir al padre; los dispositivos callados (TVs, receptores, reproductores) conservan su sitio en el mapa en lugar de caerse de su switch cada vez que se duermen; y los iconos ya no se intercambian posiciones en cada refresco.
-- **El layout lo ajustas tú** ([#656](https://github.com/gnacho/netpulse/issues/656)). Un modo de edición (solo admin) permite arrastrar routers, switches y dispositivos para acercar o alejar los satélites; al guardar, el layout queda congelado y solo cambia si vuelves a editarlo o lo restableces al automático.
-- **Los hosts de Proxmox se ven como nodos con sus VMs anidadas debajo** ([#561](https://github.com/gnacho/netpulse/issues/561)). Cada host PVE se dibuja como nodo redondo con su nombre, sus contenedores agrupados bajo él con badge +N, y arrastrar el host mueve a toda su familia de VMs. La tarjeta de dispositivo gana además un botón discreto "Etiquetar" para etiquetar sin teclear la MAC.
+Hay más, y cada pieza tiene su historia: **[el tour completo de funciones
+vive en la web](https://netpulse.cloudless.club/features)**, y todo lo
+anterior se puede tocar en la **[demo en vivo](https://demo.netpulse.cloudless.club)**.
 
-### Anterior (v2.28.17)
+## Cómo funciona el descubrimiento
 
-- **Un router OpenWrt ya no muestra un falso "host key changed" al sondearlo** ([#651](https://github.com/gnacho/netpulse/issues/651)). El descubrimiento (openssh con `accept-new`) solo fijaba la host key del algoritmo que negociaba (ed25519), mientras que el pool de sondeo (Go) negocia otro (ecdsa/rsa) con el mismo servidor; un router con varias host keys mostraba un "ssh host key changed" espurio y pedía un re-onboard sin motivo. El descubrimiento fija ahora **todas** las host keys del router (ed25519, ecdsa y rsa), así el sondeo siempre encuentra la suya, sin debilitar la protección anti-MITM: si un router cambia todas sus claves (reflash), la detección de "host key changed" sigue activa.
+NetPulse descubre los dispositivos cliente a partir de tres fuentes en los
+routers monitorizados: leases DHCP, el FDB del bridge (clientes cableados) y
+mDNS cuando `umdns` está instalado. LLDP identifica routers y switches
+vecinos. El tráfico por cliente prefiere `nlbwmon` (contadores por MAC,
+cable) y cae a los contadores de bytes de hostapd (Wi-Fi); si un cliente
+cableado no muestra serie de tráfico, instala `nlbwmon` en ese router.
+`vnstat` mide totales por interfaz, no por cliente, así que no es sustituto.
 
-### Anterior (v2.28.16)
+## Empieza en unos cinco minutos
 
-- **Los peers WireGuard se etiquetan por su nombre configurado en OpenWrt** ([#663](https://github.com/gnacho/netpulse/issues/663)). En la topología, los peers WireGuard que no estaban ya mapeados a un dispositivo NetPulse se muestran ahora con el nombre legible de la descripción UCI del peer (prioridad: nombre del dispositivo NetPulse → descripción UCI → IP del túnel) en lugar de la IP cruda del túnel. El sondeo lee `wg show dump` y `uci show network` en una sola sesión SSH (con marcador de separación) y conserva el estado de un túnel caído.
+Necesitas una caja Linux con systemd (x86_64, arm64 o armv7; un LXC o VM
+pequeña sobra) y routers OpenWrt/GL.iNet en tu LAN.
 
-### Arreglado
-
-- **Un router OpenWrt nativo ya no aparece como "Managed switch" en la tabla de dispositivos** ([#660](https://github.com/gnacho/netpulse/issues/660)). La columna Role distinguía solo gateway y "solo agente", y el resto caía en "Managed switch"; ahora se basa en el tipo del dispositivo y muestra "OpenWrt" para los routers nativos (agente SSH), dejando "Managed switch"/External para los sondeados por SNMP.
-- **El switch sondeado por SNMP ya no pierde el historial de tráfico ni los dispositivos conectados** ([#661](https://github.com/gnacho/netpulse/issues/661)). El sondeo SNMP calculaba los contadores de bytes y la tasa por puerto pero nunca los persistía, así que la "historia de tráfico" del switch quedaba vacía aunque leyera los datos (ahora vía `recordPortSamples`, la misma ruta que SSH/agente). El FDB ya no descarta las MACs cuyo índice no resolvía a un puerto conocido (antes el switch mostraba 0 dispositivos pese a tener clientes) y hay un fallback a la tabla Q-BRIDGE para los switches que solo la exponen. La tarjeta de la flota pinta ahora el tráfico agregado del switch en bps, y la gráfica de puertos de un switch SNMP usa bps (los beacons sin contadores de bytes siguen en fps).
-
-### Anterior (v2.28.15)
-
-- **La gráfica de tráfico de los puertos muestra frames/s cuando el dispositivo no mide bytes** ([#641](https://github.com/gnacho/netpulse/issues/641)). Los beacons de switches RTLPlayground (KP-9000) solo reportan contadores acumulados de tramas, no bytes. El servidor deriva ahora frames/s de esos contadores (raw, 5m y diario) y la tarjeta de Puertos del detalle dibuja fps en lugar de bps para las fuentes sin contadores de bytes, así la gráfica de un puerto de switch gestionado ya no parece vacía.
-- **La flota y el detalle muestran el desglose real de clientes por banda** ([#645](https://github.com/gnacho/netpulse/issues/645)). Cada tarjeta de router indica ahora sus clientes online por banda (2.4/5/6 GHz y cable) calculado en el servidor con la misma fuente que el total, y solo pinta las bandas que tienen clientes: un switch sin radios wifi ya no muestra bandas wifi a 0.
-- **La línea de tráfico 24h de un switch sin throughput en bps ya no es plana** ([#648](https://github.com/gnacho/netpulse/issues/648)). Para las fuentes que solo reportan tramas por puerto, el mini-gráfico de tráfico de la tarjeta se deriva ahora de los frames/s de sus puertos en lugar de la tabla de bps (que para ellas siempre estaba vacía), así la tarjeta del KP-9000 muestra su actividad real.
-- **Los switches beacon RTLPlayground reportan firmware, uptime y MAC reales** ([#639](https://github.com/gnacho/netpulse/issues/639)). El servidor sondea la consola HTTP del switch de los agentes beacon, y la tarjeta del router muestra ahora la versión de firmware real, el tiempo de actividad y la MAC del switch en lugar de marcadores de posición.
-
-### Arreglado
-
-- **El detalle de un switch gestionado ya no pinta sus puertos dos veces** ([#644](https://github.com/gnacho/netpulse/issues/644)). La tarjeta de chasis con LEDs de salud duplicaba a la de Puertos Ethernet con las bocas RJ45; el front panel ha desaparecido y la tarjeta de puertos ya muestra el enlace, la salud y el historial por puerto.
-- **Las series de puertos de un switch beacon ya no se ensucian con ceros** ([#642](https://github.com/gnacho/netpulse/issues/642)). Las fuentes externas solo persisten ahora sus contadores reales, manteniendo limpias las series de los puertos.
-
-### Anterior (v2.28.14)
-
-- **El plan de canales ya no cuenta tu propia malla como interferencia ni sugiere un canal que cruce a DFS** ([#631](https://github.com/gnacho/netpulse/issues/631)). En el análisis de canales, los BSSID de tus propios puntos de acceso ya no puntúan como vecinos (se excluyen emparejando el prefijo MAC de tus routers monitorizados), y los canales candidatos se validan contra el ancho de la radio: a 40/80/160 MHz solo se ofrecen bloques que no entran en canales DFS (52-64, 100-144). Evita que NetPulse recomiende un canal que ya usan los satélites de tu malla, o un bloque de 80 MHz que cruzaría a banda DFS.
-- **El rearm ahora recupera un agente atascado en bucle de 401** ([#630](https://github.com/gnacho/netpulse/issues/630)). Si un reinicio no trae de vuelta al agente, NetPulse regenera el token del agente y lo aplica en el router (reescribe el `.env` y reinicia) sin reinstalar, así un token desincronizado se arregla en caliente. La rotación de token en un reinstall también es atómica: si el SSH falla, el servidor restaura el token anterior, para que el agente nunca se quede empujando un token que ya no se acepta.
-
-### Anterior (v2.28.13)
-
-- **Una página de Ajustes más limpia, a una columna** ([#627](https://github.com/gnacho/netpulse/issues/627)). La página de Ajustes pasa a una columna única con un índice fijo que te sigue al hacer scroll, así cada tarjeta (Apariencia, Datos y umbrales, Servicios, Red, Integraciones, Administración, Cuenta, Acerca de) ocupa el ancho completo y es más manejable. La tarjeta Apariencia muestra previews reales del tema (claro/oscuro/sistema) y la paleta en dos columnas; el test de velocidad WAN se ejecuta real desde el servidor y rellena descarga/subida en su sitio. Los toggles de Laboratorio aparecen individuales (Orquestación, Canales, Actualizaciones) al activar Labs.
-- **Regenerar el token de un agente sin reinstalar** ([#627](https://github.com/gnacho/netpulse/issues/627)). Al regenerar el token de un dispositivo desde Ajustes, NetPulse ahora lo aplica en el propio router por SSH y reinicia el agente, así el dispositivo sigue reportando **sin reinstalar**. El one-liner de instalación solo hace falta cuando el router no es alcanzable por SSH.
-- **Actualizaciones: autodetecta la imagen de firmware** ([#629](https://github.com/gnacho/netpulse/issues/629)). En la página de actualizaciones de firmware, NetPulse resuelve la imagen del router a partir de su propio firmware (board + target + version) en el índice de descargas de OpenWrt y **prerrellena** la URL y el checksum, con un botón "Autodetectar imagen". La entrada manual se mantiene cuando no se puede resolver.
-- **Desinstalar el agente en routers justos** ([#624](https://github.com/gnacho/netpulse/issues/624)). En routers con poco espacio libre (como el UniFi 6 Lite) no cabía un reinstall; ahora hay una acción "Desinstalar" limpia que detiene y retira el agente.
-
-### Arreglado
-
-- **Los botones de copiar mostraban la clave i18n cruda** ([#628](https://github.com/gnacho/netpulse/issues/628)). Los botones de copiar de la tarjeta de adopción usaban una clave `common.copy` inexistente, así que el tooltip mostraba `common.copy`; la clave ya existe y traduce a "Copy"/"Copiar".
-
-### Anterior (v2.28.12)
-
-- **Puerto SSH personalizado por router** ([#605](https://github.com/gnacho/netpulse/issues/605)). No todos los routers dejan el daemon SSH en el puerto 22: algunos lo tienen en otro. Ahora cada router admite su propio puerto SSH al darlo de alta o editarlo, y todos los caminos del servidor (sondeo, acciones, instalación del agente, descubrimiento del gateway) lo usan automáticamente. Déjalo vacío y NetPulse sigue usando el 22.
-- **Matriz de itinerancia agrupada por dispositivo** ([#600](https://github.com/gnacho/netpulse/issues/600)). En WiFi Roaming → Matriz, las columnas se agrupan ahora bajo el nombre del punto de acceso, con una fila de cabecera que etiqueta cada banda (2.4G/5G). Ya no hay una columna suelta por AP-banda.
-- **Nombres de 802.11r más claros y sin dispositivos fantasma** ([#601](https://github.com/gnacho/netpulse/issues/601)). El título de la sección pasa a "Por AP" en lugar de "Por router", la columna a "Dispositivo", y los equipos sin radios (como el gateway) ya no aparecen en el detalle por router. Los routers descubiertos automáticamente se nombran por su hostname, no por el modelo de hardware, así la UI muestra nombres de dispositivo en toda la app.
-- **Ancho de canal propio en el análisis de canales** ([#602](https://github.com/gnacho/netpulse/issues/602)). En el análisis de canales, la fila de tu propia red muestra ahora el ancho de canal (por ejemplo `1 · 20 MHz`) junto al número de canal, cruzado con el channel-plan del router.
-- **La UI ya no se queda en negro al conectarse un cliente WireGuard** ([#592](https://github.com/gnacho/netpulse/issues/592)). NetPulse envía el tipo de peer WireGuard como texto plano y usa "desconocido" cuando no encuentra tipo. La tarjeta de la Home construía el icono sin fallback, así que un peer desconocido (o no mapeado) producía un icono en blanco y React tiraba toda la página en cuanto un cliente WireGuard se conectaba (o al abrir la UI desde él). NetPulse tiene ahora un icono de respaldo para estos casos y un tipo "desconocido" conocido, así la página sigue renderizando.
-
-### Anterior (v2.28.11)
-
-- **El agente ya no degrada tu WiFi al escanear** ([#591](https://github.com/gnacho/netpulse/issues/591)). El agente por router lanzaba un escaneo WiFi activo completo en cada sondeo, es decir cada ~30-37 s por dispositivo. En puntos de acceso eso saca la radio del canal y suelta clientes IoT/débiles. Ahora escanea como mucho cada 10 minutos, tras el arranque, o de inmediato cuando el servidor pide un refresh, y la versión de agente embebida sube para que la flota se actualice sola.
-
-### Qué se descubre
-
-NetPulse descubre dispositivos clientes a partir de tres fuentes que se ejecutan en los routers monitorizados:
-
-1. **Leases DHCP**: en cada push, el agente lee la tabla local de leases DHCP.
-2. **FDB del bridge**: los clientes cableados se aprenden de la base de datos de reenvío del switch.
-3. **mDNS / Bonjour**: si `umdns` está instalado en OpenWrt, el agente hace browse de los servicios anunciados y resuelve hostnames.
-
-LLDP solo se usa para identificar routers/switches vecinos, no dispositivos finales. El descubrimiento requiere que el agente de NetPulse esté corriendo en el router que ve a los clientes; una instalación nueva con solo routers dados de alta manualmente y sin agente en el gateway mostrará una lista de dispositivos vacía hasta que se instale el agente.
-
-El tráfico por cliente prefiere `nlbwmon` para los clientes por cable (contadores por MAC) y cae a los contadores de bytes de hostapd para los WiFi. `nlbwmon` no viene en todos los builds de OpenWrt y puede ser pesado en memoria en routers con poca RAM; `vnstat` mide totales por interfaz, no tráfico por MAC, así que no es un sustituto. Si un cliente por cable no muestra serie de tráfico, instala `nlbwmon` en ese router (o confía en el fallback WiFi).
-
-## Capturas
-
-**Topología: inferida en vivo del FDB del bridge, túneles incluidos**
-
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/screenshot-topology-es-dark.png">
-  <source media="(prefers-color-scheme: light)" srcset="assets/screenshot-topology-es-light.png">
-  <img alt="Mapa de topología con el gateway en el centro, tres puntos de acceso, clientes cableados e inalámbricos, un switch inferido y el túnel WireGuard a Internet" src="assets/screenshot-topology-es-light.png" width="800">
-</picture>
-
-**Dispositivos: cada cliente clasificado, con banda y señal**
-
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/screenshot-devices-es-dark.png">
-  <source media="(prefers-color-scheme: light)" srcset="assets/screenshot-devices-es-light.png">
-  <img alt="Lista de dispositivos con iconos por tipo, hostname, IP, banda, intensidad de señal y el router al que está asociado cada cliente" src="assets/screenshot-devices-es-light.png" width="800">
-</picture>
-
-**Routers: salud por router de un vistazo**
-
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/screenshot-router-es-dark.png">
-  <source media="(prefers-color-scheme: light)" srcset="assets/screenshot-router-es-light.png">
-  <img alt="Vista de routers con tarjetas por router mostrando modelo, firmware, CPU, memoria, temperatura y uptime" src="assets/screenshot-router-es-light.png" width="800">
-</picture>
-
-## Qué debes esperar
-
-NetPulse es un proyecto personal, construido para mi propia red y
-publicado como software libre (AGPL-3.0). Es y será siempre libre. Trabajo
-en él en mi tiempo libre: hay muchas ideas para mejoras, pero poco tiempo,
-y evoluciona siguiendo primero mis propias necesidades. Con colaboraciones
-o apoyo quizás podría crecer más rápido, pero no puedo prometer nada.
-**Nota honesta de alcance**: de momento solo se ha probado con mi propio
-hardware (un gateway GL.iNet Flint 2 y tres puntos de acceso Xiaomi AX6
-con OpenWrt), además de WireGuard y AdGuard Home. Otros dispositivos
-OpenWrt deberían funcionar, pero el tuyo sería el primero en contarlo.
-
-## Roadmap
-
-| Fase | Estado | Highlights |
-|---|---|---|
-| **1 — Topología v5** | ✅ | Mapa semántico real: FDB + LLDP en vivo, backhaul, switches gestionados vs. inferidos, hipervisores con sus CTs anidados, collector de series temporales |
-| **2 — Alertas, Push y agente (piloto)** | ✅ | Alertas con 6 categorías y config por categoría, Web Push nativo (VAPID), refresco bajo demanda, agente OpenWrt piloto (ingesta con tokens, fallback SSH, procd) |
-| **3 — Base read-only + Node→Go** | ✅ | PWA en React, sondeo SSH de solo lectura (ubus, /proc, iwinfo), AdGuard Home + WireGuard, auth multi-usuario, backend migrado a un binario Go único |
-| **4 — View-model + Ajustes remodel** | ✅ | API como view-model de presentación (`vm: 1`), canon demo single-source, topología semántica en el snapshot |
-| **5 — Resiliencia del agente** | ✅ | Watchdog + heartbeat en el router, rearme manual desde el servidor, auto-rearme tras TTL, rutas de mutación solo-admin |
-| **6 — Seguridad del agente** | ✅ | HMAC-SHA256 en la ingesta del agente, binario del agente servido desde el propio servidor |
-| **7 — Agente a fondo** | ✅ | Eventos wifi en tiempo real (`iw event`), SSE bidireccional, paquete `.ipk`, profiling (RSS 11-12 MB, CPU <1%) |
-| **8 — Consolidación** | ✅ | Métricas operativas en `/api/health`, registry de agentes persistente, escalera de retención (raw 7d → buckets 5min 1año → daily ∞), recharts v3, webhooks salientes |
-| **9 — On-box** | ✅ | Config UCI, bootstrap AUTH_PASS, TLS autofirmado + SPKI pinning, token de pairing, paquete server OpenWrt |
-| **10 — Orquestación** | ✅ | Motor plan→apply→state + executor sandboxeado (10.1), módulos AdGuard (10.2), WiFi guest, DDNS, SQM y usteer. WireGuard aplazado a la Fase 17 |
-| **11 — Paquete LuCI** | ✅ | `luci-app-netpulse`: estado local del agente (procd, UCI, logs, restart/rearm) + test connection + puente a la webapp |
-| **12 — Auditoría de seguridad** | ✅ | TRUST_PROXY, anti-replay en ingesta, body cap, password mínima 10 |
-| **13 — Auditoría de robustez** | ✅ | Single-flight GetOverview, SSE write deadline, race en sshpool.dial, %w wrapping |
-| **14 — Visibilidad WiFi/roaming** | ✅ | Matriz de señal DAWN, estado 802.11r por SSID, utilización por canal survey, feed persistente de eventos de roaming (30 días). Polish pendiente: claridad de la gráfica del análisis de canales ([#618](https://github.com/gnacho/netpulse/issues/618)) |
-| **15 — Informes** | 🔄 | Disponibilidad día/semana/mes. Pendiente: tráfico, actividad, resumen de alertas, exportación, e insights de red por cliente/VLAN ([#588](https://github.com/gnacho/netpulse/issues/588)) |
-| **16 — Alertas avanzadas** | 🔮 | Reglas custom por umbral, tipos nuevos (fallo de roaming, congestión de canal), silencio programado, email |
-| **17 — Escribir en routers** | 🔄 | Ownership UCI + apply seguro con rollback (#451), planificación de canales (#452), firmware upgrades (#453); índice completo de módulos (AdGuard full, WiFi guest, DDNS, QoS, WireGuard, OpenVPN, Tailscale, Batman, DPI) |
-| **18-20 — Programa de beta-testing** | 🔮 | Grupos de módulos por riesgo (bajo / medio / alto) con canales stable + unstable y beta-testers externos |
-
-Detalle completo en [docs/ROADMAP.md](docs/ROADMAP.md).
-
-## Instalación
-
-Requisitos: Linux (x86_64, arm64 o armv7) con systemd.
+**1. Instala el servidor** en la caja:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/gnacho/netpulse/main/install.sh | sh   # (recomendado)
+curl -fsSL https://raw.githubusercontent.com/gnacho/netpulse/main/install.sh | sh
 ```
 
-El instalador es shell plano y legible: [inspecciónalo primero](install.sh).
-Detecta tu distro y arquitectura, descarga la release verificada (sha256
-contra `checksums.txt`), crea un servicio systemd `netpulse` enjaulado y
-muestra la contraseña inicial de admin una sola vez. Actualiza
-re-ejecutando la misma línea; desinstala con `sh install.sh --uninstall`.
+El instalador es shell plano y legible ([inspecciónalo primero](install.sh)):
+detecta distro y arquitectura, descarga la release verificada contra
+`checksums.txt`, crea un servicio systemd `netpulse` enjaulado y muestra la
+contraseña inicial de admin una sola vez. Re-ejecutar la misma línea
+actualiza; `sh install.sh --uninstall` desinstala.
 
-Sidecar de latencia opcional (series temporales de sondeo TCP por router):
+**2. Abre la app** en `http://<ip-del-servidor>:3000`, entra con la
+contraseña impresa y el gateway ya está ahí: NetPulse lo encuentra en el
+primer arranque por descubrimiento LAN (barrido TCP :22 con fingerprinting
+ubus/GL-UI).
+
+**3. Autoriza la clave SSH.** El servidor generó su propio par de claves en
+el primer arranque. Copia la clave pública desde **Ajustes → Red** y, en cada
+router que quieras monitorizar, añádela:
+
+```sh
+echo "<clave pública de Ajustes>" >> /etc/dropbear/authorized_keys
+```
+
+**4. Instala los agentes desde la app.** Abre **Routers** y baja hasta la
+tabla de agentes: cada router OpenWrt tiene su fila, y los que no tienen
+agente ofrecen el botón **Instalar agente**. Un clic y el servidor registra
+el agente, empuja el binario correcto para la arquitectura del router,
+escribe la config y arranca el servicio; aparece como conectado en segundos.
+Los routers a los que el servidor no llega por SSH usan el token de
+emparejamiento (**Ajustes → Adopción de agentes**, mira la sección plegada
+de abajo).
+
+**5. Llévatela contigo.** Instala la PWA desde el navegador (Añadir a
+pantalla de inicio / Instalar app) y activa Web Push en Ajustes: las alertas
+llegan al móvil aunque la pestaña esté cerrada.
+
+¿Prefieres verla primero en tu propio hardware? `DEMO_MODE=1 ./netpulse`
+levanta la misma app con una red de muestra de 67 dispositivos, sin routers.
+
+<details>
+<summary><strong>Otras vías de instalación</strong></summary>
+
+**Paquetes OpenWrt.** Cada release publica `netpulse-agent` y
+`luci-app-netpulse` como paquetes instalables (`.ipk` para OpenWrt 24.10,
+`.apk` para 25.12, más x86/64). Bájalos de la
+[última release](https://github.com/gnacho/netpulse/releases):
+
+```sh
+# OpenWrt 24.10 (ipk)
+opkg install ./netpulse-agent_*.ipk ./luci-app-netpulse_*.ipk
+
+# OpenWrt 25.12 (apk)
+apk add --allow-untrusted ./netpulse-agent-*.apk ./luci-app-netpulse-*.apk
+```
+
+El paquete trae una config vacía, así que apúntalo a tu servidor antes de
+arrancar:
+
+```sh
+uci set netpulse-agent.main.server='http://<ip-del-servidor-netpulse>:3000'
+uci set netpulse-agent.main.slug='<slug>'
+uci set netpulse-agent.main.token='<token hex de 64>'
+uci commit netpulse-agent
+service netpulse-agent enable && service netpulse-agent start
+```
+
+Si el servidor ya puede hacer SSH al router, sáltate todo esto y pulsa
+**Instalar agente** en la app: hace cada paso por ti.
+
+**Token de emparejamiento.** Para routers a los que el servidor no llega por
+SSH, Ajustes → Adopción de agentes muestra un token reutilizable:
+`install-agent.sh --pairing-token` (ejecutado desde cualquier máquina que
+alcance el router y el servidor) registra el agente en el primer contacto.
+
+**Sidecar de latencia.** Sondeos TCP de latencia por router a largo plazo,
+opcionales:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/gnacho/netpulse/main/install-collector.sh | sh
 ```
 
-Los binarios estables se publican por tag `v*` (goreleaser); los builds
-rolling por commit viven en la prerelease `go-latest` para el updater
-in-app.
+**Modo on-box.** ¿Sin caja aparte? El servidor corre en el propio router
+OpenWrt, con config UCI y TLS autofirmado con pinning SPKI.
 
-## Conectar tus routers
+</details>
 
-El servidor genera su propio par de claves ed25519 y muestra la clave
-pública en Ajustes. Autorízala en cada router que quieras monitorizar
-(`/etc/dropbear/authorized_keys`). El gateway se autodetecta en el primer
-arranque por descubrimiento LAN (barrido TCP :22, fingerprint ubus/GL-UI);
-el resto se añade desde Ajustes. El sondeo es estrictamente de solo
-lectura.
+## Actualizaciones e historial de versiones
+
+Las releases van firmadas, con checksums, y llegan a tu flota por el
+actualizador integrado; la app muestra un panel breve y legible de "qué ha
+cambiado" antes de actualizar. El historial completo vive en
+[CHANGELOG.md](CHANGELOG.md) y en la
+[página de releases](https://github.com/gnacho/netpulse/releases); el plan
+que viene, en [docs/ROADMAP.md](docs/ROADMAP.md).
+
+## Qué debes esperar
+
+NetPulse es un proyecto personal, construido para mi propia red y publicado
+como software libre (AGPL-3.0). Es y será siempre libre. Trabajo en él en mi
+tiempo libre y evoluciona siguiendo primero mis propias necesidades; con
+colaboraciones o apoyo quizás crezca más rápido, pero no puedo prometer
+nada. **Nota honesta de alcance**: de momento solo se ha probado con mi
+propio hardware (un gateway GL.iNet Flint 2 y tres puntos de acceso Xiaomi
+AX6 con OpenWrt), además de WireGuard y AdGuard Home. Otros dispositivos
+OpenWrt deberían funcionar, pero el tuyo sería el primero en contarlo.
+
+## Documentación
+
+- **[Manual de usuario](docs/manual.es.md)** (también en
+  [inglés](docs/manual.en.md)): cada pantalla explicada, menú a menú, con
+  procedimientos paso a paso.
+- **[Web del proyecto](https://netpulse.cloudless.club)**: el proyecto en
+  cinco minutos, con [tour de funciones](https://netpulse.cloudless.club/features),
+  FAQ y capturas.
+- **[Hoja de ruta](docs/ROADMAP.md)**: qué está hecho y qué viene.
+- **[Discusiones](https://github.com/gnacho/netpulse/discussions)**:
+  preguntas, ideas y hablar del futuro.
 
 ## Desarrollo
 
@@ -288,15 +291,8 @@ go build -o netpulse ./cmd/netpulse && DEMO_MODE=1 ./netpulse
 cd app
 npm install
 npm run dev
-```
 
-El backend Node legado fue eliminado (decisión 5-Ago-2026: no se despliega ni se
-actualiza); su historial git se conserva. La migración desde su base de datos
-ocurre automáticamente en el primer arranque Go.
-
-## Tests
-
-```bash
+# Tests
 cd server-go && go test ./...
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,16 @@
   <a href="https://ko-fi.com/gnacho"><img alt="Support on Ko-fi" src="https://img.shields.io/badge/Ko--fi-Donate-ff5e5b?logo=ko-fi&logoColor=white"></a>
 </p>
 
-<p align="center"><a href="https://demo.netpulse.cloudless.club"><strong>Try the live demo</strong></a> on <code>demo.netpulse.cloudless.club</code></p>
+<p align="center">
+  <strong>The pulse of your home network. Real time. No cloud.</strong><br>
+  Watch your routers, draw your topology, score your network's health and get
+  alerted, from a single self-hosted binary. Nothing ever leaves your LAN.
+</p>
+
+<p align="center">
+  <a href="https://demo.netpulse.cloudless.club"><strong>Try the live demo</strong></a> ·
+  <a href="https://netpulse.cloudless.club/features"><strong>Full feature tour</strong></a>
+</p>
 
 <p align="center">
   <picture>
@@ -24,298 +33,172 @@
   </picture>
 </p>
 
-NetPulse is a read-only PWA for monitoring a home network built on
-OpenWrt/GL.iNet routers: fleet status, per-router health, connected devices,
-a live topology map, WireGuard peers, AdGuard Home stats and alerts, in real
-time. One static Go binary with the frontend embedded, self-hosted on a
-small Linux box.
+## See it before you install it
 
-> **Try the live demo**
->
-> See it running without installing anything. Head to **[demo.netpulse.cloudless.club](https://demo.netpulse.cloudless.club)** — a full sample network, no sign-up required. In read-only mode, so you can explore freely.
+You don't need a single router to see NetPulse working:
 
-## Why does this exist?
+- **[demo.netpulse.cloudless.club](https://demo.netpulse.cloudless.club)** is the real app
+  with a full sample network loaded, read-only, no sign-up. Click around, change
+  the theme, switch languages, watch the live updates.
+- **[netpulse.cloudless.club/features](https://netpulse.cloudless.club/features)**
+  walks through every screen and feature, with the technical decisions and the
+  honest scope of each one.
 
-I believe in digital sovereignty: if a device makes you depend on its
-cloud, its firmware or its vendor, it isn't 100% yours. That's why I've
-always favored hardware I can flash or root. My home layout ended up with
-four routers: a Flint 2 as the main one and three Xiaomi AX6 access points
-bought second-hand for 30 euros each. Cheap, powerful, and all running
-OpenWrt. That sovereignty let me orchestrate and personalize the network
-exactly how I wanted (not without some challenges), but I always missed a
-unified view of what was going on: what connects where, what's healthy,
-what isn't. There was nothing out there, or I couldn't find it, so I built
-it. NetPulse is that global viewer: it analyzes your network, spots
-anomalies, and warns you.
+## Why NetPulse?
 
-## Why this stack?
+If you run OpenWrt, you already own your network. But owning it means
+*knowing* it: what connects where, what's healthy, what changed overnight.
+LuCI shows you one router at a time; NMS suites like Zabbix or LibreNMS are
+built for datacenters. What was missing is the thing in between: a home NOC
+that installs in minutes and just shows you your network.
 
-- **Go, single static binary**: a 24/7 monitor on a small LXC. The stdlib
-  `net/http` ServeMux, no framework, `go:embed` for the frontend. Upgrade
-  is swapping one file.
-- **`modernc.org/sqlite`, CGO off**: fully static, no C toolchain needed
-  on the target. Time series, users and sessions in one embedded SQLite
-  file (WAL).
-- **Read-only by design**: the server generates its own ed25519 keypair;
-  you authorize the public key on each router and it only ever reads
-  (ubus, `/proc`, iwinfo, `bridge fdb`, `wg show`). It cannot change your
-  network.
-- **React 19 + Vite + Tailwind PWA**: installable, live over SSE (5 s),
-  the same UI shell as my other apps.
-- **systemd, no Docker**: it monitors a network; it doesn't need a
-  container to do it.
+NetPulse is that missing piece. It grew out of my own network: a GL.iNet
+Flint 2 as the gateway and three second-hand Xiaomi AX6 access points, all on
+OpenWrt, each with its own LuCI. I wanted one screen that told me the truth
+about the whole thing, so I built it and use it every morning.
 
-## Features
+Three rules shape everything it does:
 
-- **Fleet overview**: health score, live traffic, latency, per-router
-  status (CPU, memory, temperature, uptime).
-- **Live topology map**: inferred from the bridge FDB (and LLDP when
-  available), with wired/wireless clients, switches and hypervisors
-  detected, WireGuard tunnels drawn peer to Internet.
-- **Devices**: every client with type classification (hostname patterns +
-  OUI), first seen, band, signal.
-- **WireGuard**: peers, latest handshakes, transfer per peer.
-- **AdGuard Home**: query stats and top blocked domains.
-- **Alerts**: temperature, firmware available, new device, handshake, with
-  a bell feed.
-- **Multi-user auth**: bcrypt passwords, per-user language (ES/EN), admin
-  and viewer roles.
-- **Demo mode** (`DEMO_MODE=1`): a 67-device sample network, no routers
-  needed.
-- **Optional collector sidecar**: TCP latency probes per router with its
-  own long-term time series.
+- **Read-only by design.** The server generates its own SSH key; you authorize
+  the public key on each router and NetPulse only ever *reads* (ubus, `/proc`,
+  iwinfo, `bridge fdb`, `wg show`). It cannot change your network.
+- **No cloud, no accounts, no telemetry.** One static Go binary with the web
+  app embedded, running on a small box inside your LAN. SQLite for the time
+  series, WAL mode, no external services.
+- **Free as in forever.** AGPL-3.0, no premium tier waiting behind a paywall.
+  If it's useful to you, [Ko-fi](https://ko-fi.com/gnacho) is the way to say
+  thanks, never a subscription.
 
-## What's new
+## What you get
 
-Each release is pushed to the fleet through the built-in auto-updater. Newer
-versions surface a short, human-readable "what changed" panel in the app so
-you know what to expect before you update. Here is a running summary of the
-latest improvements, each linked to the GitHub issue that drove it.
+**Fleet overview and a health score that means something.** One 0-100 score
+condenses latency, loss, uptime and temperature per router and for the whole
+network, updated live every 5 seconds over SSE. Live WAN traffic against your
+contracted plan, alert feed, AdGuard Home stats and WireGuard peers on the
+same screen (that's the screenshot above).
 
-> These are written for people, not changelogs: what the feature does for you,
-> not the function names behind it.
+**A topology map that draws itself.** Inferred live from the bridge FDB (and
+LLDP where available): wired and wireless clients under the router and port
+they actually talk through, managed and inferred switches, Proxmox hosts with
+their VMs nested, and WireGuard tunnels drawn from peer to Internet. Quiet
+devices keep their place; nothing jumps around on refresh. Drag nodes to
+arrange it and the layout stays yours.
 
-### Latest (v2.28.20)
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/screenshot-topology-en-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="assets/screenshot-topology-en-light.png">
+    <img alt="Topology map with the gateway in the center, three access points, wired and wireless clients, an inferred switch and the WireGuard tunnel to Internet" src="assets/screenshot-topology-en-light.png" width="800">
+  </picture>
+</p>
 
-- **Quiet clients stay on their AP** ([#678](https://github.com/gnacho/netpulse/issues/678)): a wired device behind a bridged AP that goes silent no longer drifts to the main router — the server remembers where the cable actually is, and only local sightings count.
-- **VPN tunnel lines follow the nodes** ([#677](https://github.com/gnacho/netpulse/issues/677)): rearranging the map no longer leaves WireGuard curves pointing at empty space; they are drawn from the peer to wherever Internet actually is.
-- **The agent recovers on its own after a long outage** ([#680](https://github.com/gnacho/netpulse/issues/680)): stale buffered payloads are discarded instead of deadlocking the queue with anti-replay 401s.
+**Every device, classified.** Hostnames, IPs, type detection (hostname
+patterns + OUI), first seen, band and signal for Wi-Fi clients, and the router
+each one is attached to. Label devices, reserve IPs, and see when something
+new shows up.
 
-### Earlier (v2.28.19)
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/screenshot-devices-en-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="assets/screenshot-devices-en-light.png">
+    <img alt="Device list with type icons, hostname, IP, band, signal strength and the router each client is attached to" src="assets/screenshot-devices-en-light.png" width="800">
+  </picture>
+</p>
 
-- **Alerts (and everything else) render in your language** ([#671](https://github.com/gnacho/netpulse/issues/671)). Alert titles, descriptions and suggestions used to be server-generated Spanish, so English users saw a mixed feed. Events now carry their type and values and the app translates them in the active language — the full family, from unknown devices to port alerts.
-- **Your hostnames survive the browser translator** ([#666](https://github.com/gnacho/netpulse/issues/666)). The page used to declare Spanish even with an English UI, which made browsers offer to translate it — and the translator happily "corrected" hostnames like crowed-pixeltab into crowded-pixeltab. The declared language now follows the UI and network data is marked do-not-translate.
-- **OpenWrt packages for x86/64** ([#672](https://github.com/gnacho/netpulse/issues/672)). The agent and on-router server are now published for x86/64 systems (24.10 .ipk, 25.12 .apk), with the package architecture derived from the SDK.
+**Per-router health at a glance.** Model, firmware, CPU, memory, temperature,
+uptime and live traffic for each router, with port-level history and per-band
+client splits. SNMP-polled managed switches are first-class citizens too.
 
-### Earlier (v2.28.18)
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/screenshot-router-en-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="assets/screenshot-router-en-light.png">
+    <img alt="Routers view with per-router cards showing model, firmware, CPU, memory, temperature and uptime" src="assets/screenshot-router-en-light.png" width="800">
+  </picture>
+</p>
 
-- **The topology map now reflects where things are actually plugged, and it stops jumping around** ([#656](https://github.com/gnacho/netpulse/issues/656)). Wired clients of a bridged access point (a dumb AP on the same LAN as the main router) show under that AP instead of drifting up to the parent; quiet devices (TVs, receivers, media players) keep their place on the map instead of falling off their switch whenever they go silent; and client icons no longer swap spots on every refresh.
-- **The layout is yours to adjust** ([#656](https://github.com/gnacho/netpulse/issues/656)). A new edit mode (admin only) lets you drag routers, switches and devices to bring satellites closer or push them apart; once saved, the layout stays frozen and only changes when you edit it again or reset to the automatic arrangement.
-- **Proxmox hosts show as proper nodes with their VMs nested underneath** ([#561](https://github.com/gnacho/netpulse/issues/561)). Each PVE host renders as a round node labeled with its name, its containers grouped beneath it with a +N badge, and dragging the host moves its whole VM family. The device card also gained a discreet "Tag" button so admins can label a device without typing its MAC.
+**And the rest of the tour:**
 
-### Earlier (v2.28.17)
+- **WireGuard**: peers with real names, latest handshakes, transfer per peer.
+- **AdGuard Home**: query stats, blocked share, top blocked domains.
+- **Wi-Fi and roaming**: signal matrix per AP, 802.11r status, channel
+  utilization, persistent roaming events.
+- **Alerts that find you**: temperature, new device, firmware available, WAN
+  down, agent issues; bell feed plus native Web Push to your phone.
+- **Multi-user**: bcrypt passwords, admin and viewer roles, per-user language
+  (ES/EN).
+- **Installable PWA**: phone or desktop, live over SSE, light/dark themes.
+- **A good OpenWrt citizen**: native `netpulse-agent` packages (`.ipk`/`.apk`),
+  a `luci-app-netpulse` page, UCI config, procd init, watchdog. Or run the
+  whole server on-box.
+- **Self-updating**: the built-in updater checks for releases and applies them
+  with an atomic swap.
 
-- **An OpenWrt router no longer shows a false "host key changed" when polled** ([#651](https://github.com/gnacho/netpulse/issues/651)). Discovery (OpenSSH with `accept-new`) used to pin only the single host-key algorithm it negotiated (ed25519), while the polling pool (Go) negotiates another one (ecdsa/rsa) with the same server; a router with several host keys then showed a spurious "ssh host key changed" and demanded a pointless re-onboard. Discovery now pins **all** of the router's host keys (ed25519, ecdsa and rsa), so the poller always finds the one it negotiates, without weakening the anti-MITM protection: if a router changes every key (reflash), the "host key changed" detection still kicks in.
+There is more, and each piece has a story:
+**[the full feature tour lives on the website](https://netpulse.cloudless.club/features)**,
+and everything above is clickable in the **[live demo](https://demo.netpulse.cloudless.club)**.
 
-### Earlier (v2.28.16)
+## How discovery works
 
-- **WireGuard peers are now labeled by their OpenWrt-configured name** ([#663](https://github.com/gnacho/netpulse/issues/663)). In the topology, WireGuard peers that weren't already mapped to a NetPulse device now show the human-readable name from the peer's UCI description (priority: NetPulse device name → UCI description → tunnel IP) instead of the raw tunnel IP. The poll reads `wg show dump` and `uci show network` in a single SSH session and preserves a down tunnel's state.
+NetPulse discovers client devices from three sources on the monitored
+routers: DHCP leases, the bridge FDB (wired clients) and mDNS when `umdns` is
+installed. LLDP identifies neighbouring routers and switches. Per-client
+traffic prefers `nlbwmon` (per-MAC counters, wired) and falls back to hostapd
+byte counters (Wi-Fi); if a wired client shows no traffic series, install
+`nlbwmon` on that router. `vnstat` counts per-interface totals, not per
+client, so it is not a substitute.
 
-### Fixed
+## Get started in about five minutes
 
-- **A native OpenWrt router no longer shows as "Managed switch" in the devices table** ([#660](https://github.com/gnacho/netpulse/issues/660)). The Role column only distinguished gateway and "agent only", and everything else fell into "Managed switch"; it now switches on the device type and shows "OpenWrt" for native (SSH agent) routers, leaving "Managed switch"/External for SNMP-polled ones.
-- **An SNMP-polled switch no longer loses its traffic history or connected devices** ([#661](https://github.com/gnacho/netpulse/issues/661)). The SNMP path computed the per-port byte counters and rates but never persisted them, so the switch's traffic history was empty even though the poll read the data (now via `recordPortSamples`, the same path as the SSH/agent flows). The FDB also no longer drops MACs whose index didn't resolve to a known port (before, the switch showed 0 devices despite having clients) and there's a Q-BRIDGE MIB fallback for switches that only expose it that way. The fleet card now plots the switch's aggregate traffic in bps, and the port chart of an SNMP switch uses bps (beacons without byte counters keep using fps).
+You need a Linux box with systemd (x86_64, arm64 or armv7; a small LXC or VM
+is plenty) and OpenWrt/GL.iNet routers on your LAN.
 
-### Earlier (v2.28.15)
-
-- **Port traffic charts now show frames/s for devices that don't count bytes** ([#641](https://github.com/gnacho/netpulse/issues/641)). RTLPlayground switch beacons (KP-9000) only report cumulative frame counters, not bytes. The server now derives frames/s from those counters (raw, 5m and daily) and the port card in the detail page plots fps instead of bps for sources without byte counters, so a managed switch port chart no longer looks empty.
-- **Fleet cards and the router detail show the real per-band client split** ([#645](https://github.com/gnacho/netpulse/issues/645)). Each router card now lists its online clients by band (2.4/5/6 GHz and wired) computed server-side from the same source as the total, and only renders bands that actually have clients: a switch with no WiFi radios no longer shows WiFi bands stuck at zero.
-- **The traffic sparkline of a switch without bps throughput is no longer a flat zero line** ([#648](https://github.com/gnacho/netpulse/issues/648)). For sources that only report per-port frames, the card's 24h traffic mini-chart is now derived from its ports' frames/s instead of the bps table (which was always empty for them), so the KP-9000 card shows its real activity.
-- **RTLPlayground beacon switches report real firmware, uptime and MAC** ([#639](https://github.com/gnacho/netpulse/issues/639)). The server polls the switch's HTTP console for beacon agents, and the router card now shows the actual firmware version, uptime and MAC of the switch instead of placeholders.
-
-### Fixed
-
-- **A managed switch detail page no longer shows its ports twice** ([#644](https://github.com/gnacho/netpulse/issues/644)). The front-panel LED chassis card duplicated the Ethernet ports card with RJ45 jacks; the front panel is gone and the ports card already shows link, health and per-port history.
-- **Port series of a beacon switch are no longer polluted with zeros** ([#642](https://github.com/gnacho/netpulse/issues/642)). External sources only persist their real counters now, keeping the port series clean.
-
-### Earlier (v2.28.14)
-
-- **The channel plan no longer counts your own mesh as interference, and won't suggest a channel that crosses into DFS** ([#631](https://github.com/gnacho/netpulse/issues/631)). In the channel analysis, the BSSIDs of your own access points no longer score as neighbors (they are excluded by matching the MAC prefix of your monitored routers), and candidate channels are validated against the radio width: at 40/80/160 MHz only blocks that stay out of DFS channels (52-64, 100-144) are offered. This stops NetPulse recommending a channel your mesh satellites already use, or an 80 MHz block that would cross into a DFS band.
-- **Rearm now recovers an agent stuck in a 401 loop** ([#630](https://github.com/gnacho/netpulse/issues/630)). If a restart doesn't bring the agent back, NetPulse regenerates the agent token and applies it on the router (rewrites the env + restarts) without a reinstall, so a token that drifted out of sync is fixed in place. Token rotation on a reinstall is also atomic: if the SSH step fails, the server restores the previous token so the agent never ends up pushing a token that is no longer accepted.
-
-### Earlier (v2.28.13)
-
-- **A cleaner Settings page, one column at a time** ([#627](https://github.com/gnacho/netpulse/issues/627)). The Settings page is now a single column with a sticky index that follows you as you scroll, so each card (Appearance, Data & thresholds, Services, Network, Integrations, Administration, Account, About) is full-width and easier to use. The Appearance card shows real theme previews (light/dark/system) and a two-column palette; the WAN speed test runs a real test from the server and fills download/up in place. Labs toggles appear individually (Orchestration, Channels, Upgrades) once Labs is on.
-- **Regenerate an agent token without reinstalling** ([#627](https://github.com/gnacho/netpulse/issues/627)). When you regenerate a router's agent token from Settings, NetPulse now pushes the new token to the router and restarts the agent in place, so the device keeps reporting without a reinstall. The install one-liner is only needed when the router can't be reached over SSH.
-- **Actualizaciones: autodetect the firmware image** ([#629](https://github.com/gnacho/netpulse/issues/629)). On the firmware upgrades page, NetPulse looks up the router's image from its own firmware (board + target + version) on the OpenWrt download index and prefills the URL and checksum, with an "Autodetect image" button. Manual entry stays available when it can't be resolved.
-- **Uninstall the agent on tight routers** ([#624](https://github.com/gnacho/netpulse/issues/624)). Routers with little free space (like the UniFi 6 Lite) couldn't fit a reinstall; there's now a clean "Uninstall" action that stops and removes the agent.
-
-### Fixed
-
-- **Copy buttons show the raw i18n key** ([#628](https://github.com/gnacho/netpulse/issues/628)). The copy buttons in the adoption card used a missing `common.copy` key, so their tooltip showed `common.copy`; the key now exists and translates to "Copy"/"Copiar".
-
-### Earlier (v2.28.12)
-
-- **Set a custom SSH port per router** ([#605](https://github.com/gnacho/netpulse/issues/605)). Not every router keeps its SSH daemon on port 22 - some run it elsewhere. Now each router can be given its own SSH port when you add or edit it, and every server-side path (probing, actions, agent install, gateway discovery) uses it automatically. Leave it empty and NetPulse keeps using 22.
-- **Roaming matrix grouped per device** ([#600](https://github.com/gnacho/netpulse/issues/600)). In WiFi Roaming → Matrix, columns are now grouped under the access point's name, with a header row that labels each band (2.4G/5G). No more a loose column per AP-band.
-- **Cleaner 802.11r wording and no phantom devices** ([#601](https://github.com/gnacho/netpulse/issues/601)). The section title is now "By AP" instead of "By router", the column is "Device", and devices without radios (like the gateway) no longer show up in the per-router detail. Routers discovered automatically are also named after their hostname, not their hardware model, so the UI shows device names across the app.
-- **Own channel width in the channel scan** ([#602](https://github.com/gnacho/netpulse/issues/602)). In the channel analysis, the row for your own network now shows the channel width (for example `1 · 20 MHz`) next to the channel number, cross-referenced with the router's channel plan.
-- **The UI no longer goes black when a WireGuard client connects** ([#592](https://github.com/gnacho/netpulse/issues/592)). NetPulse reports a WireGuard peer's type as plain text, and uses "unknown" when it cannot match a type. The Home card built the peer icon with no fallback, so an unknown (or unmatched) peer produced a blank icon and React crashed the whole page the moment a WireGuard client connected (or when you opened the UI from a connected client). NetPulse now has a fallback icon for these, plus a known "unknown" type, so the page keeps rendering.
-
-### Earlier (v2.28.11)
-
-- **The agent no longer degrades your Wi-Fi while scanning** ([#591](https://github.com/gnacho/netpulse/issues/591)). The per-router agent used to run a full active Wi-Fi scan on every probe, so ~every 30-37s per device. On access points that pulls the radio off channel and drops IoT/weak clients. It now scans at most every 10 minutes, after boot, or immediately when the server asks for a refresh - and the embedded agent version bumps so the fleet updates itself.
-
-### What gets discovered
-
-NetPulse discovers client devices from three sources that run on the monitored routers:
-
-1. **DHCP leases** - every time the agent polls, it reads the local DHCP lease table.
-2. **Bridge FDB** - wired clients are learned from the switch bridge forwarding database.
-3. **mDNS / Bonjour** - when `umdns` is installed on OpenWrt, the agent browses advertised services and resolves hostnames.
-
-LLDP is used only to identify neighbouring routers/switches, not end devices. Discovery requires the NetPulse agent to be running on the router that sees the clients; a fresh install with only manually onboarded routers and no agent on the gateway will show an empty device list until the agent is installed.
-
-Per-client traffic prefers `nlbwmon` for wired clients (per-MAC counters) and falls back to the hostapd byte counters for Wi-Fi clients. `nlbwmon` is not included in every OpenWrt build and can be memory-hungry on very low-RAM routers; `vnstat` tracks per-interface totals, not per-client MAC traffic, so it is not a substitute. If a wired client shows no traffic series, install `nlbwmon` on that router (or rely on the Wi-Fi fallback).
-
-## Screenshots
-
-**Topology: inferred live from the bridge FDB, tunnels included**
-
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/screenshot-topology-en-dark.png">
-  <source media="(prefers-color-scheme: light)" srcset="assets/screenshot-topology-en-light.png">
-  <img alt="Topology map with the gateway in the center, three access points, wired and wireless clients, an inferred switch and the WireGuard tunnel to Internet" src="assets/screenshot-topology-en-light.png" width="800">
-</picture>
-
-**Devices: every client classified, with band and signal**
-
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/screenshot-devices-en-dark.png">
-  <source media="(prefers-color-scheme: light)" srcset="assets/screenshot-devices-en-light.png">
-  <img alt="Device list with type icons, hostname, IP, band, signal strength and the router each client is attached to" src="assets/screenshot-devices-en-light.png" width="800">
-</picture>
-
-**Routers: per-router health at a glance**
-
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/screenshot-router-en-dark.png">
-  <source media="(prefers-color-scheme: light)" srcset="assets/screenshot-router-en-light.png">
-  <img alt="Routers view with per-router cards showing model, firmware, CPU, memory, temperature and uptime" src="assets/screenshot-router-en-light.png" width="800">
-</picture>
-
-## What to expect
-
-NetPulse is a personal project, built for my own network and released as
-free software (AGPL-3.0). It is and will always be free. I work on it in my
-free time: there's a long list of ideas, but little time, and it evolves
-following my own needs first. With contributions or support it might grow
-faster, but I can't promise anything. **Honest scope note**: so far it has
-only been tested with my own hardware (a GL.iNet Flint 2 gateway and three
-Xiaomi AX6 access points running OpenWrt) plus WireGuard and AdGuard Home.
-Other OpenWrt devices should work, but yours would be the first to tell.
-
-## User manual
-
-Area by area and menu by menu, what each screen shows, what data it needs,
-how to read it and the design decisions behind it, plus step-by-step
-procedures (add a router, read the health score, use the topology map,
-interpret the channel plan, schedule a firmware upgrade, reserve an IP,
-block a device):
-
-- [Manual de usuario (español)](docs/manual.es.md)
-- [User manual (English)](docs/manual.en.md)
-
-## Roadmap
-
-| Phase | Status | Highlights |
-|---|---|---|
-| **1 — Topology v5** | ✅ | Semantic map: live FDB + LLDP, backhaul, managed vs. inferred switches, hypervisors with nested CTs, time-series collector |
-| **2 — Alerts, Push & agent pilot** | ✅ | 6-category alerts, native Web Push (VAPID), on-demand refresh, OpenWrt agent pilot (token ingest, SSH fallback, procd) |
-| **3 — Read-only base + Node→Go** | ✅ | React PWA, read-only SSH polling (ubus, /proc, iwinfo), AdGuard + WireGuard, multi-user auth, backend migrated to a single Go binary |
-| **4 — View-model + Settings revamp** | ✅ | API as a presentation view-model (`vm: 1`), single-sourced demo canon, semantic topology in the snapshot |
-| **5 — Agent resilience** | ✅ | Router-side watchdog + heartbeat, server-side manual rearm, TTL auto-rearm, admin-only mutation routes |
-| **6 — Agent security** | ✅ | HMAC-SHA256 on agent ingest, serve the agent binary from the server itself |
-| **7 — Agent deep dive** | ✅ | Real-time wifi events (`iw event`), bidirectional SSE, `.ipk` packaging (11-12 MB RSS, <1% CPU) |
-| **8 — Consolidation** | ✅ | `/api/health` metrics, persistent agent registry, retention ladder (raw 7d → 5min buckets 1y → daily ∞), recharts v3, outgoing alert webhooks |
-| **9 — On-box** | ✅ | UCI config, AUTH_PASS bootstrap, TLS self-signed + SPKI pinning, pairing token, OpenWrt server package |
-| **10 — Orchestration** | ✅ | Plan→apply→state engine + sandboxed executor (10.1), AdGuard (10.2), WiFi guest, DDNS, SQM, usteer modules. WireGuard moved to Phase 17 |
-| **11 — LuCI package** | ✅ | `luci-app-netpulse` shipped as `.ipk`/`.apk` on every release: local agent status/view (procd, UCI, logs, restart/rearm) + bridge to the web app |
-| **12 — Security audit** | ✅ | TRUST_PROXY, anti-replay on ingest, body cap, password min 10 |
-| **13 — Robustness audit** | ✅ | Single-flight GetOverview, SSE write deadline, sshpool dial race, error wrapping |
-| **14 — WiFi/roaming visibility** | ✅ | DAWN signal matrix, 802.11r status per SSID, channel utilization survey, persistent roaming events feed (30d). Polish pending: channel-analysis chart clarity ([#618](https://github.com/gnacho/netpulse/issues/618)) |
-| **15 — Reports** | 🔄 | Daily/week/month availability. Pending: traffic, activity, alert summary, export, and per-client/VLAN network insights ([#588](https://github.com/gnacho/netpulse/issues/588)) |
-| **16 — Advanced alerts** | 🔮 | Custom threshold rules, new alert types (roaming failure, channel congestion), scheduled silence, email |
-| **17 — Write to routers** | 🔄 | UCI ownership + safe apply with rollback (#451), channel planning (#452), firmware upgrades (#453); full module index (AdGuard full, WiFi guest, DDNS, QoS, WireGuard, OpenVPN, Tailscale, Batman, DPI) |
-| **18-20 — Beta-testing program** | 🔮 | Module groups by risk (low / medium / high) with stable + unstable release channels and external beta-testers |
-
-Full detail in [docs/ROADMAP.md](docs/ROADMAP.md).
-
-## Installation
-
-Requirements: Linux (x86_64, arm64 or armv7) with systemd.
+**1. Install the server** on the box:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/gnacho/netpulse/main/install.sh | sh   # (recommended)
+curl -fsSL https://raw.githubusercontent.com/gnacho/netpulse/main/install.sh | sh
 ```
 
-The installer is plain, readable shell: [inspect it first](install.sh). It
-detects your distro and arch, downloads the verified release (sha256
-against `checksums.txt`), creates a sandboxed `netpulse` systemd service
-and prints the initial admin password once. Update by re-running the same
-line; remove with `sh install.sh --uninstall`.
+The installer is plain, readable shell ([inspect it first](install.sh)): it
+detects distro and arch, downloads the release verified against
+`checksums.txt`, sets up a sandboxed `netpulse` systemd service and prints
+the initial admin password once. Re-running the same line updates;
+`sh install.sh --uninstall` removes.
 
-Optional latency sidecar (time series of TCP probes to each router):
+**2. Open the app** at `http://<server-ip>:3000`, log in with the printed
+password and the gateway is already there: NetPulse finds it on first boot
+via LAN discovery (a TCP :22 sweep with ubus/GL-UI fingerprinting).
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/gnacho/netpulse/main/install-collector.sh | sh
+**3. Authorize the SSH key.** The server generated its own keypair on first
+boot. Copy the public key from **Settings → Network** and, on each router you
+want to monitor, append it:
+
+```sh
+echo "<public key from Settings>" >> /etc/dropbear/authorized_keys
 ```
 
-Stable binaries are published per `v*` tag (goreleaser); rolling per-commit
-builds live in the `go-latest` prerelease for the in-app updater.
+**4. Install the agents from the app.** Open **Routers** and scroll to the
+agents table: every OpenWrt router gets a row, and routers without an agent
+offer an **Install agent** button. One click and the server registers the
+agent, pushes the right binary for the router's architecture, writes the
+config and starts the service; it shows up as connected within seconds.
+Routers the server cannot SSH into use the pairing token instead
+(**Settings → Agent adoption**, see the folded section below).
 
-## Connecting your routers
+**5. Take it with you.** Install the PWA from your browser (Add to home
+screen / Install app) and enable Web Push in Settings: alerts reach your
+phone even with the tab closed.
 
-The server generates its own ed25519 keypair and shows the public key in
-Settings. Authorize it on each router you want to monitor
-(`/etc/dropbear/authorized_keys`). The gateway is auto-detected on first
-boot via LAN discovery (TCP :22 sweep, ubus/GL-UI fingerprint); the rest
-are added from Settings. Polling is strictly read-only.
+Prefer to see it on your own hardware first? `DEMO_MODE=1 ./netpulse` runs
+the same app with a 67-device sample network, no routers needed.
 
-### Installing the agents (recommended: let the app do it)
+<details>
+<summary><strong>Other install paths</strong></summary>
 
-Once the router is in the table and the server's SSH key is authorized on
-it, the app can install and start the agent by itself: open the **Routers**
-page and scroll to the agents table at the bottom. Every OpenWrt router
-shows a row there; routers without an agent offer an **Install agent**
-button, and existing agents offer **Reinstall**. Over one SSH session the
-server registers the agent if needed (its token is created on the fly),
-detects the architecture, downloads the embedded agent binary from itself
-(token-authenticated), verifies its SHA256, writes the config, installs
-the procd init (with a self-heal step that re-downloads the binary after a
-`sysupgrade`, which only preserves `/etc`), sets up the watchdog cron and
-restarts the service. The agent shows up as connected within seconds.
-Re-running it is safe: it rotates the token and reinstalls.
-
-For routers the server cannot SSH into, use the pairing token instead:
-Settings → Agent adoption shows a reusable pairing token, and
-`install-agent.sh --pairing-token` (run from any machine that can reach
-both the router and the server) registers the agent on first contact.
-
-## OpenWrt packages
-
-Every `v*` release ships the agent and the LuCI app as installable OpenWrt
-packages alongside the tarballs:
-
-- `netpulse-agent` as `.ipk` (OpenWrt 24.10 SDK, mediatek/filogic) and `.apk`
-  (OpenWrt 25.12 SDK, qualcommax/ipq807x).
-- `luci-app-netpulse` as `.ipk` and `.apk` (`all` arch, any target): LuCI
-  pages that show the local agent status, let you restart it, edit its UCI
-  config and jump to the NetPulse web app.
-
-Grab the assets from the
-[latest release](https://github.com/gnacho/netpulse/releases) and install on
-the router (LuCI System > Software, or over SSH):
+**OpenWrt packages.** Every release ships `netpulse-agent` and
+`luci-app-netpulse` as installable packages (`.ipk` for OpenWrt 24.10,
+`.apk` for 25.12, plus x86/64). Grab them from the
+[latest release](https://github.com/gnacho/netpulse/releases):
 
 ```sh
 # OpenWrt 24.10 (ipk)
@@ -325,18 +208,8 @@ opkg install ./netpulse-agent_*.ipk ./luci-app-netpulse_*.ipk
 apk add --allow-untrusted ./netpulse-agent-*.apk ./luci-app-netpulse-*.apk
 ```
 
-`luci-app-netpulse` depends on `netpulse-agent` and `luci-base`; installing
-both packages together resolves the dependencies without extra feeds. After
-install, LuCI picks up the new pages automatically (the package restarts
-`rpcd` and clears the index cache).
-
-The package ships an empty config, so the service stays inactive until you
-point it at your server (the app cannot know these values). If the server
-can already SSH into the router, skip all of this and press **Install
-agent** in the Routers page agents table: it registers the agent, writes
-the config and starts the service for you. Otherwise, create the agent
-via the pairing token (Settings → Agent adoption plus `install-agent.sh
---pairing-token`) or `POST /api/agents`, and on the router:
+The package ships an empty config, so point it at your server before
+starting:
 
 ```sh
 uci set netpulse-agent.main.server='http://<netpulse-server-ip>:3000'
@@ -346,8 +219,56 @@ uci commit netpulse-agent
 service netpulse-agent enable && service netpulse-agent start
 ```
 
-If the server can already SSH into the router, prefer the automated path
-above: **Reinstall** does all of this for you.
+If the server can already SSH into the router, skip all of this and press
+**Install agent** in the app: it does every step for you.
+
+**Pairing token.** For routers the server cannot reach over SSH, Settings →
+Agent adoption shows a reusable pairing token:
+`install-agent.sh --pairing-token` (run from any machine that can reach both
+the router and the server) registers the agent on first contact.
+
+**Latency sidecar.** Optional long-term TCP latency probes per router:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/gnacho/netpulse/main/install-collector.sh | sh
+```
+
+**On-box mode.** No spare box? The server itself runs on an OpenWrt router,
+with UCI config and self-signed TLS with SPKI pinning.
+
+</details>
+
+## Updates and version history
+
+Releases are signed, checksummed and pushed to your fleet by the built-in
+auto-updater; the app shows a short human-readable "what changed" panel
+before you update. The full version history lives in
+[CHANGELOG.md](CHANGELOG.md) and on the
+[releases page](https://github.com/gnacho/netpulse/releases); the plan ahead
+is in [docs/ROADMAP.md](docs/ROADMAP.md).
+
+## What to expect
+
+NetPulse is a personal project, built for my own network and released as
+free software (AGPL-3.0). It is and will always be free. I work on it in my
+free time and it evolves following my own needs first; with contributions or
+support it might grow faster, but I can't promise anything. **Honest scope
+note**: so far it has been tested with my own hardware (a GL.iNet Flint 2
+gateway and three Xiaomi AX6 access points running OpenWrt) plus WireGuard
+and AdGuard Home. Other OpenWrt devices should work, but yours would be the
+first to tell.
+
+## Documentation
+
+- **[User manual](docs/manual.en.md)** (also in
+  [Spanish](docs/manual.es.md)): every screen explained, menu by menu, with
+  step-by-step procedures.
+- **[Website](https://netpulse.cloudless.club)**: the project in five
+  minutes, with a [feature tour](https://netpulse.cloudless.club/features),
+  FAQ and screenshots.
+- **[Roadmap](docs/ROADMAP.md)**: what's done, what's next.
+- **[Discussions](https://github.com/gnacho/netpulse/discussions)**: questions,
+  ideas and shape-the-future talk.
 
 ## Development
 
@@ -361,15 +282,8 @@ go build -o netpulse ./cmd/netpulse && DEMO_MODE=1 ./netpulse
 cd app
 npm install
 npm run dev
-```
 
-The legacy Node backend was removed (it is not deployed or updated anymore,
-decision 5-Ago-2026); its git history is preserved. Migration from its
-database happens automatically on the first Go boot.
-
-## Tests
-
-```bash
+# Tests
 cd server-go && go test ./...
 ```
 


### PR DESCRIPTION
Reworks README.md and README.es.md to sell the app instead of logging it.

- Lead with the pitch, the live demo and the website; reinforce both in five distinct places (badges, CTA line, "see it before you install it", end of the feature block, documentation).
- Replace the ~80-line per-release "What's new" wall and the 20-phase roadmap table with a short "Updates and version history" pointer to CHANGELOG.md, the releases page and docs/ROADMAP.md (both already carry the full detail).
- Rewrite the features section around what you see on each screen, with the existing screenshots inline next to each one (overview, topology, devices, router health) plus a compact list for the rest.
- Add a 5-minute quickstart tutorial: install the server, open the app, authorize the SSH key, press "Install agent", install the PWA. Alternative paths (OpenWrt packages, pairing token, collector sidecar, on-box) folded into a collapsible section.
- Keep the personal origin story (tightened) and the honest scope note.

Verification: all 16 referenced screenshot assets exist in the repo, all 7 linked local files exist, the three external URLs (website, /features, demo) return 200, both language versions share the same structure.

Closes #721