### PR TITLE
feat(ui): label netgrip-embedded agents as NetGrip in the agent badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/
 ### Added
 
 - **Hora fija para el respaldo diario (#741)**: campo opcional `Hora` (HH:MM, hora local) en la tarjeta de Respaldos; vacío mantiene el comportamiento "cada N horas" y con hora fija el respaldo dispara una vez al día a esa hora (ventana de mantenimiento). Validación `HH:MM` en el servidor.
+- **Los routers con NetGrip se etiquetan como "NetGrip" en toda la flota (#746)**: el badge de agente mostraba el genérico "Agente" para todos, también para los que llevan el agente embebido de NetGrip. Ahora el badge (flota, tarjetas, tabla y detalle) muestra "NetGrip" con tooltip propio ("NetGrip v{versión} · agente embebido"); la tabla de agentes ya lo distinguía y el resto de la UI queda consistente.
 
 ## [2.28.22] - 2026-09-11
 

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -832,7 +832,9 @@
       "timeline": "Upgrade",
       "timelineDone": "completed",
       "stepVerifying": "Verifying integrity",
-      "timelineSummary": "· {{count}} steps · {{secs}} s"
+      "timelineSummary": "· {{count}} steps · {{secs}} s",
+      "netgripBadge": "NetGrip",
+      "netgripFreshTip": "NetGrip v{{version}} · embedded agent"
     },
     "colClients": "Clients",
     "colCpu": "CPU",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -832,7 +832,9 @@
       "timeline": "Actualización",
       "timelineDone": "completado",
       "stepVerifying": "Comprobando integridad",
-      "timelineSummary": "· {{count}} pasos · {{secs}} s"
+      "timelineSummary": "· {{count}} pasos · {{secs}} s",
+      "netgripBadge": "NetGrip",
+      "netgripFreshTip": "NetGrip v{{version}} · agente embebido"
     },
     "colClients": "Clientes",
     "colCpu": "CPU",

--- a/app/src/components/routers/AgentBadge.tsx
+++ b/app/src/components/routers/AgentBadge.tsx
@@ -41,16 +41,19 @@ export function AgentBadge({ agent, agentOnly, deviceType, className }: AgentBad
       </span>
     )
   }
+  const isNetgrip = agent.kind === 'netgrip'
   const title = agent.fresh
     ? agent.version
-      ? t('routers.agent.freshTip', { version: agent.version })
+      ? isNetgrip
+        ? t('routers.agent.netgripFreshTip', { version: agent.version })
+        : t('routers.agent.freshTip', { version: agent.version })
       : t('routers.agent.freshTipUnknown')
     : t('routers.agent.staleTip')
   return (
     <span title={title} className={cn('inline-flex', className)}>
       <StatusPill
         tone={agent.fresh ? 'info' : 'danger'}
-        label={agent.fresh ? t('routers.agent.badge') : t('routers.agent.stale')}
+        label={agent.fresh ? (isNetgrip ? t('routers.agent.netgripBadge') : t('routers.agent.badge')) : t('routers.agent.stale')}
         pulse={!agent.fresh}
       />
     </span>


### PR DESCRIPTION
Routers whose embedded agent comes from NetGrip were indistinguishable from plain netpulse-agent installs in most of the UI: the agent badge always rendered the generic "Agent" label. The agents table already distinguished the netgrip kind, but the badge component ignored it.

The data was already in the contract (AgentInfo.kind: native | external | netgrip); this makes AgentBadge render it:

- kind netgrip shows "NetGrip" with its own tooltip ("NetGrip v{version} · embedded agent"), keeping the fresh/stale tone semantics.
- Covers every place the badge lives: fleet cards, fleet table, router card and router detail header.
- Native agents keep the current label; external pushers are unchanged.
- ES and EN strings; changelog entry.

Verified on a live instance with two NetGrip-embedded agents: both render the NetGrip badge, native agents are untouched, tooltip reads correctly, zero console errors (Playwright smoke 4/4). Frontend build and lint clean.

Closes #746