### PR TITLE
docs(readme): make it explicit that the website lists every feature

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -41,8 +41,8 @@ No necesitas un solo router para ver NetPulse funcionando:
   registro. Navega, cambia el tema, cambia de idioma, mira las
   actualizaciones en vivo.
 - **[netpulse.cloudless.club/features](https://netpulse.cloudless.club/features)**
-  recorre cada pantalla y cada función, con las decisiones técnicas y el
-  alcance honesto de cada una.
+  es el inventario completo: cada pantalla y cada función, con las decisiones
+  técnicas y el alcance honesto de cada una.
 
 ## ¿Por qué NetPulse?
 
@@ -139,8 +139,8 @@ por SNMP también son ciudadanos de primera.
 - **Se actualiza solo**: el updater integrado comprueba releases y las aplica
   con swap atómico.
 
-Hay más, y cada pieza tiene su historia: **[el tour completo de funciones
-vive en la web](https://netpulse.cloudless.club/features)**, y todo lo
+Esto sigue siendo una selección: **[todas las funcionalidades están en la
+web](https://netpulse.cloudless.club/features)**, una a una, y todo lo
 anterior se puede tocar en la **[demo en vivo](https://demo.netpulse.cloudless.club)**.
 
 ## Cómo funciona el descubrimiento

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ You don't need a single router to see NetPulse working:
   with a full sample network loaded, read-only, no sign-up. Click around, change
   the theme, switch languages, watch the live updates.
 - **[netpulse.cloudless.club/features](https://netpulse.cloudless.club/features)**
-  walks through every screen and feature, with the technical decisions and the
-  honest scope of each one.
+  is the complete feature inventory: every screen and feature, with the
+  technical decisions and the honest scope of each one.
 
 ## Why NetPulse?
 
@@ -132,9 +132,8 @@ client splits. SNMP-polled managed switches are first-class citizens too.
 - **Self-updating**: the built-in updater checks for releases and applies them
   with an atomic swap.
 
-There is more, and each piece has a story:
-**[the full feature tour lives on the website](https://netpulse.cloudless.club/features)**,
-and everything above is clickable in the **[live demo](https://demo.netpulse.cloudless.club)**.
+That is still a selection: **[every feature is on the website](https://netpulse.cloudless.club/features)**,
+one by one, and everything above is clickable in the **[live demo](https://demo.netpulse.cloudless.club)**.
 
 ## How discovery works
 


### PR DESCRIPTION
Same adjustment as the NetGrip README: the website is not just "a tour", it is the complete feature inventory, and the README should say so to drive the visit.

Two spots adjusted in both languages:

- The "see it before you install it" bullet now calls the features page the complete feature inventory (every screen and feature).
- The closing of the features section now frames the README list as a selection and states that every feature is on the website, one by one, with the live demo one click away.

No new URLs; zero em dashes; EN and ES share the same wording.

Closes #740