### PR TITLE
feat(web): github star CTA in the nav and on-box mention in the install section

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1460,7 +1460,12 @@ async function initGhMeta() {
     const r = await fetch('https://api.github.com/repos/gnacho/netpulse', { headers: { Accept: 'application/vnd.github+json' } })
     if (r.ok) {
       const d = await r.json()
-      if (typeof d.stargazers_count === 'number') show('ghStars', `★ ${d.stargazers_count}`)
+      if (typeof d.stargazers_count === 'number') {
+        show('ghStars', `★ ${d.stargazers_count}`)
+        const nav = document.getElementById('navStar')
+        const c = nav && nav.querySelector('[data-n]')
+        if (c) { c.textContent = d.stargazers_count; c.hidden = false }
+      }
     }
     const rel = await fetch('https://api.github.com/repos/gnacho/netpulse/releases/latest', { headers: { Accept: 'application/vnd.github+json' } })
     if (rel.ok) {

--- a/web/features.html
+++ b/web/features.html
@@ -28,7 +28,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css?v=20260901a" />
+  <link rel="stylesheet" href="styles.css?v=20260911a" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -82,6 +82,10 @@
         <a href="/#faq" data-i18n="nav.faq">FAQ</a>
         <a href="https://github.com/gnacho/netpulse" target="_blank" rel="noopener" data-i18n="nav.github">GitHub</a>
       </div>
+      <a class="nav-star" id="navStar" href="https://github.com/gnacho/netpulse" target="_blank" rel="noopener" data-i18n-aria="nav.starAria" aria-label="Star NetPulse on GitHub">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+        <span class="label" data-i18n="nav.star">Star</span><span class="n" data-n hidden></span>
+      </a>
       <select id="langSelect" aria-label="Language" style="margin-left:1rem;background:rgb(var(--surface));color:rgb(var(--text-secondary));border:1px solid rgb(var(--border));border-radius:var(--radius);padding:0.3rem 0.5rem;font-size:0.75rem;font-family:inherit;"></select>
       <a class="nav-cta" href="/#install" data-i18n="featuresPage.cta">Instalar en tu red</a>
     </div>
@@ -300,7 +304,7 @@
         </div>
 
         <!-- On-box -->
-        <div class="card feature reveal">
+        <div class="card feature reveal" id="on-box">
           <svg viewBox="0 0 24 24" fill="none" stroke="rgb(var(--tunnel))" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><line x1="9" y1="1" x2="9" y2="4"/><line x1="15" y1="1" x2="15" y2="4"/><line x1="9" y1="20" x2="9" y2="23"/><line x1="15" y1="20" x2="15" y2="23"/><line x1="20" y1="9" x2="23" y2="9"/><line x1="20" y1="14" x2="23" y2="14"/><line x1="1" y1="9" x2="4" y2="9"/><line x1="1" y1="14" x2="4" y2="14"/></svg>
           <h3 data-i18n="featuresPage.onboxTitle">Modo on-box</h3>
           <p data-i18n="featuresPage.onboxP">Si no tienes una caja aparte, el servidor puede correr en el propio router OpenWrt, con configuración UCI, pinning TLS y emparejamiento local.</p>
@@ -429,8 +433,8 @@
     </div>
   </div>
 
-  <script src="i18n.js?v=20260901a"></script>
-  <script src="app.js?v=20260901a"></script>
+  <script src="i18n.js?v=20260911a"></script>
+  <script src="app.js?v=20260911a"></script>
 <script defer src="https://stat.domatix.com/script.js" data-website-id="b9a57c48-cfbb-59fb-af00-e21b868371d9"></script>
 </body>
 </html>

--- a/web/i18n.js
+++ b/web/i18n.js
@@ -28,7 +28,7 @@ const DEMO = {
 const I18N = {
   /* ---------------- ENGLISH ---------------- */
   en: {
-    nav: { features: 'Features', club: 'The club', install: 'Install', github: 'GitHub' },
+    nav: { features: 'Features', club: 'The club', install: 'Install', github: 'GitHub', star: 'Star', starAria: 'Star NetPulse on GitHub' },
     hero: {
       eyebrow: 'Read-only home network monitoring',
       t1: 'Your network’s pulse.',
@@ -117,6 +117,8 @@ const I18N = {
       update: 'Update by re-running the same line. Uninstall with sh install.sh --uninstall.',
       connect: 'Connect your routers', connectp: 'The server generates its own ed25519 key pair and shows the public key in Settings. Authorize it on each router (/etc/dropbear/authorized_keys). The gateway auto-detects on first boot via LAN discovery; the rest you add from Settings. Polling is strictly read-only.',
       agentTitle: 'Agent on your routers', agentDesc: 'Install the agent directly on each OpenWrt router. It collects WiFi events, pushes data over SSE, and reports back to the server.', agentCmd: 'opkg install netpulse-agent',
+      onboxTitle: 'No spare box? The router itself works',
+      onboxDesc: 'NetPulse does not need a dedicated machine: the <strong>full server</strong>, not just the agent, runs on the OpenWrt router itself as a native package, with UCI config and self-signed TLS with SPKI pinning. <a href="/features#on-box">See the on-box mode</a>.',
     },
     honest: {
       title: 'About NetPulse',
@@ -156,7 +158,7 @@ const I18N = {
 
   /* ---------------- ESPAÑOL ---------------- */
   es: {
-    nav: { features: 'Funciones', club: 'El club', install: 'Instalar', github: 'GitHub' },
+    nav: { features: 'Funciones', club: 'El club', install: 'Instalar', github: 'GitHub', star: 'Star', starAria: 'Dale una estrella a NetPulse en GitHub' },
     hero: {
       eyebrow: 'Monitorización de solo lectura para tu red doméstica',
       t1: 'El pulso de tu red.',
@@ -233,6 +235,8 @@ const I18N = {
       update: 'Actualiza re-ejecutando la misma línea. Desinstala con sh install.sh --uninstall.',
       connect: 'Conecta tus routers', connectp: 'El servidor genera su propio par de claves ed25519 y muestra la pública en Ajustes. Autorízala en cada router (/etc/dropbear/authorized_keys). El gateway se autodetecta en el primer arranque por descubrimiento LAN; el resto se añade desde Ajustes. El sondeo es estrictamente de solo lectura.',
       agentTitle: 'Agente en tus routers', agentDesc: 'Instala el agente directamente en cada router OpenWrt. Recoge eventos WiFi, envía datos por SSE y reporta al servidor.', agentCmd: 'opkg install netpulse-agent',
+      onboxTitle: '¿Sin caja aparte? El propio router vale',
+      onboxDesc: 'NetPulse no necesita una máquina dedicada: el <strong>servidor completo</strong>, no solo el agente, corre en el propio router OpenWrt como paquete nativo, con configuración UCI y TLS autofirmado con pinning SPKI. <a href="/features#on-box">Conoce el modo on-box</a>.',
     },
     honest: {
       title: 'Acerca de NetPulse',

--- a/web/index.html
+++ b/web/index.html
@@ -28,7 +28,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css?v=20260901a" />
+  <link rel="stylesheet" href="styles.css?v=20260911a" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -109,6 +109,10 @@
         <a href="#faq" data-i18n="nav.faq">FAQ</a>
         <a href="https://github.com/gnacho/netpulse" target="_blank" rel="noopener" data-i18n="nav.github">GitHub</a>
       </div>
+      <a class="nav-star" id="navStar" href="https://github.com/gnacho/netpulse" target="_blank" rel="noopener" data-i18n-aria="nav.starAria" aria-label="Star NetPulse on GitHub">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+        <span class="label" data-i18n="nav.star">Star</span><span class="n" data-n hidden></span>
+      </a>
       <select id="langSelect" aria-label="Language" style="margin-left:1rem;background:rgb(var(--surface));color:rgb(var(--text-secondary));border:1px solid rgb(var(--border));border-radius:var(--radius);padding:0.3rem 0.5rem;font-size:0.75rem;font-family:inherit;"></select>
       <a class="nav-cta" href="#install" data-i18n="hero.cta1">Instalar en tu red</a>
     </div>
@@ -687,6 +691,8 @@
             <a href="https://github.com/gnacho/netpulse/blob/main/install.sh" target="_blank" rel="noopener" data-i18n="install.inspectorLink">inspecciónalo primero</a>.
           </p>
           <p class="install-note" data-i18n="install.auto">Las actualizaciones se cuidan solas: el auto-updater integrado comprueba cada 24 h y aplica las nuevas versiones con swap atómico. También puedes re-ejecutar el instalador o desinstalar con sh install.sh --uninstall.</p>
+          <h3 style="margin-top:1.75rem;" data-i18n="install.onboxTitle">¿Sin caja aparte? El propio router vale</h3>
+          <p class="install-note" style="font-size:0.85rem;color:rgb(var(--text-secondary));" data-i18n-html="install.onboxDesc">NetPulse no necesita una máquina dedicada: el <strong>servidor completo</strong>, no solo el agente, corre en el propio router OpenWrt como paquete nativo, con configuración UCI y TLS autofirmado con pinning SPKI. <a href="/features#on-box">Conoce el modo on-box</a>.</p>
           <h3 style="margin-top:1.75rem;" data-i18n="install.connect">Conecta tus routers</h3>
           <p class="install-note" style="font-size:0.85rem;color:rgb(var(--text-secondary));" data-i18n="install.connectp">El servidor genera su propio par de claves ed25519 y muestra la pública en Ajustes. Autorízala en cada router. El sondeo es estrictamente de solo lectura.</p>
 
@@ -842,8 +848,8 @@
     <p class="lightbox-caption" id="lightboxCaption"></p>
   </div>
 
-  <script src="i18n.js?v=20260901a"></script>
-  <script src="app.js?v=20260901a"></script>
+  <script src="i18n.js?v=20260911a"></script>
+  <script src="app.js?v=20260911a"></script>
 <script defer src="https://stat.domatix.com/script.js" data-website-id="b9a57c48-cfbb-59fb-af00-e21b868371d9"></script>
 </body>
 </html>

--- a/web/styles.css
+++ b/web/styles.css
@@ -128,6 +128,16 @@ a:hover { text-decoration: underline; }
   color: rgb(var(--accent)); white-space: nowrap; background: rgb(var(--accent) / 0.06);
 }
 .nav-cta:hover { background: rgb(var(--accent) / 0.12); text-decoration: none; }
+.nav-star {
+  display: inline-flex; align-items: center; gap: 0.4rem;
+  font-size: 0.8125rem; font-weight: 600; padding: 0.4rem 0.7rem;
+  border-radius: var(--radius); border: 1px solid rgb(var(--border));
+  color: rgb(var(--text-secondary)); white-space: nowrap; background: rgb(var(--surface));
+}
+.nav-star:hover { color: rgb(var(--warn)); border-color: rgb(var(--warn) / 0.55); text-decoration: none; }
+.nav-star svg { width: 0.95rem; height: 0.95rem; fill: rgb(var(--warn)); stroke: none; }
+.nav-star .n { font-family: "JetBrains Mono", monospace; font-size: 0.75rem; color: rgb(var(--text-secondary)); }
+@media (max-width: 560px) { .nav-star .label { display: none; } }
 #langSelect {
   margin-left: 0.5rem; background: rgb(var(--surface)); color: rgb(var(--text-secondary));
   border: 1px solid rgb(var(--border)); border-radius: var(--radius); padding: 0.35rem 0.5rem;


### PR DESCRIPTION
Two landing improvements:

- Star CTA: a nav button on `/` and `/features` with the GitHub star icon, linking to the repo, and a live star count filled by the existing `initGhMeta()` fetch. The button is always visible; the count is a progressive enhancement (hidden when the API is rate-limited). On small screens the label collapses to icon plus count.
- On-box mention: the install section now says the full server, not just the agent, also runs on the OpenWrt router itself as a native package (UCI config, self-signed TLS with SPKI pinning), linking to the on-box card in /features (which gains an `on-box` anchor). Someone without a spare Linux box no longer bounces at the install step.

i18n keys added for EN and ES; the other languages fall back to EN. Cache-bust bumped to 20260911a on both pages.

Deploy note: the live star count also required allowing `https://api.github.com` in the site CSP (`connect-src`), applied on the web server alongside this deploy. That header was also blocking the hero stars chip, which silently never showed a count; both work now.

Verified against production with a Playwright smoke (9/9): button visible on both pages, translated aria-label, count filled from the API, repo link, on-box note with correct link, anchor present, zero page errors.

Closes #724