### PR TITLE
feat(announcements): larger banner type and the full beta-program notice

### DIFF
--- a/announcements.json
+++ b/announcements.json
@@ -8,8 +8,8 @@
         "en": "NetGrip beta tester program is open"
       },
       "body": {
-        "es": "Buscamos testers para NetGrip, el panel compañero que corre en tu router OpenWrt: toggles de servicios con rollback, clientes, tráfico por aplicación. Estrena sus funciones antes que nadie y ayúdanos a pulirlas.",
-        "en": "We are looking for testers for NetGrip, the companion panel that runs on your OpenWrt router: service toggles with rollback, clients, per-app traffic. Try its features first and help us polish them."
+        "es": "NetGrip es el panel compañero de NetPulse: corre en tu propio router OpenWrt y controla WireGuard, WiFi de invitados, QoS o DNS con un clic y con rollback automático. Buscamos testers con routers OpenWrt (ARM o x86) que lo prueben en su red y nos cuenten qué falla: los beta testers estrenan cada función antes que nadie y marcan qué se construye.",
+        "en": "NetGrip is NetPulse's companion panel: it runs on your own OpenWrt router and drives WireGuard, guest Wi-Fi, QoS or DNS with one click and automatic rollback. We are looking for testers with OpenWrt routers (ARM or x86) to run it on their network and tell us what breaks: beta testers get every feature first and steer what gets built."
       },
       "url": "https://netgrip.cloudless.club",
       "urlLabel": {

--- a/app/src/components/AnnouncementBanner.tsx
+++ b/app/src/components/AnnouncementBanner.tsx
@@ -86,8 +86,8 @@ export function AnnouncementBanner() {
         >
           <Megaphone className={`h-4 w-4 shrink-0 ${warn ? 'text-warn' : 'text-accent'}`} strokeWidth={1.75} />
           <div className="min-w-0 flex-1">
-            {title && <p className="truncate text-sm font-medium text-text-primary">{title}</p>}
-            {body && <p className="text-xs text-text-muted">{body}</p>}
+            {title && <p className="text-[22px] font-bold leading-tight text-text-primary">{title}</p>}
+            {body && <p className="text-lg leading-snug text-text-secondary">{body}</p>}
           </div>
           {a.url && (
             <a


### PR DESCRIPTION
Feedback round on the announcements channel:

- Banner type goes from 14/12 px to a 22 px bold title and an 18 px body: a community-wide notice should not go unnoticed, and the previous sizes read as fine print.
- The first notice gets its full copy: what NetGrip is (the companion panel running on your own OpenWrt router, service toggles with automatic rollback), what the beta program asks for (testers with OpenWrt routers, ARM or x86, running it on their network), and what testers get (every feature first, a say in what gets built). Spanish and English.

Verified live on a production instance: computed title 22 px, body 18 px, full copy rendered, link intact, dismiss still persistent (6/6 smoke).