### PR TITLE
chore: prepare v2.28.22 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Todos los cambios notables de NetPulse se documentan en este fichero.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
-## [Unreleased]
+## [2.28.22] - 2026-09-11
 
 ### Changed
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netpulse",
-  "version": "2.28.21",
+  "version": "2.28.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netpulse-app",
-      "version": "2.28.21",
+      "version": "2.28.22",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netpulse",
   "private": true,
-  "version": "2.28.21",
+  "version": "2.28.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -52,7 +52,7 @@ import (
 // Version es la versión del backend (app.js:18). Es una var (no const) para
 // que goreleaser la inyecte con -X httpapi.Version={{.Version}} y el health
 // reporte la versión del tag; los builds locales caen al fallback.
-var Version = "2.28.21"
+var Version = "2.28.22"
 
 // Deps son las dependencias del servidor API (como createApp de app.js).
 type Deps struct {


### PR DESCRIPTION
Release preparation for v2.28.22: version bump (app package + lock, server Version) and the changelog section moved from Unreleased to [2.28.22].

Groups today's work: alert localization (#712), per-router temperature threshold (#716), Celsius/Fahrenheit (#717), rearm/token messages (#718, #719), devices grid density (#711), configurable poll interval (#715), multi-interface WireGuard (#713) and its tolerance fix (#714), plus the earlier batch (topology labels #692, quiet client attribution #694, alert relative times #698, agent last-seen #691, push localization #689, attach override #690, DHCP hostname sanitization #693, HTTPS listener #696, owut check #695) and the landing copy (#734).

Tag to follow once this is merged.