### PR TITLE
feat(ui): put the unit pickers on one row in data and thresholds

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1168,6 +1168,7 @@
       "tempNote": "The high-temperature threshold is set per router in \"Devices\" (65 °C by default).",
       "title": "Data & thresholds",
       "units": "Traffic units",
+      "unitsTitle": "Measurement units",
       "tempUnit": "Temperature unit"
     },
     "demo": {

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1168,6 +1168,7 @@
       "tempNote": "El umbral de temperatura alta se configura por router en «Dispositivos» (65 °C por defecto).",
       "title": "Datos y umbrales",
       "units": "Unidades de tráfico",
+      "unitsTitle": "Unidades de medida",
       "tempUnit": "Unidad de temperatura"
     },
     "demo": {

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -3848,52 +3848,60 @@ export default function Settings() {
               </div>
             }
           >
-            {/* cols-2: Unidades + decimal + Refresco (izq) | umbrales (der) */}
+            {/* cols-2: Unidades de medida (una fila) + Refresco (izq) | umbrales (der) */}
             <div className="grid gap-4 sm:grid-cols-2">
               <div className="space-y-4">
                 <div>
-                  <div className="text-sm font-medium text-text-primary">{t('settings.data.units')}</div>
-                  <div className="mt-2">
-                    <SegmentedControl
-                      options={[
-                        { value: 'mbps', label: 'Mbps' },
-                        { value: 'mbs', label: 'MB/s' },
-                      ]}
-                      value={units}
-                      onChange={(v) => {
-                        setUnits(v)
-                        notify()
-                      }}
-                      ariaLabel={t('settings.data.units')}
-                    />
+                  <div className="text-sm font-medium text-text-primary">{t('settings.data.unitsTitle')}</div>
+                  <div className="mt-2 flex flex-wrap items-start gap-4">
+                    <div>
+                      <div className="text-caption text-text-muted">{t('settings.data.units')}</div>
+                      <div className="mt-1.5">
+                        <SegmentedControl
+                          options={[
+                            { value: 'mbps', label: 'Mbps' },
+                            { value: 'mbs', label: 'MB/s' },
+                          ]}
+                          value={units}
+                          onChange={(v) => {
+                            setUnits(v)
+                            notify()
+                          }}
+                          ariaLabel={t('settings.data.units')}
+                        />
+                      </div>
+                    </div>
+                    <div>
+                      <div className="text-caption text-text-muted">{t('settings.data.tempUnit')}</div>
+                      <div className="mt-1.5">
+                        <SegmentedControl
+                          options={[
+                            { value: 'c', label: '°C' },
+                            { value: 'f', label: '°F' },
+                          ]}
+                          value={tempUnit}
+                          onChange={(v) => {
+                            setTempUnit(v)
+                            notify()
+                          }}
+                          ariaLabel={t('settings.data.tempUnit')}
+                        />
+                      </div>
+                    </div>
+                    <div>
+                      <div className="text-caption text-text-muted">{t('settings.data.decimalEs')}</div>
+                      <div className="mt-1.5 flex h-9 items-center">
+                        <Switch
+                          checked={decimalEs}
+                          onCheckedChange={(v) => {
+                            setDecimalEs(v)
+                            notify()
+                          }}
+                          aria-label={t('settings.data.decimalEs')}
+                        />
+                      </div>
+                    </div>
                   </div>
-                </div>
-                <div>
-                  <div className="text-sm font-medium text-text-primary">{t('settings.data.tempUnit')}</div>
-                  <div className="mt-2">
-                    <SegmentedControl
-                      options={[
-                        { value: 'c', label: '°C' },
-                        { value: 'f', label: '°F' },
-                      ]}
-                      value={tempUnit}
-                      onChange={(v) => {
-                        setTempUnit(v)
-                        notify()
-                      }}
-                      ariaLabel={t('settings.data.tempUnit')}
-                    />
-                  </div>
-                </div>
-                <div>
-                  <SwitchRow
-                    label={t('settings.data.decimalEs')}
-                    checked={decimalEs}
-                    onCheckedChange={(v) => {
-                      setDecimalEs(v)
-                      notify()
-                    }}
-                  />
                 </div>
                 <div>
                   <div className="text-sm font-medium text-text-primary">{t('settings.data.refresh')}</div>


### PR DESCRIPTION
The Data and thresholds card stacked its unit controls vertically: speed (Mbps/MB/s), temperature (C/F) and the European decimal toggle each took their own line, pushing the rest of the card down.

This groups them under a "Units" heading on a single horizontal row (flex, wrapping on small screens), keeping every control's behavior, persistence and labels untouched. The decimal toggle, previously a full-width row, becomes an inline switch aligned with the two segmented pickers.

Frontend build and lint clean (only the five pre-existing warnings). Verified live: the three controls render at the same height and wrap correctly.

Closes #748