### PR TITLE
fix(devices): use more columns in the card grid on large screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 
 ### Changed
 
+- **La vista de tarjetas de dispositivos aprovecha mejor las pantallas grandes (#711)**: el grid se quedaba en 3 columnas y dejaba mucho espacio sin usar en monitores anchos (el reporte veía solo un par de tarjetas a 1920x990). Ahora añade 4 columnas a partir de `xl` y 5 a partir de `2xl`, con un gap algo menor, para mostrar más dispositivos por pantalla sin cambiar el diseño de la tarjeta.
 - **El intervalo del sondeo SSH del servidor pasa a ser configurable y sube de 5 s a 30 s (#715)**: el poller sondeara los routers por SSH cada `NETPULSE_POLL_INTERVAL` segundos (entero > 0, 30 por defecto) en vez de cada 5 s fijos, que añadía una carga base visible en routers pequeños e inesperada para un monitor de solo lectura. El ajuste de UI "Intervalo de refresco" ya no aparenta controlar el sondeo del servidor: ahora gobierna de verdad la cadencia con la que la interfaz reconsulta los datos cuando pierde la conexión en tiempo real (3 s, 5 s, 10 s o pausado), y su etiqueta lo aclara.
 
 ### Added

--- a/app/src/pages/Devices.tsx
+++ b/app/src/pages/Devices.tsx
@@ -1428,7 +1428,7 @@ export default function Devices() {
           </div>
         </div>
       ) : (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
           <AnimatePresence initial={false}>
             {filtered.map((d, i) => (
               <GridCard


### PR DESCRIPTION
## What

The devices card grid stopped at three columns, so on a wide monitor most of the width went unused and only a couple of cards were visible at 1920x990.

## Fix

- The card grid adds a fourth column from `xl` and a fifth from `2xl`, with a slightly smaller gap, so more devices fit per screen. The card design is unchanged.
- Verified with screenshots at 1920x990: 3 columns before, 5 after.

## Verification

- Frontend build and lint clean.

Closes #711