### PR TITLE
feat(firmware): full owut flow, recurring schedule and vendor firmware guard

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1766,7 +1766,16 @@
     "stepWorking": "(building the image on ASU and downloading)",
     "stepRebooting": "(waiting for the router to come back from reboot)",
     "emptyFailure": "no details: check the Comprobar output or retry",
-    "missingPkgsBannerStack": "These packages are not in the official feeds: {{pkgs}}. Own-stack ones (netgrip / agent) will be excluded from the image but their files survive the update; anything else is lost (reinstall it afterwards)."
+    "missingPkgsBannerStack": "These packages are not in the official feeds: {{pkgs}}. Own-stack ones (netgrip / agent) will be excluded from the image but their files survive the update; anything else is lost (reinstall it afterwards).",
+    "phaseBuild": "Building the image on ASU (usually takes 1-3 min)",
+    "phaseDownload": "Downloading and verifying the image",
+    "phaseFlash": "About to flash: the router reboots shortly",
+    "consoleContact": "contacting sysupgrade.openwrt.org...",
+    "consoleBuild": "requesting image build from ASU...",
+    "consoleDownload": "downloading image...",
+    "consoleVerify": "verifying sha256...",
+    "consoleWrite": "writing firmware...",
+    "consoleReboot": "router is rebooting; waiting for it to come back (up to 15 min)"
   },
   "orchestration": {
     "title": "Orchestration",

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -226,6 +226,14 @@
       "wireguard-handshake": {
         "title": "WireGuard handshake",
         "description": "{{peer}} connected"
+      },
+      "firmware-upgrade-done": {
+        "title": "Firmware upgraded",
+        "description": "{{router}}: {{from}} → {{to}} (owut, {{origin}})"
+      },
+      "firmware-upgrade-failed": {
+        "title": "Firmware upgrade failed",
+        "description": "{{router}}: target {{to}} (owut, {{origin}}): {{detail}}"
       }
     }
   },
@@ -1708,7 +1716,9 @@
       "flashing": "Flashing",
       "done": "Done",
       "failed": "Failed",
-      "scheduled": "Scheduled"
+      "scheduled": "Scheduled",
+      "running": "running",
+      "rebooting": "rebooting"
     },
     "schedule": "Schedule",
     "scheduleAt": "Schedule for",
@@ -1722,7 +1732,31 @@
     "owutUpToDate": "No pending changes; no upgrade needed.",
     "owutNotBuildable": "The ASU server cannot build the image for this router right now.",
     "owutCheckFailed": "The check could not run (router unreachable or not responding).",
-    "owutOutput": "owut output"
+    "owutOutput": "owut output",
+    "check": "Check",
+    "installOwut": "Install owut",
+    "installingOwut": "Installing owut...",
+    "notDetected": "Not detected",
+    "installedTag": "installed",
+    "latestTag": "latest",
+    "majorWarn": "Major version jump ({{from}} → {{to}}): review the release notes before upgrading",
+    "advanced": "Advanced (URL and checksum)",
+    "owutConfirmTitle": "Upgrade with owut (ASU)",
+    "owutConfirmBody": "The ASU server will build a stock OpenWrt image and the router will install it. The session drops when it reboots.",
+    "owutConfirmPackages": "The ASU image keeps the packages you installed on the router",
+    "scheduleTitle": "Schedule upgrade",
+    "scheduleBody": "Date/time and recurrence. It only flashes when the installed version differs from the target.",
+    "rec_once": "Once",
+    "rec_weekly": "Weekly",
+    "rec_monthly": "Monthly",
+    "recDate": "Date and time",
+    "recDay": "Day of the week",
+    "recDayOfMonth": "Day of the month",
+    "recTime": "Time",
+    "recNeedDate": "Pick a date and time for the one-shot schedule",
+    "recScheduled": "Scheduled ({{kind}}): {{when}}",
+    "recRemove": "Remove schedule",
+    "recIdempotentHint": "Every attempt reports its result (alert, push and Telegram when configured). If the router is already on the target version, nothing happens."
   },
   "orchestration": {
     "title": "Orchestration",

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1765,7 +1765,8 @@
     "upgradeRunningOwut": "owut upgrade in progress {{step}} · {{elapsed}}. It can take several minutes and the router reboots at the end.",
     "stepWorking": "(building the image on ASU and downloading)",
     "stepRebooting": "(waiting for the router to come back from reboot)",
-    "emptyFailure": "no details: check the Comprobar output or retry"
+    "emptyFailure": "no details: check the Comprobar output or retry",
+    "missingPkgsBannerStack": "These packages are not in the official feeds: {{pkgs}}. Own-stack ones (netgrip / agent) will be excluded from the image but their files survive the update; anything else is lost (reinstall it afterwards)."
   },
   "orchestration": {
     "title": "Orchestration",

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1756,7 +1756,10 @@
     "recNeedDate": "Pick a date and time for the one-shot schedule",
     "recScheduled": "Scheduled ({{kind}}): {{when}}",
     "recRemove": "Remove schedule",
-    "recIdempotentHint": "Every attempt reports its result (alert, push and Telegram when configured). If the router is already on the target version, nothing happens."
+    "recIdempotentHint": "Every attempt reports its result (alert, push and Telegram when configured). If the router is already on the target version, nothing happens.",
+    "excludePkgs": "Packages to exclude from the ASU image",
+    "excludePkgsHint": "Only needed when the check complains about packages outside the official repos (they are lost on upgrade; reinstall them afterwards).",
+    "owutNotBuildableHint": "Usually a package installed outside the official repos: check the output and exclude it when upgrading."
   },
   "orchestration": {
     "title": "Orchestration",

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1775,7 +1775,10 @@
     "consoleDownload": "downloading image...",
     "consoleVerify": "verifying sha256...",
     "consoleWrite": "writing firmware...",
-    "consoleReboot": "router is rebooting; waiting for it to come back (up to 15 min)"
+    "consoleReboot": "router is rebooting; waiting for it to come back (up to 15 min)",
+    "successTitle": "Upgrade completed!",
+    "successBody": "The router is now on {{to}} in {{dur}} s: it rebooted and came back on its own, packages up to date. If you excluded a stack package, check its service is still running.",
+    "successDismiss": "Got it"
   },
   "orchestration": {
     "title": "Orchestration",

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1760,7 +1760,12 @@
     "excludePkgs": "Packages to exclude from the ASU image",
     "excludePkgsHint": "Only needed when the check complains about packages outside the official repos (they are lost on upgrade; reinstall them afterwards).",
     "owutNotBuildableHint": "Usually a package installed outside the official repos: check the output and exclude it when upgrading.",
-    "vendorNote": "This router runs vendor firmware (GL.iNet): NetPulse does not manage its upgrades. Use the GL.iNet panel (Upgrade Firmware), which already offers the latest official release for the model."
+    "vendorNote": "This router runs vendor firmware (GL.iNet): NetPulse does not manage its upgrades. Use the GL.iNet panel (Upgrade Firmware), which already offers the latest official release for the model.",
+    "missingPkgsBanner": "These packages are not in the official feeds: {{pkgs}}. They will be excluded from the image if you keep them while upgrading (they are lost; reinstall afterwards).",
+    "upgradeRunningOwut": "owut upgrade in progress {{step}} · {{elapsed}}. It can take several minutes and the router reboots at the end.",
+    "stepWorking": "(building the image on ASU and downloading)",
+    "stepRebooting": "(waiting for the router to come back from reboot)",
+    "emptyFailure": "no details: check the Comprobar output or retry"
   },
   "orchestration": {
     "title": "Orchestration",

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -1759,7 +1759,8 @@
     "recIdempotentHint": "Every attempt reports its result (alert, push and Telegram when configured). If the router is already on the target version, nothing happens.",
     "excludePkgs": "Packages to exclude from the ASU image",
     "excludePkgsHint": "Only needed when the check complains about packages outside the official repos (they are lost on upgrade; reinstall them afterwards).",
-    "owutNotBuildableHint": "Usually a package installed outside the official repos: check the output and exclude it when upgrading."
+    "owutNotBuildableHint": "Usually a package installed outside the official repos: check the output and exclude it when upgrading.",
+    "vendorNote": "This router runs vendor firmware (GL.iNet): NetPulse does not manage its upgrades. Use the GL.iNet panel (Upgrade Firmware), which already offers the latest official release for the model."
   },
   "orchestration": {
     "title": "Orchestration",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1759,7 +1759,8 @@
     "recIdempotentHint": "Cada intento avisa del resultado (alerta, push y Telegram si está configurado). Si el router ya está en la versión objetivo, no hace nada.",
     "excludePkgs": "Paquetes a excluir de la imagen ASU",
     "excludePkgsHint": "Solo necesarios si el check objeta paquetes instalados fuera de los repos oficiales (se pierden al actualizar; reinstálalos después).",
-    "owutNotBuildableHint": "Suele ser un paquete instalado que no está en los repos oficiales: revisa la salida y exclúyelo al actualizar."
+    "owutNotBuildableHint": "Suele ser un paquete instalado que no está en los repos oficiales: revisa la salida y exclúyelo al actualizar.",
+    "vendorNote": "Este router lleva firmware del fabricante (GL.iNet): NetPulse no gestiona sus actualizaciones. Usa el panel de GL.iNet (Upgrade Firmware), que ya ofrece la última versión oficial del modelo."
   },
   "orchestration": {
     "title": "Orquestación",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1775,7 +1775,10 @@
     "consoleDownload": "descargando imagen...",
     "consoleVerify": "verificando sha256...",
     "consoleWrite": "escribiendo firmware...",
-    "consoleReboot": "el router se está reiniciando; esperando a que vuelva (hasta 15 min)"
+    "consoleReboot": "el router se está reiniciando; esperando a que vuelva (hasta 15 min)",
+    "successTitle": "¡Actualización completada!",
+    "successBody": "El router quedó en {{to}} en {{dur}} s: reinició y volvió solo, con los paquetes al día. Si excluiste algún paquete del stack, comprueba que su servicio sigue activo.",
+    "successDismiss": "Entendido"
   },
   "orchestration": {
     "title": "Orquestación",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1765,7 +1765,8 @@
     "upgradeRunningOwut": "Actualización owut en curso {{step}} · {{elapsed}}. Puede tardar varios minutos y el router se reiniciará al final.",
     "stepWorking": "(construyendo la imagen en ASU y descargando)",
     "stepRebooting": "(esperando a que el router vuelva del reinicio)",
-    "emptyFailure": "sin detalles: consulta la salida de Comprobar o reintenta"
+    "emptyFailure": "sin detalles: consulta la salida de Comprobar o reintenta",
+    "missingPkgsBannerStack": "Estos paquetes no están en los feeds oficiales: {{pkgs}}. Los del propio stack (netgrip / agente) se excluirán de la imagen pero sus ficheros se conservan tras el update; cualquier otro se pierde (reinstálalo después)."
   },
   "orchestration": {
     "title": "Orquestación",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1756,7 +1756,10 @@
     "recNeedDate": "Elige fecha y hora para la programación única",
     "recScheduled": "Programado ({{kind}}): {{when}}",
     "recRemove": "Quitar programación",
-    "recIdempotentHint": "Cada intento avisa del resultado (alerta, push y Telegram si está configurado). Si el router ya está en la versión objetivo, no hace nada."
+    "recIdempotentHint": "Cada intento avisa del resultado (alerta, push y Telegram si está configurado). Si el router ya está en la versión objetivo, no hace nada.",
+    "excludePkgs": "Paquetes a excluir de la imagen ASU",
+    "excludePkgsHint": "Solo necesarios si el check objeta paquetes instalados fuera de los repos oficiales (se pierden al actualizar; reinstálalos después).",
+    "owutNotBuildableHint": "Suele ser un paquete instalado que no está en los repos oficiales: revisa la salida y exclúyelo al actualizar."
   },
   "orchestration": {
     "title": "Orquestación",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1766,7 +1766,16 @@
     "stepWorking": "(construyendo la imagen en ASU y descargando)",
     "stepRebooting": "(esperando a que el router vuelva del reinicio)",
     "emptyFailure": "sin detalles: consulta la salida de Comprobar o reintenta",
-    "missingPkgsBannerStack": "Estos paquetes no están en los feeds oficiales: {{pkgs}}. Los del propio stack (netgrip / agente) se excluirán de la imagen pero sus ficheros se conservan tras el update; cualquier otro se pierde (reinstálalo después)."
+    "missingPkgsBannerStack": "Estos paquetes no están en los feeds oficiales: {{pkgs}}. Los del propio stack (netgrip / agente) se excluirán de la imagen pero sus ficheros se conservan tras el update; cualquier otro se pierde (reinstálalo después).",
+    "phaseBuild": "Construyendo la imagen en ASU (suele tardar 1-3 min)",
+    "phaseDownload": "Descargando y verificando la imagen",
+    "phaseFlash": "A punto de flashear: el router se reiniciará en breve",
+    "consoleContact": "contactando con sysupgrade.openwrt.org...",
+    "consoleBuild": "solicitando build de la imagen a ASU...",
+    "consoleDownload": "descargando imagen...",
+    "consoleVerify": "verificando sha256...",
+    "consoleWrite": "escribiendo firmware...",
+    "consoleReboot": "el router se está reiniciando; esperando a que vuelva (hasta 15 min)"
   },
   "orchestration": {
     "title": "Orquestación",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -1760,7 +1760,12 @@
     "excludePkgs": "Paquetes a excluir de la imagen ASU",
     "excludePkgsHint": "Solo necesarios si el check objeta paquetes instalados fuera de los repos oficiales (se pierden al actualizar; reinstálalos después).",
     "owutNotBuildableHint": "Suele ser un paquete instalado que no está en los repos oficiales: revisa la salida y exclúyelo al actualizar.",
-    "vendorNote": "Este router lleva firmware del fabricante (GL.iNet): NetPulse no gestiona sus actualizaciones. Usa el panel de GL.iNet (Upgrade Firmware), que ya ofrece la última versión oficial del modelo."
+    "vendorNote": "Este router lleva firmware del fabricante (GL.iNet): NetPulse no gestiona sus actualizaciones. Usa el panel de GL.iNet (Upgrade Firmware), que ya ofrece la última versión oficial del modelo.",
+    "missingPkgsBanner": "Estos paquetes no están en los feeds oficiales: {{pkgs}}. Se excluirán de la imagen si los añades al actualizar (se pierden; reinstálalos después).",
+    "upgradeRunningOwut": "Actualización owut en curso {{step}} · {{elapsed}}. Puede tardar varios minutos y el router se reiniciará al final.",
+    "stepWorking": "(construyendo la imagen en ASU y descargando)",
+    "stepRebooting": "(esperando a que el router vuelva del reinicio)",
+    "emptyFailure": "sin detalles: consulta la salida de Comprobar o reintenta"
   },
   "orchestration": {
     "title": "Orquestación",

--- a/app/public/locales/es/translation.json
+++ b/app/public/locales/es/translation.json
@@ -226,6 +226,14 @@
       "wireguard-handshake": {
         "title": "Handshake WireGuard",
         "description": "{{peer}} conectado"
+      },
+      "firmware-upgrade-done": {
+        "title": "Firmware actualizado",
+        "description": "{{router}}: {{from}} → {{to}} (owut, {{origin}})"
+      },
+      "firmware-upgrade-failed": {
+        "title": "Actualización de firmware fallida",
+        "description": "{{router}}: objetivo {{to}} (owut, {{origin}}): {{detail}}"
       }
     }
   },
@@ -1708,7 +1716,9 @@
       "flashing": "Flasheando",
       "done": "Completada",
       "failed": "Fallida",
-      "scheduled": "Programada"
+      "scheduled": "Programada",
+      "running": "ejecutando",
+      "rebooting": "reiniciando"
     },
     "schedule": "Programar",
     "scheduleAt": "Programar para",
@@ -1722,7 +1732,31 @@
     "owutUpToDate": "Sin cambios pendientes; no es necesario actualizar.",
     "owutNotBuildable": "El servidor ASU no puede construir la imagen para este router en este momento.",
     "owutCheckFailed": "No se pudo ejecutar el check (router inalcanzable o sin respuesta).",
-    "owutOutput": "Salida de owut"
+    "owutOutput": "Salida de owut",
+    "check": "Comprobar",
+    "installOwut": "Instalar owut",
+    "installingOwut": "Instalando owut...",
+    "notDetected": "Sin detectar",
+    "installedTag": "instalada",
+    "latestTag": "última",
+    "majorWarn": "Salto de versión mayor ({{from}} → {{to}}): revisa los cambios de la rama antes de actualizar",
+    "advanced": "Avanzado (URL y checksum)",
+    "owutConfirmTitle": "Actualizar con owut (ASU)",
+    "owutConfirmBody": "El servidor ASU construirá una imagen OpenWrt estándar y el router la instalará. La sesión se cortará al reiniciar.",
+    "owutConfirmPackages": "La imagen ASU conserva los paquetes que instalaste en el router",
+    "scheduleTitle": "Programar actualización",
+    "scheduleBody": "Fecha/hora y recurrencia. Solo flashea si la versión instalada difiere del objetivo.",
+    "rec_once": "Una vez",
+    "rec_weekly": "Semanal",
+    "rec_monthly": "Mensual",
+    "recDate": "Fecha y hora",
+    "recDay": "Día de la semana",
+    "recDayOfMonth": "Día del mes",
+    "recTime": "Hora",
+    "recNeedDate": "Elige fecha y hora para la programación única",
+    "recScheduled": "Programado ({{kind}}): {{when}}",
+    "recRemove": "Quitar programación",
+    "recIdempotentHint": "Cada intento avisa del resultado (alerta, push y Telegram si está configurado). Si el router ya está en la versión objetivo, no hace nada."
   },
   "orchestration": {
     "title": "Orquestación",

--- a/app/src/pages/FirmwareUpgrades.tsx
+++ b/app/src/pages/FirmwareUpgrades.tsx
@@ -239,6 +239,15 @@ export default function FirmwareUpgrades() {
     return () => clearInterval(iv)
   }, [anyActive])
 
+  // Barra de progreso fluida: reloj local de 1s mientras hay upgrade activo
+  // (patron del ticker de agentes #691; el fetch sigue a 10 s).
+  const [nowSec, setNowSec] = useState(() => Math.floor(Date.now() / 1000))
+  useEffect(() => {
+    if (!anyActive) return
+    const iv = setInterval(() => setNowSec(Math.floor(Date.now() / 1000)), 1000)
+    return () => clearInterval(iv)
+  }, [anyActive])
+
   const updateEdit = (id: string, patch: Partial<FirmwareItem>) => {
     setEdits((prev) => ({ ...prev, [id]: { ...prev[id], ...patch } }))
   }
@@ -546,6 +555,75 @@ export default function FirmwareUpgrades() {
             .forEach((v) => {
               if (!opts.includes(v.version)) opts.push(v.version)
             })
+          // #761: mientras corre el upgrade, la tarjeta ES el proceso (icono,
+          // fase, barra y consola); el resto del formulario desaparece.
+          if (active && item.upgrade) {
+            const up = item.upgrade
+            const elapsed = Math.max(0, nowSec - up.startedAt)
+            const rebooting = up.status === 'rebooting'
+            const pct = rebooting ? 96 : Math.min((elapsed / 300) * 95, 95)
+            const phase = rebooting
+              ? t('firmwareUpgrades.stepRebooting')
+              : elapsed < 90
+                ? t('firmwareUpgrades.phaseBuild')
+                : elapsed < 300
+                  ? t('firmwareUpgrades.phaseDownload')
+                  : t('firmwareUpgrades.phaseFlash')
+            const stamp = (sec: number) => `${Math.floor(sec / 60)}:${String(sec % 60).padStart(2, '0')}`
+            const cmdVer =
+              up.targetVersion && item.detectedVersion && up.targetVersion !== item.detectedVersion
+                ? ` -V '${up.targetVersion}'`
+                : ''
+            const lines: string[] = [
+              `$ owut upgrade -q${cmdVer}`,
+              `[${stamp(0)}] ${t('firmwareUpgrades.consoleContact')}`,
+            ]
+            if (elapsed >= 10) lines.push(`[${stamp(10)}] ${t('firmwareUpgrades.consoleBuild')}`)
+            if (elapsed >= 90) lines.push(`[${stamp(90)}] ${t('firmwareUpgrades.consoleDownload')}`)
+            if (elapsed >= 180) lines.push(`[${stamp(180)}] ${t('firmwareUpgrades.consoleVerify')}`)
+            if (elapsed >= 300) lines.push(`[${stamp(300)}] ${t('firmwareUpgrades.consoleWrite')}`)
+            if (rebooting) lines.push(`[${stamp(elapsed)}] ${t('firmwareUpgrades.consoleReboot')}`)
+            return (
+              <div key={item.routerId} className="rounded-2xl border border-border bg-surface p-5">
+                <div className="mb-6 flex items-center gap-3">
+                  <Cpu className="h-5 w-5 text-accent" strokeWidth={1.75} />
+                  <div>
+                    <h2 className="text-base font-semibold text-text-primary">
+                      {sortedRouters.find((r) => r.id === item.routerId)?.name ?? item.name}
+                    </h2>
+                    <p className="text-xs text-text-muted">{detectedModel || item.model || t('common.unknown')}</p>
+                  </div>
+                  <span
+                    className={cn(
+                      'ml-auto rounded-full border px-2.5 py-0.5 text-xs font-medium',
+                      STATUS_COLORS[up.status] ?? 'bg-text-muted/10 text-text-muted border-text-muted/30'
+                    )}
+                  >
+                    {t(`firmwareUpgrades.status.${up.status}`, { defaultValue: up.status })}
+                  </span>
+                </div>
+
+                <div className="flex flex-col items-center gap-3 py-4" data-testid="fw-progress">
+                  <RefreshCw className="h-14 w-14 animate-pulse text-accent" strokeWidth={1.5} />
+                  <p className="text-sm font-medium text-text-primary">{phase}</p>
+                  <p className="font-mono text-xs text-text-muted">{stamp(elapsed)}</p>
+                  <div className="w-full max-w-md">
+                    <div className="h-1.5 overflow-hidden rounded-full bg-accent/20">
+                      <div
+                        className="h-full rounded-full bg-accent transition-all duration-1000 ease-linear"
+                        style={{ width: `${pct}%` }}
+                      />
+                    </div>
+                  </div>
+                  <pre className="mt-2 w-full max-w-md overflow-x-auto whitespace-pre-wrap rounded-lg border border-border bg-canvas px-3 py-2.5 font-mono text-xs leading-relaxed text-text-secondary">
+                    {lines.join('\n')}
+                    {'\n'}
+                    <span className="animate-pulse">▌</span>
+                  </pre>
+                </div>
+              </div>
+            )
+          }
           return (
             <div
               key={item.routerId}
@@ -570,23 +648,6 @@ export default function FirmwareUpgrades() {
                   </span>
                 )}
               </div>
-
-              {active && item.upgrade && (
-                <div className="mb-4 flex items-start gap-2 rounded-lg border border-blue-500/30 bg-blue-500/10 px-3 py-2.5 text-sm text-blue-700 dark:text-blue-300">
-                  <RefreshCw className="mt-0.5 h-4 w-4 shrink-0 animate-pulse" strokeWidth={1.75} />
-                  <span>
-                    {item.upgrade.engine === 'owut'
-                      ? t('firmwareUpgrades.upgradeRunningOwut', {
-                          elapsed: relTimeFromTs(item.upgrade.startedAt),
-                          step:
-                            item.upgrade.status === 'rebooting'
-                              ? t('firmwareUpgrades.stepRebooting')
-                              : t('firmwareUpgrades.stepWorking'),
-                        })
-                      : t('firmwareUpgrades.inProgress')}
-                  </span>
-                </div>
-              )}
 
               <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                 <label className="flex flex-col gap-1">
@@ -700,7 +761,7 @@ export default function FirmwareUpgrades() {
               </details>
               )}
 
-              {owut && (
+              {!active && owut && (
                 <div className="mt-3 space-y-2">
                   {owut.error && (
                     <div className="flex items-start gap-2 rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-600 dark:text-rose-400">

--- a/app/src/pages/FirmwareUpgrades.tsx
+++ b/app/src/pages/FirmwareUpgrades.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNetPulse } from '@/data/DataProvider'
 import { useAuth } from '@/data/AuthContext'
-import { AlertCircle, CalendarClock, Cpu, Radar, RefreshCw, Rocket, ShieldCheck, Terminal, TriangleAlert } from 'lucide-react'
+import { AlertCircle, CalendarClock, Cpu, Radar, RefreshCw, Rocket, ShieldCheck, Terminal, TriangleAlert, Download } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { relTimeFromTs } from '@/i18n'
 import {
@@ -29,6 +29,8 @@ interface FirmwareUpgrade {
   finishedAt?: number
   /** Epoch ms UTC de una programación desatendida (#494); ausente = flujo manual. */
   scheduledFor?: number
+  /** Motor del upgrade (#761): owut (ASU) o vacío (URL+checksum). */
+  engine?: string
 }
 
 interface FirmwareItem {
@@ -46,7 +48,7 @@ interface FirmwareItem {
   upgrade?: FirmwareUpgrade
 }
 
-/** Resultado de la detección + check de owut por router (#695, Fase 1). */
+/** Resultado de la detección + check de owut por router (#695). */
 interface OwutStatus {
   owutAvailable: boolean
   checkRan: boolean
@@ -56,19 +58,59 @@ interface OwutStatus {
   error?: string
 }
 
+/** Versiones destino que ASU puede construir (#761). */
+interface OwutVersion {
+  version: string
+  branch: string
+  latest?: boolean
+  newer?: boolean
+}
+
+interface OwutVersionsResp {
+  current: string
+  owutAvailable: boolean
+  versions: OwutVersion[]
+  error?: string
+}
+
+/** Programación recurrente (#761). */
+interface RecurrenceCfg {
+  enabled: boolean
+  kind: 'once' | 'weekly' | 'monthly'
+  atMs?: number
+  dayOfWeek?: number
+  dayOfMonth?: number
+  time?: string
+  lastRunMs?: number
+}
+
 const STATUS_COLORS: Record<string, string> = {
   requested: 'bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/30',
+  running: 'bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/30',
   downloading: 'bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/30',
   backing_up: 'bg-purple-500/10 text-purple-600 dark:text-purple-400 border-purple-500/30',
   verifying: 'bg-cyan-500/10 text-cyan-600 dark:text-cyan-400 border-cyan-500/30',
   flashing: 'bg-orange-500/10 text-orange-600 dark:text-orange-400 border-orange-500/30',
+  rebooting: 'bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 border-indigo-500/30',
   done: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/30',
   failed: 'bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/30',
   scheduled: 'bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 border-indigo-500/30',
 }
 
+/** majorJumpJS: mismo criterio que el backend (primer componente distinto). */
+function majorJumpJS(current: string, target: string): boolean {
+  if (!current || !target) return false
+  return current.split('.')[0] !== target.split('.')[0]
+}
+
+/** dowLabel: nombre del día de la semana en el idioma de la UI. */
+function dowLabel(lang: string, dow: number): string {
+  // 13-Sep-2026 es domingo: día i = 13 + i.
+  return new Date(2026, 8, 13 + dow).toLocaleDateString(lang, { weekday: 'long' })
+}
+
 export default function FirmwareUpgrades() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const auth = useAuth()
   const { routers } = useNetPulse()
   const isAdmin = auth?.role === 'admin'
@@ -79,13 +121,25 @@ export default function FirmwareUpgrades() {
   const [busy, setBusy] = useState<Record<string, string>>({})
   const [error, setError] = useState('')
   const [confirmId, setConfirmId] = useState<string | null>(null)
-  // #494: hora local elegida para programar (datetime-local) por router.
-  const [scheduleAt, setScheduleAt] = useState<Record<string, string>>({})
   // #629: estado de "autodetectar imagen" por router.
   const [resolveBusy, setResolveBusy] = useState<Record<string, boolean>>({})
-  // #695 Fase 1: estado del check owut por router.
+  // #695: estado del check owut por router.
   const [owutBusy, setOwutBusy] = useState<Record<string, boolean>>({})
   const [owutResult, setOwutResult] = useState<Record<string, OwutStatus>>({})
+  // #761: versiones para el desplegable e instalación de owut.
+  const [owutVersions, setOwutVersions] = useState<Record<string, OwutVersionsResp>>({})
+  const [versionsBusy, setVersionsBusy] = useState<Record<string, boolean>>({})
+  const [installBusy, setInstallBusy] = useState<Record<string, boolean>>({})
+  const [owutConfirmId, setOwutConfirmId] = useState<string | null>(null)
+  // #761: programación recurrente.
+  const [recurrence, setRecurrence] = useState<Record<string, RecurrenceCfg>>({})
+  const [recNext, setRecNext] = useState<Record<string, number>>({})
+  const [scheduleId, setScheduleId] = useState<string | null>(null)
+  const [recKind, setRecKind] = useState<'once' | 'weekly' | 'monthly'>('once')
+  const [recAt, setRecAt] = useState('')
+  const [recDow, setRecDow] = useState(5)
+  const [recDom, setRecDom] = useState(1)
+  const [recTime, setRecTime] = useState('04:00')
 
   const sortedRouters = useMemo(() => {
     return [...routers].sort((a, b) => (a.roleBadge === 'Principal' ? -1 : 1) || a.name.localeCompare(b.name))
@@ -101,11 +155,11 @@ export default function FirmwareUpgrades() {
       setItems(data)
       const initialEdits: Record<string, Partial<FirmwareItem>> = {}
       data.forEach((it) => {
-        // #477 P2: si el target guardado no tiene versión actual ni modelo,
-        // se prefillan con lo detectado del último board info del agente.
+        // #477 P2 / #761: modelo y versión actual SIEMPRE prefilleados con
+        // lo detectado del board info; solo editables sin detección posible.
         initialEdits[it.routerId] = {
-          model: it.model || it.detectedBoard || '',
-          currentVersion: it.currentVersion || it.detectedVersion || '',
+          model: it.detectedBoard || it.detectedModel || it.model || '',
+          currentVersion: it.detectedVersion || it.currentVersion || '',
           targetVersion: it.targetVersion,
           targetUrl: it.targetUrl,
           checksum: it.checksum,
@@ -119,16 +173,67 @@ export default function FirmwareUpgrades() {
     }
   }
 
+  const loadRecurrence = async (id: string) => {
+    try {
+      const res = await fetch(`/api/firmware-upgrades/${encodeURIComponent(id)}/recurrence`)
+      if (!res.ok) return
+      const body = (await res.json()) as { recurrence: RecurrenceCfg; nextRunMs?: number }
+      setRecurrence((prev) => ({ ...prev, [id]: body.recurrence }))
+      const next = body.nextRunMs ?? 0
+      setRecNext((prev) => ({ ...prev, [id]: next }))
+    } catch {
+      // fail-silent
+    }
+  }
+
+  // #761: versiones del desplegable (owut versions en el router).
+  const fetchVersions = async (id: string) => {
+    setVersionsBusy((prev) => ({ ...prev, [id]: true }))
+    try {
+      const res = await fetch(`/api/firmware-upgrades/${encodeURIComponent(id)}/owut-versions`)
+      const body = (await res.json().catch(() => ({}))) as OwutVersionsResp
+      if (!res.ok) throw new Error((body as { error?: { message?: string } })?.error?.message ?? `HTTP ${res.status}`)
+      setOwutVersions((prev) => ({ ...prev, [id]: body }))
+    } catch (e) {
+      setOwutVersions((prev) => ({ ...prev, [id]: { current: '', owutAvailable: false, versions: [], error: String(e) } }))
+    } finally {
+      setVersionsBusy((prev) => ({ ...prev, [id]: false }))
+    }
+  }
+
   useEffect(() => {
     fetchItems()
   }, [])
+
+  // Al cargar items: recurrencia y versiones por router (admin).
+  useEffect(() => {
+    if (items.length && isAdmin) {
+      items.forEach((it) => {
+        void loadRecurrence(it.routerId)
+        if (!owutVersions[it.routerId]) void fetchVersions(it.routerId)
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [items])
+
+  // #761: auto-refresco mientras haya un upgrade en curso (owut tarda y el
+  // router se reinicia al final; el estado vive en el server).
+  const anyActive = items.some((it) => {
+    const s = it.upgrade?.status
+    return !!s && s !== 'done' && s !== 'failed'
+  })
+  useEffect(() => {
+    if (!anyActive) return
+    const iv = setInterval(() => void fetchItems(), 10_000)
+    return () => clearInterval(iv)
+  }, [anyActive])
 
   const updateEdit = (id: string, patch: Partial<FirmwareItem>) => {
     setEdits((prev) => ({ ...prev, [id]: { ...prev[id], ...patch } }))
   }
 
   // #629: resolver la imagen del firmware a partir del board info detectado
-  // (vía /image) y prerellenar targetVersion/targetUrl/checksum. Se resuelve
+  // (vía /image) y prerrellenar targetVersion/targetUrl/checksum. Se resuelve
   // para la versión objetivo ya escrita (edits), o la detectada si no hay.
   const resolveImage = async (id: string) => {
     const e = edits[id]
@@ -161,20 +266,7 @@ export default function FirmwareUpgrades() {
     }
   }
 
-  // Auto-prerrelleno: al cargar, para routers con board detectado y sin target
-  // configurado, se resuelve la imagen automáticamente (no sobreescribe un
-  // target ya guardado).
-  useEffect(() => {
-    items.forEach((it) => {
-      if (it.detectedBoard && !it.targetUrl) {
-        void resolveImage(it.routerId)
-      }
-    })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [items])
-
-  // #695 Fase 1: detectar owut y ejecutar `owut check` en el router (solo
-  // detección + check para revisión; sin download/install).
+  // #695/#761: comprobar con owut ("Comprobar").
   const runOwutCheck = async (id: string) => {
     setOwutBusy((prev) => ({ ...prev, [id]: true }))
     setError('')
@@ -185,12 +277,33 @@ export default function FirmwareUpgrades() {
         body: JSON.stringify({}),
       })
       const body = await res.json().catch(() => ({}))
-      if (!res.ok) throw new Error(body.message ?? body.error ?? await res.text())
+      if (!res.ok) throw new Error(body.message ?? body.error ?? (await res.text()))
       setOwutResult((prev) => ({ ...prev, [id]: body as OwutStatus }))
     } catch (err) {
       setError(String(err))
     } finally {
       setOwutBusy((prev) => ({ ...prev, [id]: false }))
+    }
+  }
+
+  // #761: instalar owut en el router (apk/opkg).
+  const installOwut = async (id: string) => {
+    setInstallBusy((prev) => ({ ...prev, [id]: true }))
+    setError('')
+    try {
+      const res = await fetch(`/api/firmware-upgrades/${encodeURIComponent(id)}/owut-install`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body?.error?.message ?? body?.message ?? `HTTP ${res.status}`)
+      await fetchVersions(id)
+      await runOwutCheck(id)
+    } catch (err) {
+      setError(String(err))
+    } finally {
+      setInstallBusy((prev) => ({ ...prev, [id]: false }))
     }
   }
 
@@ -242,7 +355,7 @@ export default function FirmwareUpgrades() {
         body: JSON.stringify({}),
       })
       const body = await res.json().catch(() => ({}))
-      if (!res.ok) throw new Error(body.message ?? await res.text())
+      if (!res.ok) throw new Error(body.message ?? (await res.text()))
       await fetchItems()
     } catch (err) {
       setError(String(err))
@@ -251,20 +364,19 @@ export default function FirmwareUpgrades() {
     }
   }
 
-  // #494: programar un upgrade desatendido (hora local → epoch ms UTC).
-  const scheduleUpgrade = async (id: string) => {
-    const at = scheduleAt[id]
-    if (!at) return
-    const scheduledFor = new Date(at).getTime()
-    setBusy((prev) => ({ ...prev, [id]: 'schedule' }))
+  // #761: attended upgrade vía owut/ASU desde lo detectado/elegido.
+  const startOwutUpgrade = async (id: string) => {
+    const e = edits[id]
+    if (!e?.targetVersion) return
+    setBusy((prev) => ({ ...prev, [id]: 'upgrade' }))
     try {
-      const res = await fetch(`/api/firmware-upgrades/${encodeURIComponent(id)}/schedule`, {
+      const res = await fetch(`/api/firmware-upgrades/${encodeURIComponent(id)}/owut-upgrade`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ scheduledFor }),
+        body: JSON.stringify({ targetVersion: e.targetVersion }),
       })
       const body = await res.json().catch(() => ({}))
-      if (!res.ok) throw new Error(body.message ?? await res.text())
+      if (!res.ok) throw new Error(body?.error?.message ?? body?.message ?? `HTTP ${res.status}`)
       await fetchItems()
     } catch (err) {
       setError(String(err))
@@ -273,7 +385,54 @@ export default function FirmwareUpgrades() {
     }
   }
 
-  // #494: cancelar una programación aún no iniciada.
+  // #761: guardar la programación recurrente (una vez / semanal / mensual).
+  const saveRecurrence = async (id: string) => {
+    setError('')
+    const payload: RecurrenceCfg = { enabled: true, kind: recKind }
+    if (recKind === 'once') {
+      if (!recAt) {
+        setError(t('firmwareUpgrades.recNeedDate'))
+        return
+      }
+      payload.atMs = new Date(recAt).getTime()
+    } else if (recKind === 'weekly') {
+      payload.dayOfWeek = recDow
+      payload.time = recTime
+    } else {
+      payload.dayOfMonth = recDom
+      payload.time = recTime
+    }
+    try {
+      const res = await fetch(`/api/firmware-upgrades/${encodeURIComponent(id)}/recurrence`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body?.error?.message ?? body?.message ?? `HTTP ${res.status}`)
+      setScheduleId(null)
+      await loadRecurrence(id)
+    } catch (err) {
+      setError(String(err))
+    }
+  }
+
+  const removeRecurrence = async (id: string) => {
+    try {
+      const res = await fetch(`/api/firmware-upgrades/${encodeURIComponent(id)}/recurrence`, { method: 'DELETE' })
+      if (!res.ok) throw new Error(await res.text())
+      await loadRecurrence(id)
+    } catch (err) {
+      setError(String(err))
+    }
+  }
+
+  const upgradeActive = (item: FirmwareItem) => {
+    const s = item.upgrade?.status
+    return !!s && s !== 'done' && s !== 'failed' && s !== 'scheduled'
+  }
+
+  // #494: cancelar una programación one-shot aún no iniciada (legacy).
   const cancelSchedule = async (id: string) => {
     setBusy((prev) => ({ ...prev, [id]: 'cancel' }))
     try {
@@ -287,11 +446,6 @@ export default function FirmwareUpgrades() {
     }
   }
 
-  const upgradeActive = (item: FirmwareItem) => {
-    const s = item.upgrade?.status
-    return !!s && s !== 'done' && s !== 'failed' && s !== 'scheduled'
-  }
-
   const scheduledPending = (item: FirmwareItem) => item.upgrade?.status === 'scheduled'
 
   // #477: el upgrade usa el target GUARDADO (no el buffer de edición), así
@@ -299,6 +453,14 @@ export default function FirmwareUpgrades() {
   const confirmItem = items.find((i) => i.routerId === confirmId)
   const confirmName = confirmItem
     ? sortedRouters.find((r) => r.id === confirmItem.routerId)?.name ?? confirmItem.name
+    : ''
+  const owutConfirm = items.find((i) => i.routerId === owutConfirmId)
+  const owutConfirmName = owutConfirm
+    ? sortedRouters.find((r) => r.id === owutConfirm.routerId)?.name ?? owutConfirm.name
+    : ''
+  const scheduleItem = items.find((i) => i.routerId === scheduleId)
+  const scheduleName = scheduleItem
+    ? sortedRouters.find((r) => r.id === scheduleItem.routerId)?.name ?? scheduleItem.name
     : ''
 
   return (
@@ -344,13 +506,22 @@ export default function FirmwareUpgrades() {
           const active = upgradeActive(item)
           const scheduled = scheduledPending(item)
           const owut = owutResult[item.routerId]
-          // #477 P2: resumen de lo detectado por el agente (board info).
-          const detectedBits: string[] = []
-          if (item.detectedModel || item.detectedBoard) {
-            detectedBits.push([item.detectedModel, item.detectedBoard ? `(${item.detectedBoard})` : ''].filter(Boolean).join(' '))
-          }
-          if (item.detectedVersion) detectedBits.push(`OpenWrt ${item.detectedVersion}`)
-          if (item.detectedTarget) detectedBits.push(item.detectedTarget)
+          const versions = owutVersions[item.routerId]
+          const owutAvail = owut?.owutAvailable ?? versions?.owutAvailable ?? false
+          const detectedCurrent = item.detectedVersion || e.currentVersion || ''
+          const detectedModel = item.detectedBoard || item.detectedModel || ''
+          const rec = recurrence[item.routerId]
+          const targetSel = e.targetVersion ?? ''
+          const majorWarn = majorJumpJS(detectedCurrent, targetSel)
+          // Opciones del desplegable: detectada + todas las estables (desc).
+          const currentVer = item.detectedVersion || ''
+          const opts: string[] = []
+          if (currentVer && !opts.includes(currentVer)) opts.push(currentVer)
+          if (item.targetVersion && !opts.includes(item.targetVersion)) opts.push(item.targetVersion)
+          const list = (versions?.versions ?? []).map((v) => v.version)
+          list.forEach((v) => {
+            if (!opts.includes(v)) opts.push(v)
+          })
           return (
             <div
               key={item.routerId}
@@ -362,7 +533,7 @@ export default function FirmwareUpgrades() {
                   <h2 className="text-base font-semibold text-text-primary">
                     {sortedRouters.find((r) => r.id === item.routerId)?.name ?? item.name}
                   </h2>
-                  <p className="text-xs text-text-muted">{item.model || t('common.unknown')}</p>
+                  <p className="text-xs text-text-muted">{detectedModel || item.model || t('common.unknown')}</p>
                 </div>
                 {item.upgrade && (
                   <span
@@ -378,141 +549,140 @@ export default function FirmwareUpgrades() {
 
               <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                 <label className="flex flex-col gap-1">
+                  <span className="text-caption text-text-muted">{t('firmwareUpgrades.model')} *</span>
+                  <input
+                    type="text"
+                    value={detectedModel || e.model || ''}
+                    onChange={(ev) => updateEdit(item.routerId, { model: ev.target.value })}
+                    disabled={!isAdmin || !!detectedModel}
+                    className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary disabled:opacity-60"
+                    placeholder={detectedModel ? '' : 'glinet-flint2'}
+                  />
+                </label>
+                <label className="flex flex-col gap-1">
                   <span className="text-caption text-text-muted">{t('firmwareUpgrades.currentVersion')}</span>
                   <input
                     type="text"
-                    value={e.currentVersion ?? ''}
+                    value={detectedCurrent}
                     onChange={(ev) => updateEdit(item.routerId, { currentVersion: ev.target.value })}
-                    disabled={!isAdmin}
+                    disabled={!isAdmin || !!item.detectedVersion}
                     className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary disabled:opacity-60"
-                    placeholder="23.05.3"
+                    placeholder={item.detectedVersion ? '' : '23.05.3'}
                   />
                 </label>
                 <label className="flex flex-col gap-1">
                   <span className="text-caption text-text-muted">{t('firmwareUpgrades.targetVersion')} *</span>
-                  <input
-                    type="text"
-                    value={e.targetVersion ?? ''}
+                  <select
+                    value={targetSel}
                     onChange={(ev) => updateEdit(item.routerId, { targetVersion: ev.target.value })}
-                    disabled={!isAdmin}
-                    className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary disabled:opacity-60"
-                    placeholder="23.05.4"
-                  />
-                </label>
-                <label className="flex flex-col gap-1">
-                  <span className="text-caption text-text-muted">{t('firmwareUpgrades.model')} *</span>
-                  <input
-                    type="text"
-                    value={e.model ?? ''}
-                    onChange={(ev) => updateEdit(item.routerId, { model: ev.target.value })}
-                    disabled={!isAdmin}
-                    className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary disabled:opacity-60"
-                    placeholder="glinet-flint2"
-                  />
-                </label>
-                <label className="flex flex-col gap-1 sm:col-span-2">
-                  <span className="text-caption text-text-muted">{t('firmwareUpgrades.targetUrl')} *</span>
-                  <input
-                    type="text"
-                    value={e.targetUrl ?? ''}
-                    onChange={(ev) => updateEdit(item.routerId, { targetUrl: ev.target.value })}
-                    disabled={!isAdmin}
-                    className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary disabled:opacity-60"
-                    placeholder="https://downloads.openwrt.org/.../openwrt-...-squashfs-sysupgrade.bin"
-                  />
-                </label>
-                <label className="flex flex-col gap-1">
-                  <span className="text-caption text-text-muted">{t('firmwareUpgrades.checksum')}</span>
-                  <input
-                    type="text"
-                    value={e.checksum ?? ''}
-                    onChange={(ev) => updateEdit(item.routerId, { checksum: ev.target.value })}
-                    disabled={!isAdmin}
-                    className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary disabled:opacity-60"
-                    placeholder="sha256"
-                  />
+                    disabled={!isAdmin || active || versionsBusy[item.routerId]}
+                    className="h-[38px] rounded-lg border border-border bg-canvas px-3 text-sm text-text-primary disabled:opacity-60"
+                  >
+                    {opts.length === 0 && <option value="">{t('firmwareUpgrades.notDetected')}</option>}
+                    {opts.map((v) => {
+                      const info = versions?.versions.find((x) => x.version === v)
+                      const label = [
+                        v,
+                        v === currentVer ? t('firmwareUpgrades.installedTag') : '',
+                        info?.latest ? t('firmwareUpgrades.latestTag') : '',
+                      ]
+                        .filter(Boolean)
+                        .join(' · ')
+                      return (
+                        <option key={v} value={v}>
+                          {label}
+                        </option>
+                      )
+                    })}
+                  </select>
                 </label>
               </div>
 
-              {detectedBits.length > 0 && (
-                <div className="mt-3 flex items-center gap-2">
-                  <p className="flex items-center gap-1.5 text-xs text-text-muted">
-                    <Radar className="h-3.5 w-3.5 shrink-0 text-accent" strokeWidth={1.75} />
-                    <span>
-                      <span className="font-medium text-text-secondary">{t('firmwareUpgrades.detectedPrefix')}</span>{' '}
-                      {detectedBits.join(' · ')}
-                    </span>
-                  </p>
-                  {isAdmin && item.detectedBoard && (
-                    <button
-                      type="button"
-                      onClick={() => void resolveImage(item.routerId)}
-                      disabled={resolveBusy[item.routerId]}
-                      className="ml-auto flex shrink-0 items-center gap-1.5 rounded-lg border border-border bg-elevated px-2.5 py-1.5 text-xs font-medium text-text-secondary transition-colors duration-150 hover:border-accent/40 hover:text-accent disabled:opacity-50"
-                    >
-                      <Radar className={cn('h-3.5 w-3.5', resolveBusy[item.routerId] && 'animate-pulse')} strokeWidth={1.75} />
-                      {resolveBusy[item.routerId]
-                        ? t('firmwareUpgrades.detectImageBusy')
-                        : t('firmwareUpgrades.detectImage')}
-                    </button>
-                  )}
+              {majorWarn && (
+                <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-300">
+                  <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={1.75} />
+                  <span>{t('firmwareUpgrades.majorWarn', { from: detectedCurrent, to: targetSel })}</span>
                 </div>
               )}
 
-              {isAdmin && (
-                <div className="mt-4 border-t border-border pt-3">
-                  <button
-                    type="button"
-                    onClick={() => void runOwutCheck(item.routerId)}
-                    disabled={owutBusy[item.routerId]}
-                    className="inline-flex h-9 items-center gap-2 rounded-lg border border-border bg-elevated px-3 text-sm font-medium text-text-primary transition-colors hover:bg-canvas disabled:opacity-50"
-                  >
-                    <Terminal className={cn('h-4 w-4', owutBusy[item.routerId] && 'animate-pulse')} strokeWidth={1.75} />
-                    {owutBusy[item.routerId] ? t('firmwareUpgrades.owutBusy') : t('firmwareUpgrades.owutCheck')}
-                  </button>
-                  {owut && (
-                    <div className="mt-3 space-y-2">
-                      {!owut.owutAvailable && (
-                        <div className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-300">
-                          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={1.75} />
-                          <span>{t('firmwareUpgrades.owutUnavailable')}</span>
-                        </div>
-                      )}
-                      {owut.error && (
-                        <div className="flex items-start gap-2 rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-600 dark:text-rose-400">
-                          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={1.75} />
-                          <span>{t('firmwareUpgrades.owutCheckFailed')}</span>
-                        </div>
-                      )}
-                      {owut.checkRan && owut.buildable && owut.upgradeAvailable && (
-                        <div className="flex items-start gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2.5 text-sm text-emerald-700 dark:text-emerald-300">
-                          <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={1.75} />
-                          <span>{t('firmwareUpgrades.owutUpgradeAvailable')}</span>
-                        </div>
-                      )}
-                      {owut.checkRan && owut.buildable && !owut.upgradeAvailable && (
-                        <div className="flex items-start gap-2 rounded-lg border border-border bg-canvas px-3 py-2.5 text-sm text-text-secondary">
-                          <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-text-muted" strokeWidth={1.75} />
-                          <span>{t('firmwareUpgrades.owutUpToDate')}</span>
-                        </div>
-                      )}
-                      {owut.checkRan && !owut.buildable && (
-                        <div className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 text-sm text-amber-700 dark:text-amber-300">
-                          <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={1.75} />
-                          <span>{t('firmwareUpgrades.owutNotBuildable')}</span>
-                        </div>
-                      )}
-                      {owut.rawOutput && (
-                        <details className="rounded-lg border border-border bg-canvas px-3 py-2">
-                          <summary className="cursor-pointer text-sm font-medium text-text-secondary">
-                            {t('firmwareUpgrades.owutOutput')}
-                          </summary>
-                          <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-all font-mono text-xs leading-relaxed text-text-secondary">
-                            {owut.rawOutput}
-                          </pre>
-                        </details>
-                      )}
+              <details className="mt-3 rounded-lg border border-border bg-canvas px-3 py-2">
+                <summary className="cursor-pointer text-sm font-medium text-text-secondary">
+                  {t('firmwareUpgrades.advanced')}
+                </summary>
+                <div className="mt-3 grid gap-4 sm:grid-cols-2">
+                  <label className="flex flex-col gap-1 sm:col-span-2">
+                    <span className="text-caption text-text-muted">{t('firmwareUpgrades.targetUrl')}</span>
+                    <input
+                      type="text"
+                      value={e.targetUrl ?? ''}
+                      onChange={(ev) => updateEdit(item.routerId, { targetUrl: ev.target.value })}
+                      disabled={!isAdmin}
+                      className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary disabled:opacity-60"
+                      placeholder="https://downloads.openwrt.org/.../openwrt-...-squashfs-sysupgrade.bin"
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-caption text-text-muted">{t('firmwareUpgrades.checksum')}</span>
+                    <input
+                      type="text"
+                      value={e.checksum ?? ''}
+                      onChange={(ev) => updateEdit(item.routerId, { checksum: ev.target.value })}
+                      disabled={!isAdmin}
+                      className="rounded-lg border border-border bg-canvas px-3 py-2 text-sm text-text-primary disabled:opacity-60"
+                      placeholder="sha256"
+                    />
+                  </label>
+                  {isAdmin && item.detectedBoard && (
+                    <div className="flex items-end">
+                      <button
+                        type="button"
+                        onClick={() => void resolveImage(item.routerId)}
+                        disabled={resolveBusy[item.routerId]}
+                        className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-border bg-elevated px-3 text-xs font-medium text-text-secondary transition-colors duration-150 hover:border-accent/40 hover:text-accent disabled:opacity-50"
+                      >
+                        <Radar className={cn('h-3.5 w-3.5', resolveBusy[item.routerId] && 'animate-pulse')} strokeWidth={1.75} />
+                        {resolveBusy[item.routerId] ? t('firmwareUpgrades.detectImageBusy') : t('firmwareUpgrades.detectImage')}
+                      </button>
                     </div>
+                  )}
+                </div>
+              </details>
+
+              {owut && (
+                <div className="mt-3 space-y-2">
+                  {owut.error && (
+                    <div className="flex items-start gap-2 rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-600 dark:text-rose-400">
+                      <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={1.75} />
+                      <span>{t('firmwareUpgrades.owutCheckFailed')}</span>
+                    </div>
+                  )}
+                  {owut.checkRan && owut.buildable && owut.upgradeAvailable && (
+                    <div className="flex items-start gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2.5 text-sm text-emerald-700 dark:text-emerald-300">
+                      <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={1.75} />
+                      <span>{t('firmwareUpgrades.owutUpgradeAvailable')}</span>
+                    </div>
+                  )}
+                  {owut.checkRan && owut.buildable && !owut.upgradeAvailable && (
+                    <div className="flex items-start gap-2 rounded-lg border border-border bg-canvas px-3 py-2.5 text-sm text-text-secondary">
+                      <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-text-muted" strokeWidth={1.75} />
+                      <span>{t('firmwareUpgrades.owutUpToDate')}</span>
+                    </div>
+                  )}
+                  {owut.checkRan && !owut.buildable && (
+                    <div className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 text-sm text-amber-700 dark:text-amber-300">
+                      <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={1.75} />
+                      <span>{t('firmwareUpgrades.owutNotBuildable')}</span>
+                    </div>
+                  )}
+                  {owut.rawOutput && (
+                    <details className="rounded-lg border border-border bg-canvas px-3 py-2">
+                      <summary className="cursor-pointer text-sm font-medium text-text-secondary">
+                        {t('firmwareUpgrades.owutOutput')}
+                      </summary>
+                      <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-all font-mono text-xs leading-relaxed text-text-secondary">
+                        {owut.rawOutput}
+                      </pre>
+                    </details>
                   )}
                 </div>
               )}
@@ -539,18 +709,68 @@ export default function FirmwareUpgrades() {
               )}
 
               {isAdmin && (
-                <div className="mt-4 flex flex-wrap items-center gap-3">
-                  <button
-                    onClick={() => saveTarget(item.routerId)}
-                    disabled={busy[item.routerId] === 'save' || !e.targetVersion || !e.targetUrl || !e.model}
-                    className="inline-flex h-9 items-center gap-2 rounded-lg bg-accent px-4 text-sm font-medium text-canvas transition-colors hover:bg-accent/90 disabled:opacity-50"
-                  >
-                    {busy[item.routerId] === 'save' ? t('common.loading') : t('common.save')}
-                  </button>
+                <div className="mt-4 space-y-3 border-t border-border pt-3">
+                  <div className="flex flex-wrap items-center gap-3">
+                    {!owutAvail && versions !== undefined && (
+                      <button
+                        type="button"
+                        onClick={() => void installOwut(item.routerId)}
+                        disabled={installBusy[item.routerId]}
+                        className="inline-flex h-9 items-center gap-2 rounded-lg border border-border bg-elevated px-4 text-sm font-medium text-text-primary transition-colors hover:bg-canvas disabled:opacity-50"
+                      >
+                        <Download className={cn('h-4 w-4', installBusy[item.routerId] && 'animate-pulse')} strokeWidth={1.75} />
+                        {installBusy[item.routerId] ? t('firmwareUpgrades.installingOwut') : t('firmwareUpgrades.installOwut')}
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => void runOwutCheck(item.routerId)}
+                      disabled={owutBusy[item.routerId] || !owutAvail}
+                      title={!owutAvail ? t('firmwareUpgrades.owutUnavailable') : undefined}
+                      className="inline-flex h-9 items-center gap-2 rounded-lg border border-border bg-elevated px-4 text-sm font-medium text-text-primary transition-colors hover:bg-canvas disabled:opacity-50"
+                    >
+                      <Terminal className={cn('h-4 w-4', owutBusy[item.routerId] && 'animate-pulse')} strokeWidth={1.75} />
+                      {owutBusy[item.routerId] ? t('firmwareUpgrades.owutBusy') : t('firmwareUpgrades.check')}
+                    </button>
+                    <button
+                      onClick={() => saveTarget(item.routerId)}
+                      disabled={busy[item.routerId] === 'save' || !e.targetVersion || !e.model}
+                      className="inline-flex h-9 items-center gap-2 rounded-lg bg-accent px-4 text-sm font-medium text-canvas transition-colors hover:bg-accent/90 disabled:opacity-50"
+                    >
+                      {busy[item.routerId] === 'save' ? t('common.loading') : t('common.save')}
+                    </button>
+                    <button
+                      onClick={() => {
+                        if (owutAvail) setOwutConfirmId(item.routerId)
+                        else setConfirmId(item.routerId)
+                      }}
+                      disabled={active || busy[item.routerId] === 'upgrade' || scheduled || !targetSel}
+                      className="inline-flex h-9 items-center gap-2 rounded-lg border border-border bg-elevated px-4 text-sm font-medium text-text-primary transition-colors hover:bg-canvas disabled:opacity-50"
+                    >
+                      {active
+                        ? t('firmwareUpgrades.inProgress')
+                        : busy[item.routerId] === 'upgrade'
+                          ? t('common.loading')
+                          : t('firmwareUpgrades.upgrade')}
+                    </button>
+                    <button
+                      onClick={() => {
+                        const rc = recurrence[item.routerId]
+                        setRecKind(rc?.enabled ? rc.kind : 'once')
+                        setRecAt('')
+                        setScheduleId(item.routerId)
+                      }}
+                      disabled={active}
+                      className="inline-flex h-9 items-center gap-2 rounded-lg border border-border bg-elevated px-4 text-sm font-medium text-text-primary transition-colors hover:bg-canvas disabled:opacity-50"
+                    >
+                      <CalendarClock className="h-4 w-4 text-accent" strokeWidth={1.75} />
+                      {t('firmwareUpgrades.schedule')}
+                    </button>
+                  </div>
+
                   {scheduled ? (
-                    // #494: programación pendiente → hora + cancelar (sin
-                    // "actualizar ahora" para no pisar la fila programada).
-                    <>
+                    // #494: programación one-shot pendiente (legacy).
+                    <div className="flex flex-wrap items-center gap-3">
                       <span className="inline-flex items-center gap-1.5 text-sm text-text-secondary">
                         <CalendarClock className="h-4 w-4 text-accent" strokeWidth={1.75} />
                         {t('firmwareUpgrades.scheduledFor', {
@@ -564,37 +784,24 @@ export default function FirmwareUpgrades() {
                       >
                         {busy[item.routerId] === 'cancel' ? t('common.loading') : t('firmwareUpgrades.cancelSchedule')}
                       </button>
-                    </>
-                  ) : (
-                    <>
+                    </div>
+                  ) : rec?.enabled ? (
+                    <div className="flex flex-wrap items-center gap-3">
+                      <span className="inline-flex items-center gap-1.5 text-sm text-text-secondary">
+                        <CalendarClock className="h-4 w-4 text-accent" strokeWidth={1.75} />
+                        {t('firmwareUpgrades.recScheduled', {
+                          when: (recNext[item.routerId] ?? 0) > 0 ? new Date(recNext[item.routerId] ?? 0).toLocaleString() : '',
+                          kind: t(`firmwareUpgrades.rec_${rec.kind}`),
+                        })}
+                      </span>
                       <button
-                        onClick={() => setConfirmId(item.routerId)}
-                        disabled={active || busy[item.routerId] === 'upgrade' || !item.targetVersion}
+                        onClick={() => void removeRecurrence(item.routerId)}
                         className="inline-flex h-9 items-center gap-2 rounded-lg border border-border bg-elevated px-4 text-sm font-medium text-text-primary transition-colors hover:bg-canvas disabled:opacity-50"
                       >
-                        {active
-                          ? t('firmwareUpgrades.inProgress')
-                          : busy[item.routerId] === 'upgrade'
-                            ? t('common.loading')
-                            : t('firmwareUpgrades.upgrade')}
+                        {t('firmwareUpgrades.recRemove')}
                       </button>
-                      <input
-                        type="datetime-local"
-                        value={scheduleAt[item.routerId] ?? ''}
-                        onChange={(ev) => setScheduleAt((prev) => ({ ...prev, [item.routerId]: ev.target.value }))}
-                        disabled={active || !item.targetVersion}
-                        aria-label={t('firmwareUpgrades.scheduleAt')}
-                        className="h-9 rounded-lg border border-border bg-canvas px-3 text-sm text-text-primary disabled:opacity-60"
-                      />
-                      <button
-                        onClick={() => void scheduleUpgrade(item.routerId)}
-                        disabled={active || busy[item.routerId] === 'schedule' || !scheduleAt[item.routerId] || !item.targetVersion}
-                        className="inline-flex h-9 items-center gap-2 rounded-lg border border-border bg-elevated px-4 text-sm font-medium text-text-primary transition-colors hover:bg-canvas disabled:opacity-50"
-                      >
-                        {busy[item.routerId] === 'schedule' ? t('common.loading') : t('firmwareUpgrades.schedule')}
-                      </button>
-                    </>
-                  )}
+                    </div>
+                  ) : null}
                 </div>
               )}
             </div>
@@ -602,8 +809,7 @@ export default function FirmwareUpgrades() {
         })}
       </div>
 
-      {/* #477: confirmación antes de descargar/flashear, con el resumen del
-          target guardado y los avisos de verificación y reinicio. */}
+      {/* #477: confirmación del motor clásico (URL + checksum). */}
       <AlertDialog open={!!confirmItem} onOpenChange={(open) => !open && setConfirmId(null)}>
         <AlertDialogContent className="max-w-lg">
           <AlertDialogHeader>
@@ -670,6 +876,187 @@ export default function FirmwareUpgrades() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* #761: confirmación owut/ASU (actualizar desde lo detectado). */}
+      <AlertDialog open={!!owutConfirm} onOpenChange={(open) => !open && setOwutConfirmId(null)}>
+        <AlertDialogContent className="max-w-lg">
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('firmwareUpgrades.owutConfirmTitle')}</AlertDialogTitle>
+            <AlertDialogDescription>{t('firmwareUpgrades.owutConfirmBody')}</AlertDialogDescription>
+          </AlertDialogHeader>
+
+          {owutConfirm && (
+            <div className="space-y-3">
+              <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+                <dt className="text-text-muted">{t('firmwareUpgrades.confirmRouter')}</dt>
+                <dd className="min-w-0 font-medium text-text-primary">{owutConfirmName}</dd>
+                <dt className="text-text-muted">{t('firmwareUpgrades.confirmVersion')}</dt>
+                <dd className="font-mono text-text-primary">
+                  {owutConfirm.detectedVersion || owutConfirm.currentVersion || t('common.unknown')} →{' '}
+                  {edits[owutConfirm.routerId]?.targetVersion}
+                </dd>
+              </dl>
+
+              <div className="flex items-start gap-2.5 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2.5 text-sm text-emerald-700 dark:text-emerald-300">
+                <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={1.75} />
+                <span>{t('firmwareUpgrades.owutConfirmPackages')}</span>
+              </div>
+
+              <div className="flex items-start gap-2.5 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 text-sm text-amber-700 dark:text-amber-300">
+                <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={1.75} />
+                <span>{t('firmwareUpgrades.owutConfirmVendor')}</span>
+              </div>
+
+              <div className="flex items-start gap-2.5 rounded-lg border border-border bg-canvas px-3 py-2.5 text-sm text-text-secondary">
+                <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-text-muted" strokeWidth={1.75} />
+                <span>{t('firmwareUpgrades.confirmDowntime')}</span>
+              </div>
+            </div>
+          )}
+
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault()
+                if (!owutConfirmId) return
+                const id = owutConfirmId
+                setOwutConfirmId(null)
+                void startOwutUpgrade(id)
+              }}
+              disabled={!!owutConfirmId && busy[owutConfirmId] === 'upgrade'}
+            >
+              <Rocket className="mr-1.5 h-4 w-4" strokeWidth={2} />
+              {owutConfirmId && busy[owutConfirmId] === 'upgrade' ? t('common.loading') : t('firmwareUpgrades.confirmAction')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* #761: diálogo de programación (fecha/hora + recurrencia). */}
+      <AlertDialog open={!!scheduleItem} onOpenChange={(open) => !open && setScheduleId(null)}>
+        <AlertDialogContent className="max-w-md">
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('firmwareUpgrades.scheduleTitle')}</AlertDialogTitle>
+            <AlertDialogDescription>{t('firmwareUpgrades.scheduleBody')}</AlertDialogDescription>
+          </AlertDialogHeader>
+
+          {scheduleItem && (
+            <div className="space-y-4">
+              <p className="text-sm text-text-secondary">
+                {scheduleName} · <span className="font-mono">{detectedVersionOf(scheduleItem) || t('common.unknown')}</span> →{' '}
+                <span className="font-mono">{edits[scheduleItem.routerId]?.targetVersion}</span>
+              </p>
+
+              <div className="flex gap-2">
+                {(['once', 'weekly', 'monthly'] as const).map((k) => (
+                  <button
+                    key={k}
+                    type="button"
+                    onClick={() => setRecKind(k)}
+                    className={cn(
+                      'h-9 flex-1 rounded-lg border px-3 text-sm font-medium transition-colors',
+                      recKind === k
+                        ? 'border-accent bg-accent/10 text-accent'
+                        : 'border-border bg-canvas text-text-secondary hover:bg-elevated'
+                    )}
+                  >
+                    {t(`firmwareUpgrades.rec_${k}`)}
+                  </button>
+                ))}
+              </div>
+
+              {recKind === 'once' && (
+                <label className="flex flex-col gap-1">
+                  <span className="text-caption text-text-muted">{t('firmwareUpgrades.recDate')}</span>
+                  <input
+                    type="datetime-local"
+                    value={recAt}
+                    onChange={(ev) => setRecAt(ev.target.value)}
+                    className="h-9 rounded-lg border border-border bg-canvas px-3 text-sm text-text-primary"
+                  />
+                </label>
+              )}
+              {recKind === 'weekly' && (
+                <div className="grid grid-cols-2 gap-3">
+                  <label className="flex flex-col gap-1">
+                    <span className="text-caption text-text-muted">{t('firmwareUpgrades.recDay')}</span>
+                    <select
+                      value={recDow}
+                      onChange={(ev) => setRecDow(Number(ev.target.value))}
+                      className="h-9 rounded-lg border border-border bg-canvas px-3 text-sm text-text-primary"
+                    >
+                      {[0, 1, 2, 3, 4, 5, 6].map((d) => (
+                        <option key={d} value={d}>
+                          {dowLabel(i18n.language, d)}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-caption text-text-muted">{t('firmwareUpgrades.recTime')}</span>
+                    <input
+                      type="time"
+                      value={recTime}
+                      onChange={(ev) => setRecTime(ev.target.value)}
+                      className="h-9 rounded-lg border border-border bg-canvas px-3 text-sm text-text-primary"
+                    />
+                  </label>
+                </div>
+              )}
+              {recKind === 'monthly' && (
+                <div className="grid grid-cols-2 gap-3">
+                  <label className="flex flex-col gap-1">
+                    <span className="text-caption text-text-muted">{t('firmwareUpgrades.recDayOfMonth')}</span>
+                    <select
+                      value={recDom}
+                      onChange={(ev) => setRecDom(Number(ev.target.value))}
+                      className="h-9 rounded-lg border border-border bg-canvas px-3 text-sm text-text-primary"
+                    >
+                      {Array.from({ length: 31 }, (_, i) => i + 1).map((d) => (
+                        <option key={d} value={d}>
+                          {d}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-caption text-text-muted">{t('firmwareUpgrades.recTime')}</span>
+                    <input
+                      type="time"
+                      value={recTime}
+                      onChange={(ev) => setRecTime(ev.target.value)}
+                      className="h-9 rounded-lg border border-border bg-canvas px-3 text-sm text-text-primary"
+                    />
+                  </label>
+                </div>
+              )}
+
+              <p className="text-xs text-text-muted">{t('firmwareUpgrades.recIdempotentHint')}</p>
+            </div>
+          )}
+
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault()
+                if (!scheduleId) return
+                const id = scheduleId
+                setScheduleId(null)
+                void saveRecurrence(id)
+              }}
+            >
+              <CalendarClock className="mr-1.5 h-4 w-4" strokeWidth={2} />
+              {t('firmwareUpgrades.schedule')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
+}
+
+function detectedVersionOf(item: FirmwareItem): string {
+  return item.detectedVersion || item.currentVersion || ''
 }

--- a/app/src/pages/FirmwareUpgrades.tsx
+++ b/app/src/pages/FirmwareUpgrades.tsx
@@ -131,13 +131,15 @@ export default function FirmwareUpgrades() {
   const [versionsBusy, setVersionsBusy] = useState<Record<string, boolean>>({})
   const [installBusy, setInstallBusy] = useState<Record<string, boolean>>({})
   const [owutConfirmId, setOwutConfirmId] = useState<string | null>(null)
+  // #761: paquetes a excluir de la build ASU (locales sin feed, p. ej. netgrip).
+  const [removePkgs, setRemovePkgs] = useState<Record<string, string>>({})
   // #761: programación recurrente.
   const [recurrence, setRecurrence] = useState<Record<string, RecurrenceCfg>>({})
   const [recNext, setRecNext] = useState<Record<string, number>>({})
   const [scheduleId, setScheduleId] = useState<string | null>(null)
   const [recKind, setRecKind] = useState<'once' | 'weekly' | 'monthly'>('once')
   const [recAt, setRecAt] = useState('')
-  const [recDow, setRecDow] = useState(5)
+  const [recDow, setRecDow] = useState(1)
   const [recDom, setRecDom] = useState(1)
   const [recTime, setRecTime] = useState('04:00')
 
@@ -160,7 +162,7 @@ export default function FirmwareUpgrades() {
         initialEdits[it.routerId] = {
           model: it.detectedBoard || it.detectedModel || it.model || '',
           currentVersion: it.detectedVersion || it.currentVersion || '',
-          targetVersion: it.targetVersion,
+          targetVersion: it.targetVersion || it.detectedVersion || '',
           targetUrl: it.targetUrl,
           checksum: it.checksum,
         }
@@ -373,7 +375,10 @@ export default function FirmwareUpgrades() {
       const res = await fetch(`/api/firmware-upgrades/${encodeURIComponent(id)}/owut-upgrade`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ targetVersion: e.targetVersion }),
+        body: JSON.stringify({
+          targetVersion: e.targetVersion,
+          removePackages: (removePkgs[id] ?? '').split(/[\s,]+/).filter(Boolean),
+        }),
       })
       const body = await res.json().catch(() => ({}))
       if (!res.ok) throw new Error(body?.error?.message ?? body?.message ?? `HTTP ${res.status}`)
@@ -675,7 +680,9 @@ export default function FirmwareUpgrades() {
                   {owut.checkRan && !owut.buildable && (
                     <div className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 text-sm text-amber-700 dark:text-amber-300">
                       <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={1.75} />
-                      <span>{t('firmwareUpgrades.owutNotBuildable')}</span>
+                      <span>
+                        {t('firmwareUpgrades.owutNotBuildable')} {t('firmwareUpgrades.owutNotBuildableHint')}
+                      </span>
                     </div>
                   )}
                   {owut.rawOutput && (
@@ -915,6 +922,18 @@ export default function FirmwareUpgrades() {
                 <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-text-muted" strokeWidth={1.75} />
                 <span>{t('firmwareUpgrades.confirmDowntime')}</span>
               </div>
+
+              <label className="flex flex-col gap-1">
+                <span className="text-caption text-text-muted">{t('firmwareUpgrades.excludePkgs')}</span>
+                <input
+                  type="text"
+                  value={removePkgs[owutConfirm.routerId] ?? ''}
+                  onChange={(ev) => setRemovePkgs((prev) => ({ ...prev, [owutConfirm.routerId]: ev.target.value }))}
+                  placeholder="netgrip"
+                  className="rounded-lg border border-border bg-canvas px-3 py-2 font-mono text-sm text-text-primary"
+                />
+                <span className="text-xs text-text-muted">{t('firmwareUpgrades.excludePkgsHint')}</span>
+              </label>
             </div>
           )}
 
@@ -990,7 +1009,7 @@ export default function FirmwareUpgrades() {
                       onChange={(ev) => setRecDow(Number(ev.target.value))}
                       className="h-9 rounded-lg border border-border bg-canvas px-3 text-sm text-text-primary"
                     >
-                      {[0, 1, 2, 3, 4, 5, 6].map((d) => (
+                      {[1, 2, 3, 4, 5, 6, 0].map((d) => (
                         <option key={d} value={d}>
                           {dowLabel(i18n.language, d)}
                         </option>

--- a/app/src/pages/FirmwareUpgrades.tsx
+++ b/app/src/pages/FirmwareUpgrades.tsx
@@ -69,6 +69,7 @@ interface OwutVersion {
 interface OwutVersionsResp {
   current: string
   owutAvailable: boolean
+  vendorFirmware?: string
   versions: OwutVersion[]
   error?: string
 }
@@ -512,7 +513,8 @@ export default function FirmwareUpgrades() {
           const scheduled = scheduledPending(item)
           const owut = owutResult[item.routerId]
           const versions = owutVersions[item.routerId]
-          const owutAvail = owut?.owutAvailable ?? versions?.owutAvailable ?? false
+          const vendorFw = versions?.vendorFirmware
+          const owutAvail = !vendorFw && (owut?.owutAvailable ?? versions?.owutAvailable ?? false)
           const detectedCurrent = item.detectedVersion || e.currentVersion || ''
           const detectedModel = item.detectedBoard || item.detectedModel || ''
           const rec = recurrence[item.routerId]
@@ -579,6 +581,7 @@ export default function FirmwareUpgrades() {
                     placeholder={item.detectedVersion ? '' : '23.05.3'}
                   />
                 </label>
+                {!vendorFw && (
                 <label className="flex flex-col gap-1">
                   <span className="text-caption text-text-muted">{t('firmwareUpgrades.targetVersion')} *</span>
                   <select
@@ -605,15 +608,24 @@ export default function FirmwareUpgrades() {
                     })}
                   </select>
                 </label>
+                )}
               </div>
 
-              {majorWarn && (
+              {vendorFw && (
+                <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 text-sm text-amber-700 dark:text-amber-300">
+                  <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={1.75} />
+                  <span>{t('firmwareUpgrades.vendorNote')}</span>
+                </div>
+              )}
+
+              {!vendorFw && majorWarn && (
                 <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-300">
                   <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={1.75} />
                   <span>{t('firmwareUpgrades.majorWarn', { from: detectedCurrent, to: targetSel })}</span>
                 </div>
               )}
 
+              {!vendorFw && (
               <details className="mt-3 rounded-lg border border-border bg-canvas px-3 py-2">
                 <summary className="cursor-pointer text-sm font-medium text-text-secondary">
                   {t('firmwareUpgrades.advanced')}
@@ -656,6 +668,7 @@ export default function FirmwareUpgrades() {
                   )}
                 </div>
               </details>
+              )}
 
               {owut && (
                 <div className="mt-3 space-y-2">
@@ -719,7 +732,7 @@ export default function FirmwareUpgrades() {
                 </div>
               )}
 
-              {isAdmin && (
+              {isAdmin && !vendorFw && (
                 <div className="mt-4 space-y-3 border-t border-border pt-3">
                   <div className="flex flex-wrap items-center gap-3">
                     {!owutAvail && versions !== undefined && (

--- a/app/src/pages/FirmwareUpgrades.tsx
+++ b/app/src/pages/FirmwareUpgrades.tsx
@@ -99,6 +99,10 @@ const STATUS_COLORS: Record<string, string> = {
   scheduled: 'bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 border-indigo-500/30',
 }
 
+/** Paquetes del propio stack: sus ficheros sobreviven al update
+ * (NetPulse los añade a /etc/sysupgrade.conf antes de flashear). */
+const STACK_PKGS = new Set(['netgrip', 'netpulse-agent', 'owpanel'])
+
 /** versionRe: misma regla que el backend para aceptar un targetVersion. */
 const versionRe = /^\d+\.\d+(\.\d+)?(-[a-zA-Z0-9.]+)?$/
 
@@ -721,7 +725,9 @@ export default function FirmwareUpgrades() {
                       <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={1.75} />
                       <span>
                         {owut.missingPkgs?.length
-                          ? t('firmwareUpgrades.missingPkgsBanner', { pkgs: owut.missingPkgs.join(', ') })
+                          ? (owut.missingPkgs as string[]).some((pkg) => STACK_PKGS.has(pkg))
+                            ? t('firmwareUpgrades.missingPkgsBannerStack', { pkgs: owut.missingPkgs.join(', ') })
+                            : t('firmwareUpgrades.missingPkgsBanner', { pkgs: owut.missingPkgs.join(', ') })
                           : `${t('firmwareUpgrades.owutNotBuildable')} ${t('firmwareUpgrades.owutNotBuildableHint')}`}
                       </span>
                     </div>

--- a/app/src/pages/FirmwareUpgrades.tsx
+++ b/app/src/pages/FirmwareUpgrades.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNetPulse } from '@/data/DataProvider'
 import { useAuth } from '@/data/AuthContext'
-import { AlertCircle, CalendarClock, Cpu, Radar, RefreshCw, Rocket, ShieldCheck, Terminal, TriangleAlert, Download } from 'lucide-react'
+import { AlertCircle, CalendarClock, Cpu, PartyPopper, Radar, RefreshCw, Rocket, ShieldCheck, Terminal, TriangleAlert, Download } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { relTimeFromTs } from '@/i18n'
 import {
@@ -142,6 +142,8 @@ export default function FirmwareUpgrades() {
   const [owutConfirmId, setOwutConfirmId] = useState<string | null>(null)
   // #761: paquetes a excluir de la build ASU (locales sin feed, p. ej. netgrip).
   const [removePkgs, setRemovePkgs] = useState<Record<string, string>>({})
+  // #761: upgrade done cuya fiesta ya se cerro (routerId -> upgrade.id).
+  const [dismissedDone, setDismissedDone] = useState<Record<string, number>>({})
   // #761: programación recurrente.
   const [recurrence, setRecurrence] = useState<Record<string, RecurrenceCfg>>({})
   const [recNext, setRecNext] = useState<Record<string, number>>({})
@@ -164,6 +166,23 @@ export default function FirmwareUpgrades() {
       if (!res.ok) throw new Error(await res.text())
       const data = (await res.json()) as FirmwareItem[]
       setItems(data)
+      // #761: al completar un upgrade, el check previo (banner verde / salida)
+      // queda caduco: fuera, que no vuelva tras el exito.
+      const nowMs = Date.now()
+      data.forEach((it) => {
+        if (
+          it.upgrade?.status === 'done' &&
+          it.upgrade.finishedAt &&
+          nowMs / 1000 - it.upgrade.finishedAt < 600
+        ) {
+          setOwutResult((prev) => {
+            if (!prev[it.routerId]) return prev
+            const next = { ...prev }
+            delete next[it.routerId]
+            return next
+          })
+        }
+      })
       const initialEdits: Record<string, Partial<FirmwareItem>> = {}
       data.forEach((it) => {
         // #477 P2 / #761: modelo y versión actual SIEMPRE prefilleados con
@@ -555,6 +574,57 @@ export default function FirmwareUpgrades() {
             .forEach((v) => {
               if (!opts.includes(v.version)) opts.push(v.version)
             })
+          // #761: exito reciente (owut done < 10 min sin cerrar): fiesta.
+          const justDone =
+            item.upgrade &&
+            item.upgrade.status === 'done' &&
+            item.upgrade.engine === 'owut' &&
+            item.upgrade.finishedAt &&
+            Date.now() / 1000 - item.upgrade.finishedAt < 600 &&
+            dismissedDone[item.routerId] !== item.upgrade.id
+          if (justDone && item.upgrade) {
+            const up = item.upgrade
+            const dur = Math.max(1, (up.finishedAt ?? up.startedAt) - up.startedAt)
+            return (
+              <div key={item.routerId} className="rounded-2xl border border-emerald-500/30 bg-emerald-500/5 p-5" data-testid="fw-success">
+                <div className="mb-6 flex items-center gap-3">
+                  <Cpu className="h-5 w-5 text-accent" strokeWidth={1.75} />
+                  <div>
+                    <h2 className="text-base font-semibold text-text-primary">
+                      {sortedRouters.find((r) => r.id === item.routerId)?.name ?? item.name}
+                    </h2>
+                    <p className="text-xs text-text-muted">{detectedModel || item.model || t('common.unknown')}</p>
+                  </div>
+                </div>
+                <div className="flex flex-col items-center gap-3 py-6 text-center">
+                  <PartyPopper className="h-16 w-16 text-emerald-500" strokeWidth={1.5} />
+                  <p className="text-lg font-semibold text-text-primary">{t('firmwareUpgrades.successTitle')}</p>
+                  <p className="max-w-md text-sm text-text-secondary">
+                    {t('firmwareUpgrades.successBody', {
+                      to: up.targetVersion,
+                      dur: String(dur),
+                    })}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setDismissedDone((prev) => ({ ...prev, [item.routerId]: up.id }))
+                      setOwutResult((prev) => {
+                        if (!prev[item.routerId]) return prev
+                        const next = { ...prev }
+                        delete next[item.routerId]
+                        return next
+                      })
+                      void fetchItems()
+                    }}
+                    className="mt-2 inline-flex h-9 items-center gap-2 rounded-lg bg-accent px-4 text-sm font-medium text-canvas transition-colors hover:bg-accent/90"
+                  >
+                    {t('firmwareUpgrades.successDismiss')}
+                  </button>
+                </div>
+              </div>
+            )
+          }
           // #761: mientras corre el upgrade, la tarjeta ES el proceso (icono,
           // fase, barra y consola); el resto del formulario desaparece.
           if (active && item.upgrade) {

--- a/app/src/pages/FirmwareUpgrades.tsx
+++ b/app/src/pages/FirmwareUpgrades.tsx
@@ -513,15 +513,19 @@ export default function FirmwareUpgrades() {
           const rec = recurrence[item.routerId]
           const targetSel = e.targetVersion ?? ''
           const majorWarn = majorJumpJS(detectedCurrent, targetSel)
-          // Opciones del desplegable: detectada + todas las estables (desc).
+          // Opciones del desplegable (#761): la instalada + superiores (si
+          // las hubiera) + el target ya guardado (downgrade explícito previo).
           const currentVer = item.detectedVersion || ''
           const opts: string[] = []
           if (currentVer && !opts.includes(currentVer)) opts.push(currentVer)
-          if (item.targetVersion && !opts.includes(item.targetVersion)) opts.push(item.targetVersion)
-          const list = (versions?.versions ?? []).map((v) => v.version)
-          list.forEach((v) => {
-            if (!opts.includes(v)) opts.push(v)
-          })
+          if (item.targetVersion && item.targetVersion !== currentVer && !opts.includes(item.targetVersion)) {
+            opts.push(item.targetVersion)
+          }
+          ;(versions?.versions ?? [])
+            .filter((v) => v.newer)
+            .forEach((v) => {
+              if (!opts.includes(v.version)) opts.push(v.version)
+            })
           return (
             <div
               key={item.routerId}

--- a/app/src/pages/FirmwareUpgrades.tsx
+++ b/app/src/pages/FirmwareUpgrades.tsx
@@ -54,6 +54,7 @@ interface OwutStatus {
   checkRan: boolean
   upgradeAvailable: boolean
   buildable: boolean
+  missingPkgs?: string[]
   rawOutput?: string
   error?: string
 }
@@ -97,6 +98,9 @@ const STATUS_COLORS: Record<string, string> = {
   failed: 'bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/30',
   scheduled: 'bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 border-indigo-500/30',
 }
+
+/** versionRe: misma regla que el backend para aceptar un targetVersion. */
+const versionRe = /^\d+\.\d+(\.\d+)?(-[a-zA-Z0-9.]+)?$/
 
 /** majorJumpJS: mismo criterio que el backend (primer componente distinto). */
 function majorJumpJS(current: string, target: string): boolean {
@@ -525,7 +529,12 @@ export default function FirmwareUpgrades() {
           const currentVer = item.detectedVersion || ''
           const opts: string[] = []
           if (currentVer && !opts.includes(currentVer)) opts.push(currentVer)
-          if (item.targetVersion && item.targetVersion !== currentVer && !opts.includes(item.targetVersion)) {
+          if (
+            item.targetVersion &&
+            item.targetVersion !== currentVer &&
+            versionRe.test(item.targetVersion) &&
+            !opts.includes(item.targetVersion)
+          ) {
             opts.push(item.targetVersion)
           }
           ;(versions?.versions ?? [])
@@ -557,6 +566,23 @@ export default function FirmwareUpgrades() {
                   </span>
                 )}
               </div>
+
+              {active && item.upgrade && (
+                <div className="mb-4 flex items-start gap-2 rounded-lg border border-blue-500/30 bg-blue-500/10 px-3 py-2.5 text-sm text-blue-700 dark:text-blue-300">
+                  <RefreshCw className="mt-0.5 h-4 w-4 shrink-0 animate-pulse" strokeWidth={1.75} />
+                  <span>
+                    {item.upgrade.engine === 'owut'
+                      ? t('firmwareUpgrades.upgradeRunningOwut', {
+                          elapsed: relTimeFromTs(item.upgrade.startedAt),
+                          step:
+                            item.upgrade.status === 'rebooting'
+                              ? t('firmwareUpgrades.stepRebooting')
+                              : t('firmwareUpgrades.stepWorking'),
+                        })
+                      : t('firmwareUpgrades.inProgress')}
+                  </span>
+                </div>
+              )}
 
               <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                 <label className="flex flex-col gap-1">
@@ -694,7 +720,9 @@ export default function FirmwareUpgrades() {
                     <div className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 text-sm text-amber-700 dark:text-amber-300">
                       <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={1.75} />
                       <span>
-                        {t('firmwareUpgrades.owutNotBuildable')} {t('firmwareUpgrades.owutNotBuildableHint')}
+                        {owut.missingPkgs?.length
+                          ? t('firmwareUpgrades.missingPkgsBanner', { pkgs: owut.missingPkgs.join(', ') })
+                          : `${t('firmwareUpgrades.owutNotBuildable')} ${t('firmwareUpgrades.owutNotBuildableHint')}`}
                       </span>
                     </div>
                   )}
@@ -718,7 +746,7 @@ export default function FirmwareUpgrades() {
                   <span>
                     {t('firmwareUpgrades.lastFailure')}
                     {relTimeFromTs(item.upgrade.startedAt) ? ` (${relTimeFromTs(item.upgrade.startedAt)})` : ''}:{' '}
-                    {item.upgrade.error}
+                    {item.upgrade.error || t('firmwareUpgrades.emptyFailure')}
                   </span>
                   {isAdmin && (
                     <button
@@ -765,8 +793,15 @@ export default function FirmwareUpgrades() {
                     </button>
                     <button
                       onClick={() => {
-                        if (owutAvail) setOwutConfirmId(item.routerId)
-                        else setConfirmId(item.routerId)
+                        if (owutAvail) {
+                          const missing = owut?.missingPkgs ?? []
+                          if (missing.length && !(removePkgs[item.routerId] ?? '').trim()) {
+                            setRemovePkgs((prev) => ({ ...prev, [item.routerId]: missing.join(' ') }))
+                          }
+                          setOwutConfirmId(item.routerId)
+                        } else {
+                          setConfirmId(item.routerId)
+                        }
                       }}
                       disabled={active || busy[item.routerId] === 'upgrade' || scheduled || !targetSel}
                       className="inline-flex h-9 items-center gap-2 rounded-lg border border-border bg-elevated px-4 text-sm font-medium text-text-primary transition-colors hover:bg-canvas disabled:opacity-50"

--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -549,6 +549,7 @@ func run() error {
 		ConfigBackup:    cfgBackup,
 		Firmware:        fwStore,
 		Speedtest:       stScheduler,
+		AlertEmitter:    adapter.AlertsEngine(),
 		ChannelPlan:     chPlan,
 		LastOverview: func() *adapters.Overview {
 			return p.LastOverview()

--- a/server-go/internal/db/db.go
+++ b/server-go/internal/db/db.go
@@ -470,6 +470,8 @@ func Open(dataDir string, opts ...OpenOption) (*DB, error) {
 	migrate(sqldb, "routers", "temp_threshold", "ALTER TABLE routers ADD COLUMN temp_threshold INTEGER")
 	// issue #494: upgrades desatendidos programados (epoch ms UTC; NULL = manual).
 	migrate(sqldb, "firmware_upgrades", "scheduled_for", "ALTER TABLE firmware_upgrades ADD COLUMN scheduled_for INTEGER")
+	// issue #761: motor del upgrade ("" = clásico URL+checksum, "owut" = ASU).
+	migrate(sqldb, "firmware_upgrades", "engine", "ALTER TABLE firmware_upgrades ADD COLUMN engine TEXT NOT NULL DEFAULT ''")
 
 	// Si no hubo migración Node (instalación fresca creada por Go), marca la
 	// DB para que el siguiente arranque no dispare una "migración" espuria

--- a/server-go/internal/firmware/owut.go
+++ b/server-go/internal/firmware/owut.go
@@ -61,6 +61,10 @@ type OwutStatus struct {
 	// Buildable: la infraestructura ASU puede construir la imagen (owut salió
 	// con código 0, es decir, sin paquetes missing ni build failures).
 	Buildable bool `json:"buildable"`
+	// MissingPkgs (#761): paquetes instalados fuera de los feeds oficiales
+	// ("missing to-version") que bloquean la build de ASU. La UI los muestra
+	// y ofrece excluirlos del upgrade (-r): se pierden y hay que reinstalar.
+	MissingPkgs []string `json:"missingPkgs,omitempty"`
 	// RawOutput: salida completa de `owut check` (sin la línea de exit code).
 	RawOutput string `json:"rawOutput,omitempty"`
 	// Error: fallo de transporte (router inalcanzable, timeout SSH), no un
@@ -89,6 +93,7 @@ func CheckOwut(runner Runner, host string) OwutStatus {
 	status.CheckRan = raw != ""
 	status.RawOutput = raw
 	status.UpgradeAvailable, status.Buildable = parseOwutCheck(raw, exitCode)
+	status.MissingPkgs = ParseMissingPkgs(raw)
 	return status
 }
 
@@ -112,6 +117,25 @@ func extractExitCode(out string) (int, string) {
 	// Elimina la línea del marcador (y el \n previo que le precede).
 	raw := owutExitRe.ReplaceAllString(out, "")
 	return code, strings.TrimRight(raw, "\n")
+}
+
+// owutMissingRe caza las líneas de paquete del reporte de owut:
+//
+//	netgrip    0.71.0-r1    missing to-version
+var owutMissingRe = regexp.MustCompile(`(?m)^\s{2,}([a-zA-Z0-9][a-zA-Z0-9._+-]*)\s+\S+\s+missing to-version\s*$`)
+
+// ParseMissingPkgs extrae los paquetes instalados fuera de los feeds
+// oficiales (bloquean la build de ASU). Función pura.
+func ParseMissingPkgs(out string) []string {
+	var pkgs []string
+	seen := map[string]bool{}
+	for _, m := range owutMissingRe.FindAllStringSubmatch(out, -1) {
+		if !seen[m[1]] {
+			seen[m[1]] = true
+			pkgs = append(pkgs, m[1])
+		}
+	}
+	return pkgs
 }
 
 // parseOwutCheck interpreta la salida de `owut check` a dos señales claras:

--- a/server-go/internal/firmware/owut.go
+++ b/server-go/internal/firmware/owut.go
@@ -29,12 +29,15 @@ const (
 // owutDetectCmd comprueba si el binario owut está en el PATH del router.
 const owutDetectCmd = "command -v owut"
 
-// owutCheckCmd envuelve `owut check` fusionando stderr en stdout y añadiendo
-// una línea final con el exit code. SSHPool.Run descarta el stdout cuando el
-// comando sale con código distinto de cero (session.Output), así que sin este
-// wrapper un check fallido perdería su salida. La línea `__owut_exit__=N` se
-// parsea y se retira del rawOutput antes de exponerlo.
-const owutCheckCmd = "owut check 2>&1; printf '\\n__owut_exit__=%d\\n' $?"
+// owutCheckCmd envuelve `owut check -v` fusionando stderr en stdout y
+// añadiendo una línea final con el exit code. El verbose es necesario para
+// que la salida LISTE los paquetes "missing to-version" (sus nombres), que
+// el resumen sin -v solo cuenta; de ahí salen los MissingPkgs para sugerir
+// la exclusión. SSHPool.Run descarta el stdout cuando el comando sale con
+// código distinto de cero (session.Output), así que sin este wrapper un
+// check fallido perdería su salida. La línea `__owut_exit__=N` se parsea y
+// se retira del rawOutput antes de exponerlo.
+const owutCheckCmd = "owut check -v 2>&1; printf '\\n__owut_exit__=%d\\n' $?"
 
 // owutExitRe extrae el exit code embebido por el wrapper de owutCheckCmd.
 var owutExitRe = regexp.MustCompile(`__owut_exit__=(\d+)`)

--- a/server-go/internal/firmware/owut_flow.go
+++ b/server-go/internal/firmware/owut_flow.go
@@ -223,8 +223,11 @@ type Platform struct {
 // platformDetectCmd: una sola ida SSH resuelve ambas señales. La marca de
 // vendor son los repositorios propios (fw.gl-inet.com en apk u opkg): el
 // /etc/openwrt_release de los GL op25 es idéntico al vanilla y NO sirve.
+// OJO: busybox grep sale con 2 si algún fichero listado no existe (aunque
+// haya matches), así que el match se decide por salida (grep -q .), no por
+// exit code del primer grep.
 const platformDetectCmd = `command -v owut >/dev/null 2>&1 && printf '__owut__\n'; ` +
-	`grep -s fw.gl-inet.com /etc/apk/repositories /etc/apk/repositories.d/* /etc/opkg/distfeeds.conf >/dev/null 2>&1 && printf '__gl__\n'; true`
+	`grep -hs fw.gl-inet.com /etc/apk/repositories /etc/apk/repositories.d/* /etc/opkg/distfeeds.conf 2>/dev/null | grep -q . && printf '__gl__\n'; true`
 
 // DetectPlatform sondea owut y vendor del router (tolerante: runner/host
 // vacíos → Platform vacía).

--- a/server-go/internal/firmware/owut_flow.go
+++ b/server-go/internal/firmware/owut_flow.go
@@ -79,10 +79,16 @@ func ParseOwutVersions(out, current string) []OwutVersion {
 	return versions
 }
 
-// stableVersion filtra release candidates y snapshots del desplegable.
+// stableVersion filtra release candidates y snapshots del desplegable
+// (incluido el "SNAPSHOT" literal con que cierra cada rama del server ASU).
 func stableVersion(v string) bool {
+	if v == "SNAPSHOT" || !strings.ContainsFunc(v, isDigitRune) {
+		return false
+	}
 	return !strings.Contains(v, "-rc") && !strings.HasSuffix(v, "-SNAPSHOT")
 }
+
+func isDigitRune(r rune) bool { return r >= '0' && r <= '9' }
 
 // VersionCmp compara dos versiones OpenWrt ("25.12.5") numéricamente por
 // componentes; devuelve -1/0/1. Componentes no numéricos valen 0.

--- a/server-go/internal/firmware/owut_flow.go
+++ b/server-go/internal/firmware/owut_flow.go
@@ -251,6 +251,30 @@ func ParsePlatform(out string) Platform {
 	return p
 }
 
+// stackPreserveCmd garantiza de forma idempotente que los ficheros del
+// stack propio presente en el router (netgrip y/o agente NetPulse) estén en
+// /etc/sysupgrade.conf: ASU no puede incluir paquetes sin feed en la imagen,
+// pero los ficheros listados SOBREVIVEN al flash (el servicio arranca en el
+// primer boot; el registro apk se recupera con una reinstalación posterior).
+const stackPreserveCmd = `P=/etc/sysupgrade.conf; touch $P; ensure() { grep -qxF "$1" $P || echo "$1" >> $P; }; ` +
+	`if [ -f /usr/sbin/netgrip ]; then ensure /usr/sbin/netgrip; ensure /etc/init.d/netgrip; ` +
+	`ensure /usr/libexec/netgrip-restore-rules; ensure /etc/netgrip/; ` +
+	`for f in /etc/rc.d/*netgrip*; do [ -e "$f" ] && ensure "$f"; done; fi; ` +
+	`if [ -f /usr/sbin/netpulse-agent ]; then ensure /usr/sbin/netpulse-agent; ensure /etc/netpulse-agent.env; ` +
+	`ensure /usr/sbin/netpulse-watchdog; ensure /etc/init.d/netpulse-agent; ` +
+	`for f in /etc/rc.d/*netpulse-agent*; do [ -e "$f" ] && ensure "$f"; done; fi; true`
+
+// EnsureStackPreserved ejecuta la preservación en el router (tolerante: un
+// runner nil es no-op; devuelve el error de transporte si falla y el caller
+// decide si continúa).
+func EnsureStackPreserved(runner Runner, host string) error {
+	if runner == nil || host == "" {
+		return nil
+	}
+	_, err := runner.Run(host, stackPreserveCmd, owutDetectTimeout)
+	return err
+}
+
 // OpenWrtVersionRe: versión destino válida para -V ("25.12.5", "24.10.2").
 // Evita que textos libres guardados como target disparen upgrades sin sentido.
 var OpenWrtVersionRe = regexp.MustCompile(`^\d+\.\d+(\.\d+)?(-[a-zA-Z0-9.]+)?$`)

--- a/server-go/internal/firmware/owut_flow.go
+++ b/server-go/internal/firmware/owut_flow.go
@@ -251,6 +251,15 @@ func ParsePlatform(out string) Platform {
 	return p
 }
 
+// OpenWrtVersionRe: versión destino válida para -V ("25.12.5", "24.10.2").
+// Evita que textos libres guardados como target disparen upgrades sin sentido.
+var OpenWrtVersionRe = regexp.MustCompile(`^\d+\.\d+(\.\d+)?(-[a-zA-Z0-9.]+)?$`)
+
+// ValidOpenWrtVersion informa de si target parece una versión OpenWrt.
+func ValidOpenWrtVersion(v string) bool {
+	return OpenWrtVersionRe.MatchString(strings.TrimSpace(v))
+}
+
 // shQuote entrecomilla un valor para shell POSIX (single-quote escaping).
 func shQuote(v string) string {
 	return "'" + strings.ReplaceAll(v, "'", `'\''`) + "'"

--- a/server-go/internal/firmware/owut_flow.go
+++ b/server-go/internal/firmware/owut_flow.go
@@ -1,0 +1,187 @@
+// owut_flow.go - ciclo owut completo (#761): lista de versiones disponibles,
+// instalación del paquete y comando de upgrade desatendido.
+//
+// `owut upgrade` es no interactivo por diseño (verificado sobre el fuente
+// ucode de owut 2026.07): aborta solo si los checks fallan, hace warn sin
+// preguntar cuando hay default packages perdidos, y si no hay cambios termina
+// con exit 0 sin tocar nada (idempotencia nativa). Sin -V reconstruye la
+// versión instalada con los paquetes al día; con -V VERSION salta de versión
+// conservando los paquetes instalados (attended sysupgrade vía ASU).
+package firmware
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	owutVersionsTimeout = 60 * time.Second
+	owutInstallTimeout  = 240 * time.Second
+	// OwutUpgradeTimeout: build ASU + descarga + verificación + flash. El
+	// build remoto puede tardar minutos; el flash final mata dropbear y la
+	// sesión SSH muere con el router reiniciándose (resultado esperado).
+	OwutUpgradeTimeout = 15 * time.Minute
+)
+
+// OwutVersion es una versión destino que ASU puede construir para el router.
+type OwutVersion struct {
+	Version string `json:"version"`
+	Branch  string `json:"branch"`
+	Latest  bool   `json:"latest,omitempty"`
+	Newer   bool   `json:"newer,omitempty"`
+}
+
+var (
+	owutBranchRe = regexp.MustCompile(`^\s{2}(\S+)\s+release branch\s*$`)
+	owutVerRe    = regexp.MustCompile(`^\s{4}(\S+)(\s+\(latest\))?\s*$`)
+)
+
+// ListOwutVersions parsea `owut versions` y devuelve las versiones estables
+// (se excluyen -rc* y *-SNAPSHOT) con la marca Latest y Newer respecto a la
+// versión instalada actual (vacía = todas sin comparar).
+func ListOwutVersions(runner Runner, host, current string) ([]OwutVersion, error) {
+	if runner == nil || host == "" {
+		return nil, fmt.Errorf("firmware: runner o host vacío")
+	}
+	out, err := runner.Run(host, "owut versions 2>&1", owutVersionsTimeout)
+	if err != nil {
+		return nil, err
+	}
+	return ParseOwutVersions(out, current), nil
+}
+
+// ParseOwutVersions interpreta la salida de `owut versions` (función pura,
+// testeada): ramas con dos espacios y versiones con cuatro.
+func ParseOwutVersions(out, current string) []OwutVersion {
+	var versions []OwutVersion
+	branch := ""
+	for _, line := range strings.Split(out, "\n") {
+		if m := owutBranchRe.FindStringSubmatch(line); m != nil {
+			branch = m[1]
+			continue
+		}
+		if m := owutVerRe.FindStringSubmatch(line); m != nil {
+			v := m[1]
+			if !stableVersion(v) {
+				continue
+			}
+			versions = append(versions, OwutVersion{
+				Version: v,
+				Branch:  branch,
+				Latest:  m[2] != "",
+				Newer:   current != "" && VersionCmp(v, current) > 0,
+			})
+		}
+	}
+	return versions
+}
+
+// stableVersion filtra release candidates y snapshots del desplegable.
+func stableVersion(v string) bool {
+	return !strings.Contains(v, "-rc") && !strings.HasSuffix(v, "-SNAPSHOT")
+}
+
+// VersionCmp compara dos versiones OpenWrt ("25.12.5") numéricamente por
+// componentes; devuelve -1/0/1. Componentes no numéricos valen 0.
+func VersionCmp(a, b string) int {
+	as := strings.Split(a, ".")
+	bs := strings.Split(b, ".")
+	n := len(as)
+	if len(bs) > n {
+		n = len(bs)
+	}
+	for i := 0; i < n; i++ {
+		av, bv := 0, 0
+		if i < len(as) {
+			av, _ = strconv.Atoi(as[i])
+		}
+		if i < len(bs) {
+			bv, _ = strconv.Atoi(bs[i])
+		}
+		if av != bv {
+			if av < bv {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}
+
+// MajorJump informa de si pasar de current a target cambia de rama mayor
+// ("23.05.5" -> "24.10.0" es salto mayor; "23.05.5" -> "23.05.7" no).
+func MajorJump(current, target string) bool {
+	if current == "" || target == "" {
+		return false
+	}
+	cs := strings.Split(current, ".")
+	ts := strings.Split(target, ".")
+	if len(cs) == 0 || len(ts) == 0 {
+		return false
+	}
+	return cs[0] != ts[0]
+}
+
+// owutInstallCmd detecta el gestor de paquetes del router e instala owut.
+// Solo apk (24.10+ snapshots recientes y 25.x) u opkg (24.10): en releases sin
+// paquete owut (23.05 y anteriores) el comando falla con el error del gestor.
+const owutInstallCmd = `if command -v apk >/dev/null 2>&1; then apk update && apk add owut; ` +
+	`elif command -v opkg >/dev/null 2>&1; then opkg update && opkg install owut; ` +
+	`else printf '__no_pm__\n'; fi 2>&1; printf '\n__owut_exit__=%d\n' $?`
+
+// InstallOwut instala el paquete owut en el router con el gestor disponible.
+// Devuelve la salida del gestor; error si no hay gestor, falla la instalación
+// o falla el transporte SSH.
+func InstallOwut(runner Runner, host string) (string, error) {
+	if runner == nil || host == "" {
+		return "", fmt.Errorf("firmware: runner o host vacío")
+	}
+	out, err := runner.Run(host, owutInstallCmd, owutInstallTimeout)
+	if err != nil {
+		return out, err
+	}
+	exit, raw := extractExitCode(out)
+	if strings.Contains(raw, "__no_pm__") {
+		return raw, fmt.Errorf("firmware: el router no tiene apk ni opkg")
+	}
+	if exit != 0 {
+		return raw, fmt.Errorf("firmware: instalación de owut falló (exit %d)", exit)
+	}
+	return raw, nil
+}
+
+// OwutUpgradeCmd construye el comando de upgrade desatendido. Con target
+// distinto de la versión actual añade -V TARGET (salto de versión); si son
+// iguales (o current desconocida) reconstruye la versión instalada con los
+// paquetes al día.
+func OwutUpgradeCmd(target, current string) string {
+	if target != "" && current != "" && target != current {
+		return "owut upgrade -q -V " + shQuote(target)
+	}
+	return "owut upgrade -q"
+}
+
+// RunOwutUpgrade ejecuta el comando de upgrade con el wrapper de exit code y
+// devuelve (exit, salida, error de transporte). Un error de transporte al
+// final del flujo es NORMAL: el sysupgrade reinicia el router y la sesión SSH
+// muere sin llegar a escribir la línea de exit (el caller lo interpreta).
+func RunOwutUpgrade(runner Runner, host, cmd string) (int, string, error) {
+	wrapped := cmd + ` 2>&1; printf '\n__owut_exit__=%d\n' $?`
+	out, err := runner.Run(host, wrapped, OwutUpgradeTimeout)
+	exit, raw := extractExitCode(out)
+	return exit, raw, err
+}
+
+// OwutInstalled informa de si el router tiene owut en su PATH (detección
+// local y barata; la usa el loop de recurrencia y el endpoint de versiones).
+func OwutInstalled(runner Runner, host string) bool {
+	return detectOwut(runner, host)
+}
+
+// shQuote entrecomilla un valor para shell POSIX (single-quote escaping).
+func shQuote(v string) string {
+	return "'" + strings.ReplaceAll(v, "'", `'\''`) + "'"
+}

--- a/server-go/internal/firmware/owut_flow.go
+++ b/server-go/internal/firmware/owut_flow.go
@@ -131,15 +131,14 @@ func MajorJump(current, target string) bool {
 	return cs[0] != ts[0]
 }
 
-// owutInstallCmd detecta el gestor de paquetes del router e instala owut.
-// El reintento con el repo oficial de OpenWrt cubre los firmware de vendor
-// (p. ej. GL.iNet op25) cuyos mirrors propios no empaquetan owut: se usa la
-// versión del propio router (/etc/openwrt_release) y el arch de apk. En
-// releases sin paquete owut (23.05 y anteriores) el comando falla con el
-// error del gestor.
+// owutInstallCmd detecta el gestor de paquetes del router e instala owut con
+// los repositorios PROPIOS del router (los firmware vanilla lo empaquetan).
+// En releases sin paquete owut (23.05-) el comando falla con el error del
+// gestor; en firmware de fabricante (GL.iNet) el flujo va bloqueado antes
+// (cada vendor gestiona sus actualizaciones en su propio panel).
 const owutInstallCmd = `if command -v apk >/dev/null 2>&1; then ` +
 	`apk update >/dev/null 2>&1; ` +
-	`apk add owut || apk add --repository "https://downloads.openwrt.org/releases/$(. /etc/openwrt_release 2>/dev/null; echo ${DISTRIB_RELEASE%%-*})/packages/$(apk --print-arch)/packages/packages.adb" owut; ` +
+	`apk add owut; ` +
 	`elif command -v opkg >/dev/null 2>&1; then opkg update && opkg install owut; ` +
 	`else printf '__no_pm__\n'; fi 2>&1; printf '\n__owut_exit__=%d\n' $?`
 
@@ -212,10 +211,41 @@ func RunOwutUpgrade(runner Runner, host, cmd string) (int, string, error) {
 	return exit, raw, err
 }
 
-// OwutInstalled informa de si el router tiene owut en su PATH (detección
-// local y barata; la usa el loop de recurrencia y el endpoint de versiones).
-func OwutInstalled(runner Runner, host string) bool {
-	return detectOwut(runner, host)
+// Platform es la foto de plataforma de un router: si tiene owut y si lleva
+// firmware de fabricante. Vendor != "" significa firmware compilado por el
+// vendor con su propia gestión de actualizaciones (GL.iNet): NetPulse NO
+// ofrece upgrades ASU ahí, el vendor ya resuelve los suyos en su panel.
+type Platform struct {
+	Owut   bool
+	Vendor string // "" | "gl-inet"
+}
+
+// platformDetectCmd: una sola ida SSH resuelve ambas señales. La marca de
+// vendor son los repositorios propios (fw.gl-inet.com en apk u opkg): el
+// /etc/openwrt_release de los GL op25 es idéntico al vanilla y NO sirve.
+const platformDetectCmd = `command -v owut >/dev/null 2>&1 && printf '__owut__\n'; ` +
+	`grep -s fw.gl-inet.com /etc/apk/repositories /etc/apk/repositories.d/* /etc/opkg/distfeeds.conf >/dev/null 2>&1 && printf '__gl__\n'; true`
+
+// DetectPlatform sondea owut y vendor del router (tolerante: runner/host
+// vacíos → Platform vacía).
+func DetectPlatform(runner Runner, host string) Platform {
+	if runner == nil || host == "" {
+		return Platform{}
+	}
+	out, _ := runner.Run(host, platformDetectCmd, owutDetectTimeout)
+	return ParsePlatform(out)
+}
+
+// ParsePlatform interpreta las marcas de platformDetectCmd (función pura).
+func ParsePlatform(out string) Platform {
+	p := Platform{}
+	if strings.Contains(out, "__owut__") {
+		p.Owut = true
+	}
+	if strings.Contains(out, "__gl__") {
+		p.Vendor = "gl-inet"
+	}
+	return p
 }
 
 // shQuote entrecomilla un valor para shell POSIX (single-quote escaping).

--- a/server-go/internal/firmware/owut_flow.go
+++ b/server-go/internal/firmware/owut_flow.go
@@ -132,15 +132,21 @@ func MajorJump(current, target string) bool {
 }
 
 // owutInstallCmd detecta el gestor de paquetes del router e instala owut.
-// Solo apk (24.10+ snapshots recientes y 25.x) u opkg (24.10): en releases sin
-// paquete owut (23.05 y anteriores) el comando falla con el error del gestor.
-const owutInstallCmd = `if command -v apk >/dev/null 2>&1; then apk update && apk add owut; ` +
+// El reintento con el repo oficial de OpenWrt cubre los firmware de vendor
+// (p. ej. GL.iNet op25) cuyos mirrors propios no empaquetan owut: se usa la
+// versión del propio router (/etc/openwrt_release) y el arch de apk. En
+// releases sin paquete owut (23.05 y anteriores) el comando falla con el
+// error del gestor.
+const owutInstallCmd = `if command -v apk >/dev/null 2>&1; then ` +
+	`apk update >/dev/null 2>&1; ` +
+	`apk add owut || apk add --repository "https://downloads.openwrt.org/releases/$(. /etc/openwrt_release 2>/dev/null; echo ${DISTRIB_RELEASE%%-*})/packages/$(apk --print-arch)/packages/packages.adb" owut; ` +
 	`elif command -v opkg >/dev/null 2>&1; then opkg update && opkg install owut; ` +
 	`else printf '__no_pm__\n'; fi 2>&1; printf '\n__owut_exit__=%d\n' $?`
 
-// InstallOwut instala el paquete owut en el router con el gestor disponible.
-// Devuelve la salida del gestor; error si no hay gestor, falla la instalación
-// o falla el transporte SSH.
+// InstallOwut instala el paquete owut en el router con el gestor disponible
+// (con reintento vía repo oficial para firmware de vendor). Devuelve la
+// salida del gestor; error si no hay gestor, falla la instalación o falla el
+// transporte SSH.
 func InstallOwut(runner Runner, host string) (string, error) {
 	if runner == nil || host == "" {
 		return "", fmt.Errorf("firmware: runner o host vacío")
@@ -154,7 +160,11 @@ func InstallOwut(runner Runner, host string) (string, error) {
 		return raw, fmt.Errorf("firmware: el router no tiene apk ni opkg")
 	}
 	if exit != 0 {
-		return raw, fmt.Errorf("firmware: instalación de owut falló (exit %d)", exit)
+		tail := raw
+		if len(tail) > 300 {
+			tail = "..." + tail[len(tail)-300:]
+		}
+		return raw, fmt.Errorf("instalación de owut falló (exit %d): %s", exit, strings.TrimSpace(tail))
 	}
 	return raw, nil
 }
@@ -162,12 +172,33 @@ func InstallOwut(runner Runner, host string) (string, error) {
 // OwutUpgradeCmd construye el comando de upgrade desatendido. Con target
 // distinto de la versión actual añade -V TARGET (salto de versión); si son
 // iguales (o current desconocida) reconstruye la versión instalada con los
-// paquetes al día.
-func OwutUpgradeCmd(target, current string) string {
+// paquetes al día. removePkgs excluye paquetes locales que no están en los
+// feeds oficiales ( owut "-r"): sin ellos ASU se niega a construir la imagen.
+func OwutUpgradeCmd(target, current string, removePkgs []string) string {
+	cmd := "owut upgrade -q"
 	if target != "" && current != "" && target != current {
-		return "owut upgrade -q -V " + shQuote(target)
+		cmd += " -V " + shQuote(target)
 	}
-	return "owut upgrade -q"
+	if pkgs := sanitizeRemovePkgs(removePkgs); pkgs != "" {
+		cmd += " -r " + shQuote(pkgs)
+	}
+	return cmd
+}
+
+// pkgNameRe: nombre de paquete apk/opkg sano (defensa contra inyección en
+// el comando SSH; el shQuote ya protege, esto limita el abuso).
+var pkgNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._+-]*$`)
+
+// sanitizeRemovePkgs filtra y une la lista de exclusiones (máx 20).
+func sanitizeRemovePkgs(list []string) string {
+	var keep []string
+	for _, p := range list {
+		p = strings.TrimSpace(p)
+		if p != "" && pkgNameRe.MatchString(p) && len(keep) < 20 {
+			keep = append(keep, p)
+		}
+	}
+	return strings.Join(keep, " ")
 }
 
 // RunOwutUpgrade ejecuta el comando de upgrade con el wrapper de exit code y

--- a/server-go/internal/firmware/owut_flow_test.go
+++ b/server-go/internal/firmware/owut_flow_test.go
@@ -1,0 +1,153 @@
+// owut_flow_test.go - tests del ciclo owut completo (#761): parse de
+// versiones, comparadores, construcción del comando de upgrade e instalación.
+package firmware
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeSSHRunner struct {
+	out string
+	err error
+	got string
+}
+
+func (f *fakeSSHRunner) Run(host, cmd string, timeout time.Duration) (string, error) {
+	f.got = cmd
+	return f.out, f.err
+}
+
+// owutVersionsOut reproduce el formato real de `owut versions` (verificado en
+// un router OpenWrt 25.12 con owut 2026.07).
+const owutVersionsOut = `Available 'version-to' values from https://sysupgrade.openwrt.org:
+  22.03 release branch
+    22.03.0-rc1
+    22.03.7 (latest)
+    22.03-SNAPSHOT
+  23.05 release branch
+    23.05.4
+    23.05.5 (latest)
+  24.10 release branch
+    24.10.0
+    24.10.2 (latest)
+  25.12 release branch
+    25.12.4
+    25.12.5
+    25.12.7 (latest)
+`
+
+func TestParseOwutVersions(t *testing.T) {
+	vs := ParseOwutVersions(owutVersionsOut, "25.12.5")
+	if len(vs) != 8 {
+		t.Fatalf("esperaba 8 versiones estables (rc y SNAPSHOT fuera), got %d: %+v", len(vs), vs)
+	}
+	byVer := map[string]OwutVersion{}
+	for _, v := range vs {
+		byVer[v.Version] = v
+	}
+	if v := byVer["25.12.7"]; !v.Latest || !v.Newer || v.Branch != "25.12" {
+		t.Fatalf("25.12.7: %+v", v)
+	}
+	if v := byVer["25.12.5"]; v.Latest || v.Newer {
+		t.Fatalf("25.12.5 (instalada): %+v", v)
+	}
+	if v := byVer["23.05.5"]; v.Branch != "23.05" {
+		t.Fatalf("23.05.5: %+v", v)
+	}
+	if _, ok := byVer["22.03.0-rc1"]; ok {
+		t.Fatalf("un rc no debe aparecer: %+v", byVer["22.03.0-rc1"])
+	}
+	if _, ok := byVer["22.03-SNAPSHOT"]; ok {
+		t.Fatalf("un SNAPSHOT no debe aparecer")
+	}
+}
+
+func TestVersionCmp(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"25.12.5", "25.12.5", 0},
+		{"25.12.7", "25.12.5", 1},
+		{"23.05.5", "24.10.0", -1},
+		{"25.12", "25.12.0", 0},
+		{"25.12.1", "25.12", 1},
+		{"", "", 0},
+	}
+	for _, c := range cases {
+		if got := VersionCmp(c.a, c.b); got != c.want {
+			t.Fatalf("VersionCmp(%q, %q) = %d, esperaba %d", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestMajorJump(t *testing.T) {
+	cases := []struct {
+		current, target string
+		want            bool
+	}{
+		{"23.05.5", "24.10.0", true},
+		{"23.05.5", "23.05.7", false},
+		{"25.12.5", "25.12.7", false},
+		{"", "24.10.0", false},
+		{"23.05.5", "", false},
+	}
+	for _, c := range cases {
+		if got := MajorJump(c.current, c.target); got != c.want {
+			t.Fatalf("MajorJump(%q, %q) = %v, esperaba %v", c.current, c.target, got, c.want)
+		}
+	}
+}
+
+func TestOwutUpgradeCmd(t *testing.T) {
+	if got := OwutUpgradeCmd("25.12.7", "25.12.5"); got != "owut upgrade -q -V '25.12.7'" {
+		t.Fatalf("salto de versión: %q", got)
+	}
+	if got := OwutUpgradeCmd("25.12.5", "25.12.5"); got != "owut upgrade -q" {
+		t.Fatalf("misma versión (rebuild de paquetes): %q", got)
+	}
+	if got := OwutUpgradeCmd("25.12.7", ""); got != "owut upgrade -q" {
+		t.Fatalf("current desconocida: %q", got)
+	}
+}
+
+func TestRunOwutUpgradeParsesExit(t *testing.T) {
+	f := &fakeSSHRunner{out: "There are no changes to upgrade\n__owut_exit__=0\n"}
+	exit, out, err := RunOwutUpgrade(f, "h", OwutUpgradeCmd("25.12.5", "25.12.5"))
+	if err != nil || exit != 0 || !strings.Contains(out, "no changes") {
+		t.Fatalf("exit=%d err=%v out=%q", exit, err, out)
+	}
+	if !strings.Contains(f.got, "__owut_exit__") {
+		t.Fatalf("el comando debe llevar el wrapper de exit: %q", f.got)
+	}
+}
+
+func TestRunOwutUpgradeTransportDeath(t *testing.T) {
+	// La sesión SSH muere con el reinicio del sysupgrade: err != nil, sin
+	// línea de exit (el caller decide con la duración).
+	f := &fakeSSHRunner{err: errors.New("ssh: connection reset")}
+	exit, _, err := RunOwutUpgrade(f, "h", "owut upgrade -q")
+	if err == nil {
+		t.Fatalf("debe propagar el error de transporte")
+	}
+	if exit != 0 {
+		t.Fatalf("sin línea de exit el código es 0 por defecto, got %d", exit)
+	}
+}
+
+func TestInstallOwutNoPackageManager(t *testing.T) {
+	f := &fakeSSHRunner{out: "__no_pm__\n__owut_exit__=0\n"}
+	if _, err := InstallOwut(f, "h"); err == nil {
+		t.Fatalf("sin apk ni opkg debe devolver error")
+	}
+}
+
+func TestInstallOwutFails(t *testing.T) {
+	f := &fakeSSHRunner{out: "ERROR: unable to select packages\n__owut_exit__=1\n"}
+	if _, err := InstallOwut(f, "h"); err == nil {
+		t.Fatalf("exit 1 del gestor debe ser error")
+	}
+}

--- a/server-go/internal/firmware/owut_flow_test.go
+++ b/server-go/internal/firmware/owut_flow_test.go
@@ -168,3 +168,25 @@ func TestInstallOwutFails(t *testing.T) {
 		t.Fatalf("exit 1 del gestor debe ser error")
 	}
 }
+
+func TestParsePlatform(t *testing.T) {
+	cases := []struct {
+		name       string
+		out        string
+		wantOwut   bool
+		wantVendor string
+	}{
+		{"vanilla con owut", "__owut__\n", true, ""},
+		{"vanilla sin owut", "", false, ""},
+		{"GL sin owut", "__gl__\n", false, "gl-inet"},
+		{"GL con owut instalado", "__owut__\n__gl__\n", true, "gl-inet"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ParsePlatform(c.out)
+			if got.Owut != c.wantOwut || got.Vendor != c.wantVendor {
+				t.Fatalf("ParsePlatform(%q) = %+v", c.out, got)
+			}
+		})
+	}
+}

--- a/server-go/internal/firmware/owut_flow_test.go
+++ b/server-go/internal/firmware/owut_flow_test.go
@@ -63,6 +63,17 @@ func TestParseOwutVersions(t *testing.T) {
 	if _, ok := byVer["22.03-SNAPSHOT"]; ok {
 		t.Fatalf("un SNAPSHOT no debe aparecer")
 	}
+	if _, ok := byVer["SNAPSHOT"]; ok {
+		t.Fatalf("el SNAPSHOT literal de fin de rama no debe aparecer")
+	}
+}
+
+func TestParseOwutVersionsBranchSnapshot(t *testing.T) {
+	// El server ASU cierra cada rama con "SNAPSHOT" (sin versión): fuera.
+	vs := ParseOwutVersions("  25.12 release branch\n    25.12.4\n    SNAPSHOT (latest)\n", "25.12.4")
+	if len(vs) != 1 || vs[0].Version != "25.12.4" {
+		t.Fatalf("esperaba solo 25.12.4, got %+v", vs)
+	}
 }
 
 func TestVersionCmp(t *testing.T) {

--- a/server-go/internal/firmware/owut_flow_test.go
+++ b/server-go/internal/firmware/owut_flow_test.go
@@ -114,20 +114,26 @@ func TestMajorJump(t *testing.T) {
 }
 
 func TestOwutUpgradeCmd(t *testing.T) {
-	if got := OwutUpgradeCmd("25.12.7", "25.12.5"); got != "owut upgrade -q -V '25.12.7'" {
+	if got := OwutUpgradeCmd("25.12.7", "25.12.5", nil); got != "owut upgrade -q -V '25.12.7'" {
 		t.Fatalf("salto de versión: %q", got)
 	}
-	if got := OwutUpgradeCmd("25.12.5", "25.12.5"); got != "owut upgrade -q" {
+	if got := OwutUpgradeCmd("25.12.5", "25.12.5", nil); got != "owut upgrade -q" {
 		t.Fatalf("misma versión (rebuild de paquetes): %q", got)
 	}
-	if got := OwutUpgradeCmd("25.12.7", ""); got != "owut upgrade -q" {
+	if got := OwutUpgradeCmd("25.12.7", "", nil); got != "owut upgrade -q" {
 		t.Fatalf("current desconocida: %q", got)
+	}
+	if got := OwutUpgradeCmd("25.12.5", "25.12.5", []string{"netgrip", ""}); got != "owut upgrade -q -r 'netgrip'" {
+		t.Fatalf("exclusión de paquete local: %q", got)
+	}
+	if got := OwutUpgradeCmd("25.12.5", "25.12.5", []string{"a;rm -rf /", "b"}); got != "owut upgrade -q -r 'b'" {
+		t.Fatalf("nombres hostiles se filtran: %q", got)
 	}
 }
 
 func TestRunOwutUpgradeParsesExit(t *testing.T) {
 	f := &fakeSSHRunner{out: "There are no changes to upgrade\n__owut_exit__=0\n"}
-	exit, out, err := RunOwutUpgrade(f, "h", OwutUpgradeCmd("25.12.5", "25.12.5"))
+	exit, out, err := RunOwutUpgrade(f, "h", OwutUpgradeCmd("25.12.5", "25.12.5", nil))
 	if err != nil || exit != 0 || !strings.Contains(out, "no changes") {
 		t.Fatalf("exit=%d err=%v out=%q", exit, err, out)
 	}

--- a/server-go/internal/firmware/owut_flow_test.go
+++ b/server-go/internal/firmware/owut_flow_test.go
@@ -190,3 +190,20 @@ func TestParsePlatform(t *testing.T) {
 		})
 	}
 }
+
+func TestParseMissingPkgs(t *testing.T) {
+	// Salida real de owut check -v en un router con un paquete local sin feed.
+	out := `Collecting package data ...
+  netgrip                            0.71.0-r1                      missing to-version
+1 packages missing in target version, cannot upgrade
+46 packages are out-of-date
+It is safe to proceed with an upgrade (re-run with '--verbose' for details)
+`
+	pkgs := ParseMissingPkgs(out)
+	if len(pkgs) != 1 || pkgs[0] != "netgrip" {
+		t.Fatalf("ParseMissingPkgs = %v, esperaba [netgrip]", pkgs)
+	}
+	if got := ParseMissingPkgs("sin nada relevante"); got != nil {
+		t.Fatalf("sin matches debe devolver nil, got %v", got)
+	}
+}

--- a/server-go/internal/firmware/recurrence.go
+++ b/server-go/internal/firmware/recurrence.go
@@ -1,0 +1,272 @@
+// recurrence.go - programación recurrente de firmware por router (#761).
+//
+// Patrón de speedtest (#744) y backups (#741): ajustes en kv, vencimiento
+// derivado del last_run PERSISTIDO (reinicios/auto-update no resetean el
+// reloj) y decisión pura RecurrenceDue. La ejecución es idempotente por
+// contrato: el disparo solo flashea si la versión instalada difiere del
+// target guardado; un router al día es un no-op silencioso.
+package firmware
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+)
+
+// Kinds de recurrencia.
+const (
+	RecurrenceOnce    = "once"
+	RecurrenceWeekly  = "weekly"
+	RecurrenceMonthly = "monthly"
+)
+
+// Recurrence es la programación persistida de un router.
+type Recurrence struct {
+	Enabled bool `json:"enabled"`
+	// Kind: once (AtMs fijo, se desactiva tras disparar) | weekly
+	// (DayOfWeek a Time local) | monthly (DayOfMonth a Time local; clamp
+	// al último día si el mes no lo tiene).
+	Kind       string `json:"kind"`
+	AtMs       int64  `json:"atMs,omitempty"`       // once, epoch ms
+	DayOfWeek  *int   `json:"dayOfWeek,omitempty"`  // 0=domingo..6 (weekly)
+	DayOfMonth *int   `json:"dayOfMonth,omitempty"` // 1..31 (monthly)
+	Time       string `json:"time,omitempty"`       // "HH:MM" hora local
+	LastRunMs  int64  `json:"lastRunMs,omitempty"`  // último disparo (cualquier resultado)
+}
+
+// ValidateRecurrence comprueba la coherencia kind/campos (patrón speedtest).
+func ValidateRecurrence(rc Recurrence) error {
+	switch rc.Kind {
+	case RecurrenceOnce:
+		if rc.AtMs <= 0 {
+			return fmt.Errorf("once exige atMs (epoch ms)")
+		}
+	case RecurrenceWeekly:
+		if rc.DayOfWeek == nil || *rc.DayOfWeek < 0 || *rc.DayOfWeek > 6 {
+			return fmt.Errorf("weekly exige dayOfWeek 0-6 (0 = domingo)")
+		}
+		if !validRecTime(rc.Time) {
+			return fmt.Errorf("weekly exige time HH:MM")
+		}
+	case RecurrenceMonthly:
+		if rc.DayOfMonth == nil || *rc.DayOfMonth < 1 || *rc.DayOfMonth > 31 {
+			return fmt.Errorf("monthly exige dayOfMonth 1-31")
+		}
+		if !validRecTime(rc.Time) {
+			return fmt.Errorf("monthly exige time HH:MM")
+		}
+	default:
+		return fmt.Errorf("kind debe ser once, weekly o monthly")
+	}
+	return nil
+}
+
+// RecurrenceDue decide si toca disparar (función pura). El vencimiento
+// siempre deriva de LastRunMs: weekly exige día exacto de la semana y que el
+// slot de hoy sea posterior al último disparo; monthly aplica clamp de fin de
+// mes; once dispara una única vez (AtMs) aunque LastRunMs sea 0.
+func RecurrenceDue(rc Recurrence, now time.Time) bool {
+	if !rc.Enabled {
+		return false
+	}
+	switch rc.Kind {
+	case RecurrenceOnce:
+		return now.UnixMilli() >= rc.AtMs && rc.LastRunMs < rc.AtMs
+	case RecurrenceWeekly:
+		dow := 0
+		if rc.DayOfWeek != nil {
+			dow = *rc.DayOfWeek
+		}
+		if int(now.Weekday()) != dow {
+			return false
+		}
+		slot := recTodaySlot(rc.Time, now)
+		return !now.Before(slot) && rc.LastRunMs < slot.UnixMilli()
+	case RecurrenceMonthly:
+		dom := 1
+		if rc.DayOfMonth != nil {
+			dom = *rc.DayOfMonth
+		}
+		h, m := recParseTime(rc.Time)
+		slot := time.Date(now.Year(), now.Month(), recClampDay(dom, now), h, m, 0, 0, now.Location())
+		return !now.Before(slot) && rc.LastRunMs < slot.UnixMilli()
+	}
+	return false
+}
+
+// NextRecurrenceAt calcula el próximo disparo para la UI (Status).
+func NextRecurrenceAt(rc Recurrence, now time.Time) time.Time {
+	h, m := recParseTime(rc.Time)
+	switch rc.Kind {
+	case RecurrenceOnce:
+		return time.UnixMilli(rc.AtMs)
+	case RecurrenceWeekly:
+		dow := 0
+		if rc.DayOfWeek != nil {
+			dow = *rc.DayOfWeek
+		}
+		today := recTodaySlot(rc.Time, now)
+		if int(now.Weekday()) == dow && (now.Before(today) || rc.LastRunMs < today.UnixMilli()) {
+			return today
+		}
+		days := (dow - int(now.Weekday()) + 7) % 7
+		if days == 0 {
+			days = 7
+		}
+		d := now.AddDate(0, 0, days)
+		return time.Date(d.Year(), d.Month(), d.Day(), h, m, 0, 0, now.Location())
+	case RecurrenceMonthly:
+		dom := 1
+		if rc.DayOfMonth != nil {
+			dom = *rc.DayOfMonth
+		}
+		slot := time.Date(now.Year(), now.Month(), recClampDay(dom, now), h, m, 0, 0, now.Location())
+		if now.Before(slot) || rc.LastRunMs < slot.UnixMilli() {
+			return slot
+		}
+		next := now.AddDate(0, 1, 0)
+		return time.Date(next.Year(), next.Month(), recClampDay(dom, next), h, m, 0, 0, now.Location())
+	}
+	return time.Time{}
+}
+
+// --- Persistencia kv (claves firmware.recurrence.<router>.<campo>) ---
+
+func recKey(routerID, field string) string {
+	return "firmware.recurrence." + routerID + "." + field
+}
+
+// LoadRecurrence lee la programación del router (valores ausentes = default).
+func LoadRecurrence(db *sql.DB, routerID string) Recurrence {
+	rc := Recurrence{}
+	if db == nil || routerID == "" {
+		return rc
+	}
+	rc.Enabled = recKVGet(db, recKey(routerID, "enabled")) == "1"
+	rc.Kind = recKVGet(db, recKey(routerID, "kind"))
+	rc.AtMs = recKVParseInt(db, recKey(routerID, "at_ms"))
+	rc.LastRunMs = recKVParseInt(db, recKey(routerID, "last_run"))
+	if v, ok := recKVIntPtr(db, recKey(routerID, "dow")); ok {
+		rc.DayOfWeek = v
+	}
+	if v, ok := recKVIntPtr(db, recKey(routerID, "dom")); ok {
+		rc.DayOfMonth = v
+	}
+	rc.Time = recKVGet(db, recKey(routerID, "time"))
+	return rc
+}
+
+// SaveRecurrence persiste la programación completa (UPSERT por clave).
+func SaveRecurrence(db *sql.DB, routerID string, rc Recurrence) error {
+	if db == nil || routerID == "" {
+		return fmt.Errorf("firmware: db o router vacío")
+	}
+	if err := ValidateRecurrence(rc); err != nil {
+		return err
+	}
+	recKVSet(db, recKey(routerID, "enabled"), boolRecStr(rc.Enabled))
+	recKVSet(db, recKey(routerID, "kind"), rc.Kind)
+	recKVSet(db, recKey(routerID, "at_ms"), strconv.FormatInt(rc.AtMs, 10))
+	recKVSet(db, recKey(routerID, "last_run"), strconv.FormatInt(rc.LastRunMs, 10))
+	dow, dom := "", ""
+	if rc.DayOfWeek != nil {
+		dow = strconv.Itoa(*rc.DayOfWeek)
+	}
+	if rc.DayOfMonth != nil {
+		dom = strconv.Itoa(*rc.DayOfMonth)
+	}
+	recKVSet(db, recKey(routerID, "dow"), dow)
+	recKVSet(db, recKey(routerID, "dom"), dom)
+	recKVSet(db, recKey(routerID, "time"), rc.Time)
+	return nil
+}
+
+// SetRecurrenceLastRun actualiza solo el último disparo (lo toca el loop).
+func SetRecurrenceLastRun(db *sql.DB, routerID string, ms int64) {
+	recKVSet(db, recKey(routerID, "last_run"), strconv.FormatInt(ms, 10))
+}
+
+// DisableRecurrence apaga la programación (config inválida detectada en
+// runtime: sin target guardado, etc.).
+func DisableRecurrence(db *sql.DB, routerID string) {
+	recKVSet(db, recKey(routerID, "enabled"), "0")
+}
+
+// --- helpers (patrón speedtest, locales del paquete) ---
+
+func validRecTime(v string) bool {
+	if v == "" {
+		return false
+	}
+	_, err := time.Parse("15:04", v)
+	return err == nil
+}
+
+func recParseTime(v string) (int, int) {
+	t, err := time.Parse("15:04", v)
+	if err != nil {
+		return 0, 0
+	}
+	return t.Hour(), t.Minute()
+}
+
+func recDaysInMonth(t time.Time) int {
+	return time.Date(t.Year(), t.Month()+1, 0, 0, 0, 0, 0, t.Location()).Day()
+}
+
+func recClampDay(dom int, t time.Time) int {
+	if dom < 1 {
+		dom = 1
+	}
+	if max := recDaysInMonth(t); dom > max {
+		dom = max
+	}
+	return dom
+}
+
+func recTodaySlot(v string, now time.Time) time.Time {
+	h, m := recParseTime(v)
+	return time.Date(now.Year(), now.Month(), now.Day(), h, m, 0, 0, now.Location())
+}
+
+func boolRecStr(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}
+
+func recKVGet(db *sql.DB, key string) string {
+	var v string
+	if err := db.QueryRow("SELECT value FROM kv WHERE key = ?", key).Scan(&v); err != nil {
+		return ""
+	}
+	return v
+}
+
+func recKVParseInt(db *sql.DB, key string) int64 {
+	n, _ := strconv.ParseInt(recKVGet(db, key), 10, 64)
+	return n
+}
+
+func recKVIntPtr(db *sql.DB, key string) (*int, bool) {
+	raw := recKVGet(db, key)
+	if raw == "" {
+		return nil, false
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return nil, false
+	}
+	return &n, true
+}
+
+func recKVSet(db *sql.DB, key, val string) {
+	if _, err := db.Exec(
+		`INSERT INTO kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+		key, val); err != nil {
+		log.Printf("[firmware] kv set %s: %v", key, err)
+	}
+}

--- a/server-go/internal/firmware/recurrence_test.go
+++ b/server-go/internal/firmware/recurrence_test.go
@@ -1,0 +1,125 @@
+// recurrence_test.go - tests de la programación recurrente de firmware
+// (#761): vencimiento weekly/monthly/once (patrón de scheduler744_test) y
+// persistencia kv roundtrip.
+package firmware
+
+import (
+	"testing"
+	"time"
+)
+
+func intPtr(v int) *int { return &v }
+
+func TestRecurrenceDueWeekly(t *testing.T) {
+	// Domingo 2026-09-13 10:00 local (fecha del desarrollo de #761).
+	now := time.Date(2026, 9, 13, 10, 0, 0, 0, time.Local)
+	slot := time.Date(2026, 9, 13, 3, 30, 0, 0, time.Local)
+	cases := []struct {
+		name string
+		rc   Recurrence
+		now  time.Time
+		want bool
+	}{
+		{"domingo despues del slot sin lastRun", Recurrence{Enabled: true, Kind: RecurrenceWeekly, DayOfWeek: intPtr(0), Time: "03:30"}, now, true},
+		{"domingo antes del slot", Recurrence{Enabled: true, Kind: RecurrenceWeekly, DayOfWeek: intPtr(0), Time: "11:00"}, now, false},
+		{"otro dia", Recurrence{Enabled: true, Kind: RecurrenceWeekly, DayOfWeek: intPtr(3), Time: "03:30"}, now, false},
+		{"ya disparado hoy", Recurrence{Enabled: true, Kind: RecurrenceWeekly, DayOfWeek: intPtr(0), Time: "03:30", LastRunMs: slot.UnixMilli()}, now, false},
+		{"disparado ayer", Recurrence{Enabled: true, Kind: RecurrenceWeekly, DayOfWeek: intPtr(0), Time: "03:30", LastRunMs: slot.Add(-24 * time.Hour).UnixMilli()}, now, true},
+		{"disabled", Recurrence{Enabled: false, Kind: RecurrenceWeekly, DayOfWeek: intPtr(0), Time: "03:30"}, now, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := RecurrenceDue(c.rc, c.now); got != c.want {
+				t.Fatalf("RecurrenceDue = %v, esperaba %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestRecurrenceDueMonthly(t *testing.T) {
+	now := time.Date(2026, 9, 12, 10, 0, 0, 0, time.Local)
+	slot := time.Date(2026, 9, 12, 4, 0, 0, 0, time.Local)
+	cases := []struct {
+		name string
+		rc   Recurrence
+		now  time.Time
+		want bool
+	}{
+		{"dia 12 a las 04", Recurrence{Enabled: true, Kind: RecurrenceMonthly, DayOfMonth: intPtr(12), Time: "04:00"}, now, true},
+		{"dia 13", Recurrence{Enabled: true, Kind: RecurrenceMonthly, DayOfMonth: intPtr(13), Time: "04:00"}, now, false},
+		{"ya disparado este mes", Recurrence{Enabled: true, Kind: RecurrenceMonthly, DayOfMonth: intPtr(12), Time: "04:00", LastRunMs: slot.UnixMilli()}, now, false},
+		{"clamp 31 en febrero", Recurrence{Enabled: true, Kind: RecurrenceMonthly, DayOfMonth: intPtr(31), Time: "04:00"}, time.Date(2026, 2, 28, 5, 0, 0, 0, time.Local), true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := RecurrenceDue(c.rc, c.now); got != c.want {
+				t.Fatalf("RecurrenceDue = %v, esperaba %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestRecurrenceDueOnce(t *testing.T) {
+	now := time.Now()
+	past := now.Add(-time.Hour).UnixMilli()
+	future := now.Add(time.Hour).UnixMilli()
+	if !RecurrenceDue(Recurrence{Enabled: true, Kind: RecurrenceOnce, AtMs: past}, now) {
+		t.Fatalf("once vencido sin disparar debe disparar")
+	}
+	if RecurrenceDue(Recurrence{Enabled: true, Kind: RecurrenceOnce, AtMs: past, LastRunMs: past + 1}, now) {
+		t.Fatalf("once ya disparado no repite")
+	}
+	if RecurrenceDue(Recurrence{Enabled: true, Kind: RecurrenceOnce, AtMs: future}, now) {
+		t.Fatalf("once futuro no dispara")
+	}
+}
+
+func TestValidateRecurrence(t *testing.T) {
+	if err := ValidateRecurrence(Recurrence{Kind: RecurrenceWeekly}); err == nil {
+		t.Fatalf("weekly sin dayOfWeek/time debe fallar")
+	}
+	if err := ValidateRecurrence(Recurrence{Kind: RecurrenceMonthly, DayOfMonth: intPtr(12)}); err == nil {
+		t.Fatalf("monthly sin time debe fallar")
+	}
+	if err := ValidateRecurrence(Recurrence{Kind: RecurrenceOnce}); err == nil {
+		t.Fatalf("once sin atMs debe fallar")
+	}
+	if err := ValidateRecurrence(Recurrence{Kind: "hourly"}); err == nil {
+		t.Fatalf("kind desconocido debe fallar")
+	}
+	if err := ValidateRecurrence(Recurrence{Kind: RecurrenceWeekly, DayOfWeek: intPtr(5), Time: "23:59"}); err != nil {
+		t.Fatalf("weekly válida: %v", err)
+	}
+}
+
+func TestRecurrenceSaveLoadRoundtrip(t *testing.T) {
+	st := open(t)
+	rc := Recurrence{
+		Enabled: true, Kind: RecurrenceWeekly, DayOfWeek: intPtr(2), Time: "04:15",
+	}
+	if err := SaveRecurrence(st.db, "rt1", rc); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got := LoadRecurrence(st.db, "rt1")
+	if !got.Enabled || got.Kind != RecurrenceWeekly || got.DayOfWeek == nil || *got.DayOfWeek != 2 || got.Time != "04:15" {
+		t.Fatalf("roundtrip: %+v", got)
+	}
+	SetRecurrenceLastRun(st.db, "rt1", 12345)
+	if LoadRecurrence(st.db, "rt1").LastRunMs != 12345 {
+		t.Fatalf("lastRun no persistió")
+	}
+	DisableRecurrence(st.db, "rt1")
+	if LoadRecurrence(st.db, "rt1").Enabled {
+		t.Fatalf("disable no aplicó")
+	}
+}
+
+func TestNextRecurrenceAtWeekly(t *testing.T) {
+	// Domingo 10:00, programado martes 04:15 -> próximo martes.
+	now := time.Date(2026, 9, 13, 10, 0, 0, 0, time.Local)
+	rc := Recurrence{Enabled: true, Kind: RecurrenceWeekly, DayOfWeek: intPtr(2), Time: "04:15"}
+	next := NextRecurrenceAt(rc, now)
+	if next.Weekday() != time.Tuesday || next.Hour() != 4 || next.Minute() != 15 {
+		t.Fatalf("next = %v (%s), esperaba martes 04:15", next, next.Weekday())
+	}
+}

--- a/server-go/internal/firmware/store.go
+++ b/server-go/internal/firmware/store.go
@@ -33,6 +33,9 @@ type Upgrade struct {
 	// upgrade es del flujo manual/inmediato. Nota: StartedAt/FinishedAt siguen
 	// en unix SEGUNDOS (convención previa), ScheduledFor en ms.
 	ScheduledFor *int64 `json:"scheduledFor,omitempty"`
+	// Engine (#761): "owut" (attended sysupgrade vía ASU) o "" (motor
+	// clásico con imagen URL+checksum).
+	Engine string `json:"engine,omitempty"`
 }
 
 // Store persiste targets y upgrades.
@@ -136,9 +139,10 @@ func scanUpgrade(sc rowScanner) (*Upgrade, error) {
 	var u Upgrade
 	var finished, scheduled sql.NullInt64
 	var errStr, backup sql.NullString
+	var engine sql.NullString
 	if err := sc.Scan(
 		&u.ID, &u.RouterID, &u.TargetVersion, &u.TargetURL, &u.Checksum,
-		&u.Status, &errStr, &backup, &u.StartedAt, &finished, &scheduled,
+		&u.Status, &errStr, &backup, &u.StartedAt, &finished, &scheduled, &engine,
 	); err != nil {
 		return nil, err
 	}
@@ -154,13 +158,22 @@ func scanUpgrade(sc rowScanner) (*Upgrade, error) {
 	if backup.Valid {
 		u.BackupPath = backup.String
 	}
+	if engine.Valid {
+		u.Engine = engine.String
+	}
 	return &u, nil
+}
+
+// SetEngine marca el motor que ejecuta el upgrade (#761: owut vs clásico).
+func (s *Store) SetEngine(id int64, engine string) error {
+	_, err := s.db.Exec(`UPDATE firmware_upgrades SET engine = ? WHERE id = ?`, engine, id)
+	return err
 }
 
 // LatestUpgrade devuelve el upgrade más reciente de un router.
 func (s *Store) LatestUpgrade(routerID string) (*Upgrade, error) {
 	u, err := scanUpgrade(s.db.QueryRow(`
-		SELECT id, router_id, target_version, target_url, checksum, status, error, backup_path, started_at, finished_at, scheduled_for
+		SELECT id, router_id, target_version, target_url, checksum, status, error, backup_path, started_at, finished_at, scheduled_for, engine
 		FROM firmware_upgrades
 		WHERE router_id = ?
 		ORDER BY started_at DESC
@@ -178,7 +191,7 @@ func (s *Store) LatestUpgrade(routerID string) (*Upgrade, error) {
 // GetUpgradeByID busca un upgrade por ID (para validar propiedad del agente).
 func (s *Store) GetUpgradeByID(id int64) (*Upgrade, error) {
 	u, err := scanUpgrade(s.db.QueryRow(`
-		SELECT id, router_id, target_version, target_url, checksum, status, error, backup_path, started_at, finished_at, scheduled_for
+		SELECT id, router_id, target_version, target_url, checksum, status, error, backup_path, started_at, finished_at, scheduled_for, engine
 		FROM firmware_upgrades WHERE id = ?
 	`, id))
 	if err == sql.ErrNoRows {
@@ -249,7 +262,7 @@ func (s *Store) CancelScheduled(routerID string) error {
 // scheduled_for <= nowMs), ordenadas por hora para lanzarlas en orden.
 func (s *Store) DueScheduled(nowMs int64) ([]Upgrade, error) {
 	rows, err := s.db.Query(`
-		SELECT id, router_id, target_version, target_url, checksum, status, error, backup_path, started_at, finished_at, scheduled_for
+		SELECT id, router_id, target_version, target_url, checksum, status, error, backup_path, started_at, finished_at, scheduled_for, engine
 		FROM firmware_upgrades
 		WHERE status = 'scheduled' AND scheduled_for <= ?
 		ORDER BY scheduled_for ASC

--- a/server-go/internal/httpapi/firmware.go
+++ b/server-go/internal/httpapi/firmware.go
@@ -47,6 +47,9 @@ func (s *server) registerFirmwareRoutes(mux *http.ServeMux) {
 		return
 	}
 
+	// Ciclo owut completo + recurrencia (#761).
+	s.registerFirmwareOwutRoutes(mux)
+
 	mux.Handle("GET /api/firmware-upgrades", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if s.db == nil {
 			writeError(w, http.StatusServiceUnavailable, "no_db")

--- a/server-go/internal/httpapi/firmware.go
+++ b/server-go/internal/httpapi/firmware.go
@@ -205,8 +205,11 @@ func (s *server) registerFirmwareRoutes(mux *http.ServeMux) {
 		if st := readJSONBody(w, r, &body); st != 0 {
 			return
 		}
-		if body.Model == "" || body.TargetVersion == "" || body.TargetURL == "" {
-			writeError(w, http.StatusBadRequest, "invalid_body", "model, targetVersion y targetUrl son requeridos")
+		// #761: la URL de la imagen ya no es obligatoria al guardar el target;
+		// el flujo owut la construye ASU. El motor clásico (URL+checksum) la
+		// sigue exigiendo al disparar (ErrNoTarget en StartUpgrade).
+		if body.Model == "" || body.TargetVersion == "" {
+			writeError(w, http.StatusBadRequest, "invalid_body", "model y targetVersion son requeridos")
 			return
 		}
 		if err := s.firmware.SetTarget(firmware.Target{

--- a/server-go/internal/httpapi/firmware_owut.go
+++ b/server-go/internal/httpapi/firmware_owut.go
@@ -32,11 +32,11 @@ type alertEmitter interface {
 	Emit(ev alerts.AlertEvent) bool
 }
 
-// owutDetectCacheEntry cachea la detección de owut por router (1 h): el loop
-// de recurrencia la consulta en cada disparo y sondear el PATH cada vez
-// sería ruido SSH innecesario.
-type owutDetectCacheEntry struct {
-	ok bool
+// platformCacheEntry cachea la plataforma (owut + vendor) por router (1 h):
+// el loop de recurrencia y los endpoints la consultan y sondear por SSH en
+// cada operación sería ruido innecesario.
+type platformCacheEntry struct {
+	p  firmware.Platform
 	at time.Time
 }
 
@@ -69,12 +69,21 @@ func (s *server) registerFirmwareOwutRoutes(mux *http.ServeMux) {
 			return
 		}
 		resp := struct {
-			Current       string                 `json:"current"`
-			OwutAvailable bool                   `json:"owutAvailable"`
-			Versions      []firmware.OwutVersion `json:"versions"`
-			Error         string                 `json:"error,omitempty"`
+			Current        string                 `json:"current"`
+			OwutAvailable  bool                   `json:"owutAvailable"`
+			VendorFirmware string                 `json:"vendorFirmware,omitempty"`
+			Versions       []firmware.OwutVersion `json:"versions"`
+			Error          string                 `json:"error,omitempty"`
 		}{Current: s.detectedFirmwareVersion(id)}
-		if !s.owutInstalled(id, host) {
+		plat := s.platform(id, host)
+		if plat.Vendor != "" {
+			// Firmware de fabricante: sus updates los gestiona el vendor.
+			resp.VendorFirmware = plat.Vendor
+			resp.Versions = []firmware.OwutVersion{}
+			writeJSON(w, http.StatusOK, resp)
+			return
+		}
+		if !plat.Owut {
 			resp.Versions = []firmware.OwutVersion{}
 			writeJSON(w, http.StatusOK, resp)
 			return
@@ -102,12 +111,17 @@ func (s *server) registerFirmwareOwutRoutes(mux *http.ServeMux) {
 			writeError(w, http.StatusServiceUnavailable, "no_ssh_pool")
 			return
 		}
+		if s.platform(id, host).Vendor != "" {
+			writeError(w, http.StatusUnprocessableEntity, "vendor_firmware",
+				"El router lleva firmware del fabricante (GL.iNet): NetPulse no gestiona sus actualizaciones, usa su propio panel.")
+			return
+		}
 		output, err := firmware.InstallOwut(s.pool, host)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "owut_install_failed", err.Error())
 			return
 		}
-		s.invalidateOwutCache(id)
+		s.invalidatePlatformCache(id)
 		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "output": output})
 	})))
 
@@ -123,6 +137,11 @@ func (s *server) registerFirmwareOwutRoutes(mux *http.ServeMux) {
 		}
 		if body.TargetVersion == "" {
 			writeError(w, http.StatusBadRequest, "invalid_body", "targetVersion es requerido")
+			return
+		}
+		if host := s.hostOfRouter(id); host != "" && s.platform(id, host).Vendor != "" {
+			writeError(w, http.StatusUnprocessableEntity, "vendor_firmware",
+				"El router lleva firmware del fabricante (GL.iNet): NetPulse no gestiona sus actualizaciones, usa su propio panel.")
 			return
 		}
 		upgradeID, err := s.startOwutUpgrade(id, body.TargetVersion, "manual", body.RemovePkgs)
@@ -351,21 +370,21 @@ func (s *server) routerName(routerID string) string {
 
 // --- Detección owut cacheada ---
 
-func (s *server) owutInstalled(routerID, host string) bool {
+func (s *server) platform(routerID, host string) firmware.Platform {
 	s.owutMu.Lock()
 	defer s.owutMu.Unlock()
 	if s.owutCache == nil {
-		s.owutCache = map[string]owutDetectCacheEntry{}
+		s.owutCache = map[string]platformCacheEntry{}
 	}
 	if e, ok := s.owutCache[routerID]; ok && time.Since(e.at) < owutDetectCacheTTL {
-		return e.ok
+		return e.p
 	}
-	ok := firmware.OwutInstalled(s.pool, host)
-	s.owutCache[routerID] = owutDetectCacheEntry{ok: ok, at: time.Now()}
-	return ok
+	p := firmware.DetectPlatform(s.pool, host)
+	s.owutCache[routerID] = platformCacheEntry{p: p, at: time.Now()}
+	return p
 }
 
-func (s *server) invalidateOwutCache(routerID string) {
+func (s *server) invalidatePlatformCache(routerID string) {
 	s.owutMu.Lock()
 	defer s.owutMu.Unlock()
 	delete(s.owutCache, routerID)
@@ -443,7 +462,14 @@ func (s *server) runRecurrenceShot(routerID string) {
 	}
 	firmware.SetRecurrenceLastRun(s.db.DB, routerID, time.Now().UnixMilli())
 	host := s.hostOfRouter(routerID)
-	if host != "" && s.pool != nil && s.owutInstalled(routerID, host) {
+	if host != "" && s.pool != nil {
+		if plat := s.platform(routerID, host); plat.Vendor != "" {
+			firmware.DisableRecurrence(s.db.DB, routerID)
+			s.emitFirmwareConfigAlert(routerID, "router con firmware del fabricante (GL.iNet): sus actualizaciones las gestiona su propio panel")
+			return
+		}
+	}
+	if host != "" && s.pool != nil && s.platform(routerID, host).Owut {
 		if _, err := s.startOwutUpgrade(routerID, target.TargetVersion, "scheduled", nil); err != nil {
 			s.emitFirmwareResult(routerID, current, target.TargetVersion, "scheduled", false, err.Error())
 		}

--- a/server-go/internal/httpapi/firmware_owut.go
+++ b/server-go/internal/httpapi/firmware_owut.go
@@ -1,0 +1,459 @@
+// firmware_owut.go - ciclo owut completo y recurrencia de firmware (#761).
+//
+// Endpoints: lista de versiones (dropdown), instalación del paquete owut,
+// upgrade desatendido (máquina de estados running -> rebooting -> done) y
+// programación recurrente (once/weekly/monthly, idempotente). El resultado
+// de cada intento (éxito o fallo) se emite como alerta urgent, que llega al
+// feed, push, webhook y Telegram con la configuración existente.
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/adapters"
+	"github.com/gnacho/netpulse/server-go/internal/alerts"
+	"github.com/gnacho/netpulse/server-go/internal/auth"
+	"github.com/gnacho/netpulse/server-go/internal/firmware"
+	"github.com/gnacho/netpulse/server-go/internal/routerstore"
+)
+
+// Estados no terminales de un upgrade (clásico + owut).
+func owutUpgradeActive(status string) bool {
+	return status != "" && status != "done" && status != "failed"
+}
+
+// alertEmitter lo cumple *alerts.Engine (mismo patrón que speedtest).
+type alertEmitter interface {
+	Emit(ev alerts.AlertEvent) bool
+}
+
+// owutDetectCacheEntry cachea la detección de owut por router (1 h): el loop
+// de recurrencia la consulta en cada disparo y sondear el PATH cada vez
+// sería ruido SSH innecesario.
+type owutDetectCacheEntry struct {
+	ok bool
+	at time.Time
+}
+
+const (
+	owutDetectCacheTTL = time.Hour
+	// owutRebootGrace: margen para que el router reinicie, vuelva el sondeo
+	// y el board info reporte la versión nueva.
+	owutRebootGrace = 15 * time.Minute
+	// owutSSHMinRun: si la sesión SSH muere antes de este umbral, no fue el
+	// reinicio del sysupgrade: el comando ni arrancó.
+	owutSSHMinRun = 30 * time.Second
+	recTickEvery  = time.Minute
+)
+
+func (s *server) registerFirmwareOwutRoutes(mux *http.ServeMux) {
+	if s.firmware == nil {
+		return
+	}
+
+	// GET versions: candidatos del dropdown (requiere owut en el router).
+	mux.Handle("GET /api/firmware-upgrades/{routerId}/owut-versions", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("routerId")
+		host := s.hostOfRouter(id)
+		if host == "" {
+			writeError(w, http.StatusNotFound, "not_found")
+			return
+		}
+		if s.pool == nil {
+			writeError(w, http.StatusServiceUnavailable, "no_ssh_pool")
+			return
+		}
+		resp := struct {
+			Current       string                 `json:"current"`
+			OwutAvailable bool                   `json:"owutAvailable"`
+			Versions      []firmware.OwutVersion `json:"versions"`
+			Error         string                 `json:"error,omitempty"`
+		}{Current: s.detectedFirmwareVersion(id)}
+		if !s.owutInstalled(id, host) {
+			resp.Versions = []firmware.OwutVersion{}
+			writeJSON(w, http.StatusOK, resp)
+			return
+		}
+		resp.OwutAvailable = true
+		versions, err := firmware.ListOwutVersions(s.pool, host, resp.Current)
+		if err != nil {
+			resp.Error = err.Error()
+			resp.Versions = []firmware.OwutVersion{}
+		} else {
+			resp.Versions = versions
+		}
+		writeJSON(w, http.StatusOK, resp)
+	})))
+
+	// POST owut-install: instala el paquete owut con apk u opkg.
+	mux.Handle("POST /api/firmware-upgrades/{routerId}/owut-install", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("routerId")
+		host := s.hostOfRouter(id)
+		if host == "" {
+			writeError(w, http.StatusNotFound, "not_found")
+			return
+		}
+		if s.pool == nil {
+			writeError(w, http.StatusServiceUnavailable, "no_ssh_pool")
+			return
+		}
+		output, err := firmware.InstallOwut(s.pool, host)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "owut_install_failed", err.Error())
+			return
+		}
+		s.invalidateOwutCache(id)
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "output": output})
+	})))
+
+	// POST owut-upgrade: lanza el attended upgrade desatendido (ASU).
+	mux.Handle("POST /api/firmware-upgrades/{routerId}/owut-upgrade", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("routerId")
+		var body struct {
+			TargetVersion string `json:"targetVersion"`
+		}
+		if st := readJSONBody(w, r, &body); st != 0 {
+			return
+		}
+		if body.TargetVersion == "" {
+			writeError(w, http.StatusBadRequest, "invalid_body", "targetVersion es requerido")
+			return
+		}
+		upgradeID, err := s.startOwutUpgrade(id, body.TargetVersion, "manual")
+		switch {
+		case errors.Is(err, firmware.ErrUpgradeInProgress):
+			writeError(w, http.StatusConflict, "upgrade_in_progress", "Ya hay un upgrade en curso")
+		case errors.Is(err, errRouterNotFound):
+			writeError(w, http.StatusNotFound, "not_found")
+		case err != nil:
+			writeError(w, http.StatusInternalServerError, "firmware_error", err.Error())
+		default:
+			writeJSON(w, http.StatusAccepted, map[string]any{"upgradeId": upgradeID, "engine": "owut"})
+		}
+	})))
+
+	// GET/PUT/DELETE recurrence: programación once/weekly/monthly.
+	mux.Handle("GET /api/firmware-upgrades/{routerId}/recurrence", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("routerId")
+		rc := firmware.LoadRecurrence(s.db.DB, id)
+		out := map[string]any{"recurrence": rc}
+		if rc.Enabled {
+			next := firmware.NextRecurrenceAt(rc, time.Now())
+			if !next.IsZero() {
+				out["nextRunMs"] = next.UnixMilli()
+			}
+		}
+		writeJSON(w, http.StatusOK, out)
+	})))
+
+	mux.Handle("PUT /api/firmware-upgrades/{routerId}/recurrence", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("routerId")
+		var body firmware.Recurrence
+		if st := readJSONBody(w, r, &body); st != 0 {
+			return
+		}
+		prev := firmware.LoadRecurrence(s.db.DB, id)
+		body.LastRunMs = prev.LastRunMs
+		if err := firmware.SaveRecurrence(s.db.DB, id, body); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_body", err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+	})))
+
+	mux.Handle("DELETE /api/firmware-upgrades/{routerId}/recurrence", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("routerId")
+		firmware.DisableRecurrence(s.db.DB, id)
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+	})))
+}
+
+// startOwutUpgrade crea la fila del upgrade y lanza la goroutine que lo
+// ejecuta por SSH. El POST responde 202 inmediatamente; el progreso se sigue
+// por GET /api/firmware-upgrades (item.upgrade).
+func (s *server) startOwutUpgrade(routerID, targetVersion, origin string) (int64, error) {
+	host := s.hostOfRouter(routerID)
+	if host == "" {
+		return 0, errRouterNotFound
+	}
+	if s.pool == nil {
+		return 0, errors.New("sin pool SSH")
+	}
+	if up, _ := s.firmware.LatestUpgrade(routerID); up != nil && owutUpgradeActive(up.Status) {
+		return 0, firmware.ErrUpgradeInProgress
+	}
+	id, err := s.firmware.BeginUpgrade(routerID, targetVersion, "", "")
+	if err != nil {
+		return 0, err
+	}
+	_ = s.firmware.SetEngine(id, "owut")
+	go s.runOwutUpgrade(id, routerID, host, targetVersion, origin)
+	return id, nil
+}
+
+// runOwutUpgrade ejecuta `owut upgrade` y decide la transición. La muerte de
+// la sesión SSH tras >owutSSHMinRun es el final NORMAL del flash (el sysupgrade
+// reinicia el router); el resultado se confirma mirando el board info.
+func (s *server) runOwutUpgrade(id int64, routerID, host, target, origin string) {
+	from := ""
+	if s.boardVersionFn != nil {
+		from = s.boardVersionFn(routerID)
+	}
+	cmd := firmware.OwutUpgradeCmd(target, from)
+	_ = s.firmware.SetStatus(id, "running", "", "")
+	start := time.Now()
+	exit, out, err := firmware.RunOwutUpgrade(s.pool, host, cmd)
+	dur := time.Since(start)
+	switch {
+	case err == nil && exit == 0 && strings.Contains(out, "no changes"):
+		_ = s.firmware.SetStatus(id, "done", "sin cambios: ya estaba al día", "")
+	case (err == nil && exit == 0) || (err != nil && dur >= owutSSHMinRun):
+		s.awaitReboot(id, routerID, target, origin, from)
+	default:
+		msg := owutTail(out, err)
+		_ = s.firmware.SetStatus(id, "failed", msg, "")
+		s.emitFirmwareResult(routerID, from, target, origin, false, msg)
+	}
+}
+
+// awaitReboot espera a que el router vuelva del sysupgrade y su board info
+// reporte la versión objetivo. Deadline: owutRebootGrace.
+func (s *server) awaitReboot(id int64, routerID, target, origin, from string) {
+	_ = s.firmware.SetStatus(id, "rebooting", "", "")
+	deadline := time.Now().Add(owutRebootGrace)
+	for time.Now().Before(deadline) {
+		time.Sleep(20 * time.Second)
+		if v := s.detectedFirmwareVersion(routerID); v == target && target != "" {
+			_ = s.firmware.SetStatus(id, "done", "", "")
+			s.emitFirmwareResult(routerID, from, target, origin, true, "")
+			return
+		}
+	}
+	msg := "sin confirmación tras el reinicio (¿versión instalada distinta del objetivo?)"
+	_ = s.firmware.SetStatus(id, "failed", msg, "")
+	s.emitFirmwareResult(routerID, from, target, origin, false, msg)
+}
+
+// detectedFirmwareVersion: última versión reportada por el board info.
+func (s *server) detectedFirmwareVersion(routerID string) string {
+	if s.adapter == nil {
+		return ""
+	}
+	if bi := s.adapter.BoardInfoFor(routerID); bi != nil {
+		return bi.Release.Version
+	}
+	return ""
+}
+
+// boardInfoFor expone el board info completo (tests y debug).
+func (s *server) boardInfoFor(routerID string) *adapters.BoardInfo {
+	if s.adapter == nil {
+		return nil
+	}
+	return s.adapter.BoardInfoFor(routerID)
+}
+
+// owutTail recorta la salida de owut para el campo error (últimas líneas).
+func owutTail(out string, err error) string {
+	msg := strings.TrimSpace(out)
+	if err != nil {
+		if msg != "" {
+			msg += "; "
+		}
+		msg += err.Error()
+	}
+	if len(msg) > 400 {
+		msg = "..." + msg[len(msg)-400:]
+	}
+	return msg
+}
+
+// emitFirmwareResult notifica el resultado de un intento de upgrade (éxito o
+// fallo, manual o programado). Urgent para cruzar el Notifier (Telegram,
+// push, webhook); severity info/warn según resultado.
+func (s *server) emitFirmwareResult(routerID, from, to, origin string, ok bool, detail string) {
+	if s.alertEmitter == nil {
+		return
+	}
+	name := routerID
+	if rt := s.routerName(routerID); rt != "" {
+		name = rt
+	}
+	originTxt := "manual"
+	if origin == "scheduled" {
+		originTxt = "programado"
+	}
+	ev := alerts.AlertEvent{
+		ID:       fmt.Sprintf("alert-firmware-upgrade-%s-%d", routerID, time.Now().UnixMilli()),
+		Category: alerts.CatSystem,
+		Urgent:   true,
+		RouterID: routerID,
+		Time:     "ahora mismo",
+		Ts:       time.Now().Unix(),
+		Type:     "firmware-upgrade",
+		Vars:     map[string]string{"router": name, "from": from, "to": to, "origin": originTxt},
+	}
+	if ok {
+		ev.Severity = "info"
+		ev.Title = "Firmware actualizado"
+		ev.Description = fmt.Sprintf("%s: %s -> %s (owut, %s)", name, from, to, originTxt)
+	} else {
+		ev.Severity = "warn"
+		ev.Title = "Actualización de firmware fallida"
+		ev.Description = fmt.Sprintf("%s: objetivo %s (owut, %s): %s", name, to, originTxt, detail)
+		ev.Vars["detail"] = detail
+	}
+	s.alertEmitter.Emit(ev)
+}
+
+// emitFirmwareConfigAlert avisa de una recurrencia desactivada por config
+// inválida (sin target guardado, sin motor disponible).
+func (s *server) emitFirmwareConfigAlert(routerID, reason string) {
+	if s.alertEmitter == nil {
+		return
+	}
+	name := routerID
+	if rt := s.routerName(routerID); rt != "" {
+		name = rt
+	}
+	s.alertEmitter.Emit(alerts.AlertEvent{
+		ID:          fmt.Sprintf("alert-firmware-recurrence-%s-%d", routerID, time.Now().UnixMilli()),
+		Category:    alerts.CatSystem,
+		Urgent:      true,
+		Severity:    "warn",
+		RouterID:    routerID,
+		Title:       "Programación de firmware desactivada",
+		Description: fmt.Sprintf("%s: %s", name, reason),
+		Time:        "ahora mismo",
+		Ts:          time.Now().Unix(),
+	})
+}
+
+// routerName resuelve el nombre visible del router (fallback: su ID).
+func (s *server) routerName(routerID string) string {
+	if s.db == nil {
+		return ""
+	}
+	for _, rt := range routerstore.ListRouters(s.db.DB) {
+		if rt.ID == routerID {
+			return rt.Name
+		}
+	}
+	return ""
+}
+
+// --- Detección owut cacheada ---
+
+func (s *server) owutInstalled(routerID, host string) bool {
+	s.owutMu.Lock()
+	defer s.owutMu.Unlock()
+	if s.owutCache == nil {
+		s.owutCache = map[string]owutDetectCacheEntry{}
+	}
+	if e, ok := s.owutCache[routerID]; ok && time.Since(e.at) < owutDetectCacheTTL {
+		return e.ok
+	}
+	ok := firmware.OwutInstalled(s.pool, host)
+	s.owutCache[routerID] = owutDetectCacheEntry{ok: ok, at: time.Now()}
+	return ok
+}
+
+func (s *server) invalidateOwutCache(routerID string) {
+	s.owutMu.Lock()
+	defer s.owutMu.Unlock()
+	delete(s.owutCache, routerID)
+}
+
+// --- Loop de recurrencia (#761) ---
+
+// firmwareRecurrenceLoop: tick corto; el vencimiento se deriva del last_run
+// persistido (reboot-safe). Solo en live (en demo no hay datos que actualizar).
+func (s *server) firmwareRecurrenceLoop(ctx context.Context, tickEvery time.Duration) {
+	ticker := time.NewTicker(tickEvery)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.recurrenceTick()
+		}
+	}
+}
+
+func (s *server) recurrenceTick() {
+	if s.db == nil || s.firmware == nil {
+		return
+	}
+	now := time.Now()
+	for _, rt := range routerstore.ListRouters(s.db.DB) {
+		if !agentUpgradeable(rt.Type) {
+			continue
+		}
+		rc := firmware.LoadRecurrence(s.db.DB, rt.ID)
+		if !firmware.RecurrenceDue(rc, now) {
+			continue
+		}
+		s.recMu.Lock()
+		if s.recInFlight[rt.ID] {
+			s.recMu.Unlock()
+			continue
+		}
+		if s.recInFlight == nil {
+			s.recInFlight = map[string]bool{}
+		}
+		s.recInFlight[rt.ID] = true
+		s.recMu.Unlock()
+		go func(id string) {
+			defer func() {
+				s.recMu.Lock()
+				delete(s.recInFlight, id)
+				s.recMu.Unlock()
+			}()
+			s.runRecurrenceShot(id)
+		}(rt.ID)
+	}
+}
+
+// runRecurrenceShot ejecuta un disparo vencido. Idempotente por contrato: si
+// la versión instalada ya coincide con el target, no-op silencioso; el
+// resultado real (éxito/fallo) se notifica desde la máquina de estados owut.
+func (s *server) runRecurrenceShot(routerID string) {
+	target, err := s.firmware.GetTarget(routerID)
+	if err != nil || target == nil || target.TargetVersion == "" {
+		firmware.DisableRecurrence(s.db.DB, routerID)
+		s.emitFirmwareConfigAlert(routerID, "sin target de firmware guardado")
+		return
+	}
+	current := ""
+	if s.boardVersionFn != nil {
+		current = s.boardVersionFn(routerID)
+	}
+	if current != "" && current == target.TargetVersion {
+		// Al día: el disparo consume el slot sin flashear nada (#761).
+		firmware.SetRecurrenceLastRun(s.db.DB, routerID, time.Now().UnixMilli())
+		return
+	}
+	firmware.SetRecurrenceLastRun(s.db.DB, routerID, time.Now().UnixMilli())
+	host := s.hostOfRouter(routerID)
+	if host != "" && s.pool != nil && s.owutInstalled(routerID, host) {
+		if _, err := s.startOwutUpgrade(routerID, target.TargetVersion, "scheduled"); err != nil {
+			s.emitFirmwareResult(routerID, current, target.TargetVersion, "scheduled", false, err.Error())
+		}
+		return
+	}
+	// Sin owut: motor clásico si hay imagen URL+checksum configurada.
+	if target.TargetURL != "" && s.firmwareEngine != nil {
+		if _, err := s.firmwareEngine.StartUpgrade(routerID); err != nil {
+			s.emitFirmwareResult(routerID, current, target.TargetVersion, "scheduled", false, err.Error())
+		}
+		return
+	}
+	firmware.DisableRecurrence(s.db.DB, routerID)
+	s.emitFirmwareConfigAlert(routerID, "router sin owut y sin URL de imagen para el motor clásico")
+}

--- a/server-go/internal/httpapi/firmware_owut.go
+++ b/server-go/internal/httpapi/firmware_owut.go
@@ -295,15 +295,16 @@ func (s *server) emitFirmwareResult(routerID, from, to, origin string, ok bool, 
 		RouterID: routerID,
 		Time:     "ahora mismo",
 		Ts:       time.Now().Unix(),
-		Type:     "firmware-upgrade",
 		Vars:     map[string]string{"router": name, "from": from, "to": to, "origin": originTxt},
 	}
 	if ok {
 		ev.Severity = "info"
+		ev.Type = "firmware-upgrade-done"
 		ev.Title = "Firmware actualizado"
 		ev.Description = fmt.Sprintf("%s: %s -> %s (owut, %s)", name, from, to, originTxt)
 	} else {
 		ev.Severity = "warn"
+		ev.Type = "firmware-upgrade-failed"
 		ev.Title = "Actualización de firmware fallida"
 		ev.Description = fmt.Sprintf("%s: objetivo %s (owut, %s): %s", name, to, originTxt, detail)
 		ev.Vars["detail"] = detail

--- a/server-go/internal/httpapi/firmware_owut.go
+++ b/server-go/internal/httpapi/firmware_owut.go
@@ -27,6 +27,13 @@ func owutUpgradeActive(status string) bool {
 	return status != "" && status != "done" && status != "failed"
 }
 
+// Cinturones de plataforma (#761): firmware de fabricante fuera, y sin owut
+// instalado no se lanza nada.
+var (
+	errVendorFirmware   = errors.New("firmware de fabricante (GL.iNet) sin soporte")
+	ErrOwutNotInstalled = errors.New("owut no está instalado en el router")
+)
+
 // alertEmitter lo cumple *alerts.Engine (mismo patrón que speedtest).
 type alertEmitter interface {
 	Emit(ev alerts.AlertEvent) bool
@@ -148,6 +155,12 @@ func (s *server) registerFirmwareOwutRoutes(mux *http.ServeMux) {
 		switch {
 		case errors.Is(err, firmware.ErrUpgradeInProgress):
 			writeError(w, http.StatusConflict, "upgrade_in_progress", "Ya hay un upgrade en curso")
+		case errors.Is(err, errVendorFirmware):
+			writeError(w, http.StatusUnprocessableEntity, "vendor_firmware",
+				"El router lleva firmware del fabricante (GL.iNet): NetPulse no gestiona sus actualizaciones, usa su propio panel.")
+		case errors.Is(err, ErrOwutNotInstalled):
+			writeError(w, http.StatusPreconditionFailed, "owut_not_installed",
+				"owut no está instalado en el router: instálalo primero con el botón Instalar owut.")
 		case errors.Is(err, errRouterNotFound):
 			writeError(w, http.StatusNotFound, "not_found")
 		case err != nil:
@@ -203,6 +216,13 @@ func (s *server) startOwutUpgrade(routerID, targetVersion, origin string, remove
 	}
 	if s.pool == nil {
 		return 0, errors.New("sin pool SSH")
+	}
+	// Cinturones de platform (#761): firmware de fabricante fuera, y sin
+	// owut instalado no se lanza nada (el comando moriría en 127).
+	if plat := s.platform(routerID, host); plat.Vendor != "" {
+		return 0, errVendorFirmware
+	} else if !plat.Owut {
+		return 0, ErrOwutNotInstalled
 	}
 	if up, _ := s.firmware.LatestUpgrade(routerID); up != nil && owutUpgradeActive(up.Status) {
 		return 0, firmware.ErrUpgradeInProgress

--- a/server-go/internal/httpapi/firmware_owut.go
+++ b/server-go/internal/httpapi/firmware_owut.go
@@ -252,6 +252,11 @@ func (s *server) runOwutUpgrade(id int64, routerID, host, target, origin string,
 	}
 	cmd := firmware.OwutUpgradeCmd(target, from, removePkgs)
 	_ = s.firmware.SetStatus(id, "running", "", "")
+	// #761: antes de flashear, asegurar que el stack presente (netgrip /
+	// agente) sobrevive al update (ASU no puede empaquetarlos: sin feed).
+	if err := firmware.EnsureStackPreserved(s.pool, host); err != nil {
+		log.Printf("[firmware] preserve-stack %s falló (continuo): %v", routerID, err)
+	}
 	start := time.Now()
 	exit, out, err := firmware.RunOwutUpgrade(s.pool, host, cmd)
 	dur := time.Since(start)

--- a/server-go/internal/httpapi/firmware_owut.go
+++ b/server-go/internal/httpapi/firmware_owut.go
@@ -115,7 +115,8 @@ func (s *server) registerFirmwareOwutRoutes(mux *http.ServeMux) {
 	mux.Handle("POST /api/firmware-upgrades/{routerId}/owut-upgrade", auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("routerId")
 		var body struct {
-			TargetVersion string `json:"targetVersion"`
+			TargetVersion string   `json:"targetVersion"`
+			RemovePkgs    []string `json:"removePackages"`
 		}
 		if st := readJSONBody(w, r, &body); st != 0 {
 			return
@@ -124,7 +125,7 @@ func (s *server) registerFirmwareOwutRoutes(mux *http.ServeMux) {
 			writeError(w, http.StatusBadRequest, "invalid_body", "targetVersion es requerido")
 			return
 		}
-		upgradeID, err := s.startOwutUpgrade(id, body.TargetVersion, "manual")
+		upgradeID, err := s.startOwutUpgrade(id, body.TargetVersion, "manual", body.RemovePkgs)
 		switch {
 		case errors.Is(err, firmware.ErrUpgradeInProgress):
 			writeError(w, http.StatusConflict, "upgrade_in_progress", "Ya hay un upgrade en curso")
@@ -176,7 +177,7 @@ func (s *server) registerFirmwareOwutRoutes(mux *http.ServeMux) {
 // startOwutUpgrade crea la fila del upgrade y lanza la goroutine que lo
 // ejecuta por SSH. El POST responde 202 inmediatamente; el progreso se sigue
 // por GET /api/firmware-upgrades (item.upgrade).
-func (s *server) startOwutUpgrade(routerID, targetVersion, origin string) (int64, error) {
+func (s *server) startOwutUpgrade(routerID, targetVersion, origin string, removePkgs []string) (int64, error) {
 	host := s.hostOfRouter(routerID)
 	if host == "" {
 		return 0, errRouterNotFound
@@ -192,19 +193,19 @@ func (s *server) startOwutUpgrade(routerID, targetVersion, origin string) (int64
 		return 0, err
 	}
 	_ = s.firmware.SetEngine(id, "owut")
-	go s.runOwutUpgrade(id, routerID, host, targetVersion, origin)
+	go s.runOwutUpgrade(id, routerID, host, targetVersion, origin, removePkgs)
 	return id, nil
 }
 
 // runOwutUpgrade ejecuta `owut upgrade` y decide la transición. La muerte de
 // la sesión SSH tras >owutSSHMinRun es el final NORMAL del flash (el sysupgrade
 // reinicia el router); el resultado se confirma mirando el board info.
-func (s *server) runOwutUpgrade(id int64, routerID, host, target, origin string) {
+func (s *server) runOwutUpgrade(id int64, routerID, host, target, origin string, removePkgs []string) {
 	from := ""
 	if s.boardVersionFn != nil {
 		from = s.boardVersionFn(routerID)
 	}
-	cmd := firmware.OwutUpgradeCmd(target, from)
+	cmd := firmware.OwutUpgradeCmd(target, from, removePkgs)
 	_ = s.firmware.SetStatus(id, "running", "", "")
 	start := time.Now()
 	exit, out, err := firmware.RunOwutUpgrade(s.pool, host, cmd)
@@ -443,7 +444,7 @@ func (s *server) runRecurrenceShot(routerID string) {
 	firmware.SetRecurrenceLastRun(s.db.DB, routerID, time.Now().UnixMilli())
 	host := s.hostOfRouter(routerID)
 	if host != "" && s.pool != nil && s.owutInstalled(routerID, host) {
-		if _, err := s.startOwutUpgrade(routerID, target.TargetVersion, "scheduled"); err != nil {
+		if _, err := s.startOwutUpgrade(routerID, target.TargetVersion, "scheduled", nil); err != nil {
 			s.emitFirmwareResult(routerID, current, target.TargetVersion, "scheduled", false, err.Error())
 		}
 		return

--- a/server-go/internal/httpapi/firmware_owut.go
+++ b/server-go/internal/httpapi/firmware_owut.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -146,6 +147,11 @@ func (s *server) registerFirmwareOwutRoutes(mux *http.ServeMux) {
 			writeError(w, http.StatusBadRequest, "invalid_body", "targetVersion es requerido")
 			return
 		}
+		if !firmware.ValidOpenWrtVersion(body.TargetVersion) {
+			writeError(w, http.StatusBadRequest, "invalid_target_version",
+				"targetVersion debe ser una versión OpenWrt (p. ej. 25.12.5), no un texto libre")
+			return
+		}
 		if host := s.hostOfRouter(id); host != "" && s.platform(id, host).Vendor != "" {
 			writeError(w, http.StatusUnprocessableEntity, "vendor_firmware",
 				"El router lleva firmware del fabricante (GL.iNet): NetPulse no gestiona sus actualizaciones, usa su propio panel.")
@@ -256,6 +262,10 @@ func (s *server) runOwutUpgrade(id int64, routerID, host, target, origin string,
 		s.awaitReboot(id, routerID, target, origin, from)
 	default:
 		msg := owutTail(out, err)
+		if strings.TrimSpace(msg) == "" {
+			msg = fmt.Sprintf("owut terminó sin salida (exit %d)", exit)
+		}
+		log.Printf("[firmware] owut upgrade %s falló (exit %d): %s", routerID, exit, msg)
 		_ = s.firmware.SetStatus(id, "failed", msg, "")
 		s.emitFirmwareResult(routerID, from, target, origin, false, msg)
 	}

--- a/server-go/internal/httpapi/firmware_owut_internal_test.go
+++ b/server-go/internal/httpapi/firmware_owut_internal_test.go
@@ -1,0 +1,160 @@
+// firmware_owut_internal_test.go - tests internos (package httpapi) del
+// disparo recurrente: idempotencia cuando la versión instalada coincide con
+// el target, y autodesactivación con config inválida (#761).
+package httpapi
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gnacho/netpulse/server-go/internal/auth"
+	"github.com/gnacho/netpulse/server-go/internal/config"
+	"github.com/gnacho/netpulse/server-go/internal/db"
+	"github.com/gnacho/netpulse/server-go/internal/firmware"
+	"github.com/gnacho/netpulse/server-go/internal/routerstore"
+	"github.com/gnacho/netpulse/server-go/internal/sse"
+)
+
+// recFakeSSH registra comandos y responde owut instalado (para el camino
+// owut del disparo) sin tocar ningún router real.
+type recFakeSSH struct {
+	mu   sync.Mutex
+	cmds []string
+}
+
+func (f *recFakeSSH) Run(host, cmd string, _ time.Duration) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cmds = append(f.cmds, cmd)
+	if strings.Contains(cmd, "command -v owut") {
+		return "/usr/bin/owut\n", nil
+	}
+	if strings.Contains(cmd, "owut upgrade") {
+		return "There are no changes to upgrade\n__owut_exit__=0\n", nil
+	}
+	return "", nil
+}
+
+func (f *recFakeSSH) saw(substr string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, c := range f.cmds {
+		if strings.Contains(c, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// makeRecServer monta un server mínimo (sin HTTP) con la BD, el store de
+// firmware, el pool fake y el hook de versión instalada.
+func makeRecServer(t *testing.T, installed string) (*server, string, *recFakeSSH) {
+	t.Helper()
+	dataDir := t.TempDir()
+	cfg, err := config.Load(map[string]string{
+		"AUTH_USER": "admin", "AUTH_PASS": "test123456",
+		"DEMO_MODE": "0", "DATA_DIR": dataDir, "NODE_ENV": "test",
+	}, dataDir)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	d, err := db.Open(dataDir)
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	secret, err := auth.EnsureSessionSecret(d, cfg)
+	if err != nil {
+		t.Fatalf("secret: %v", err)
+	}
+	if err := auth.EnsureUsers(d, cfg); err != nil {
+		t.Fatalf("users: %v", err)
+	}
+	r, err := routerstore.AddRouter(d.DB, routerstore.AddInput{
+		Name: "RecRouter", Host: "192.168.1.60", Type: "openwrt",
+	})
+	if err != nil {
+		t.Fatalf("add router: %v", err)
+	}
+	pool := &recFakeSSH{}
+	s := &server{
+		cfg: cfg, db: d, adapter: nil,
+		hub:    sse.NewHub(d, cfg.MaxSSEClients, func() any { return nil }),
+		secret: secret, pool: pool,
+		firmware:       firmware.NewStore(d.DB),
+		firmwareEngine: firmware.NewEngine(firmware.NewStore(d.DB), nil),
+	}
+	s.boardVersionFn = func(string) string { return installed }
+	return s, r.ID, pool
+}
+
+func TestRunRecurrenceShotNoOpWhenUpToDate(t *testing.T) {
+	s, rid, pool := makeRecServer(t, "25.12.5")
+	if err := s.firmware.SetTarget(firmware.Target{
+		RouterID: rid, Model: "x", CurrentVersion: "25.12.5",
+		TargetVersion: "25.12.5", TargetURL: "http://x/i.bin",
+	}); err != nil {
+		t.Fatalf("target: %v", err)
+	}
+	if err := firmware.SaveRecurrence(s.db.DB, rid, firmware.Recurrence{
+		Enabled: true, Kind: firmware.RecurrenceWeekly, DayOfWeek: func() *int { v := 0; return &v }(), Time: "00:00",
+	}); err != nil {
+		t.Fatalf("recurrence: %v", err)
+	}
+
+	s.runRecurrenceShot(rid)
+
+	if pool.saw("owut upgrade") {
+		t.Fatalf("al día no debe flashear: %v", pool.cmds)
+	}
+	if got := firmware.LoadRecurrence(s.db.DB, rid).LastRunMs; got == 0 {
+		t.Fatalf("lastRun debe quedar marcado tras el disparo")
+	}
+}
+
+func TestRunRecurrenceShotDisablesWithoutTarget(t *testing.T) {
+	s, rid, _ := makeRecServer(t, "25.12.5")
+	if err := firmware.SaveRecurrence(s.db.DB, rid, firmware.Recurrence{
+		Enabled: true, Kind: firmware.RecurrenceWeekly, DayOfWeek: func() *int { v := 1; return &v }(), Time: "00:00",
+	}); err != nil {
+		t.Fatalf("recurrence: %v", err)
+	}
+
+	s.runRecurrenceShot(rid)
+
+	if firmware.LoadRecurrence(s.db.DB, rid).Enabled {
+		t.Fatalf("sin target guardado la recurrencia debe autodesactivarse")
+	}
+}
+
+func TestRunRecurrenceShotLaunchesOwutWhenOutdated(t *testing.T) {
+	s, rid, pool := makeRecServer(t, "25.12.5")
+	if err := s.firmware.SetTarget(firmware.Target{
+		RouterID: rid, Model: "x", CurrentVersion: "25.12.5",
+		TargetVersion: "25.12.7", TargetURL: "",
+	}); err != nil {
+		t.Fatalf("target: %v", err)
+	}
+	if err := firmware.SaveRecurrence(s.db.DB, rid, firmware.Recurrence{
+		Enabled: true, Kind: firmware.RecurrenceWeekly, DayOfWeek: func() *int { v := 2; return &v }(), Time: "00:00",
+	}); err != nil {
+		t.Fatalf("recurrence: %v", err)
+	}
+
+	s.runRecurrenceShot(rid)
+
+	// El upgrade corre en goroutine: esperar a que el comando llegue al fake.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if pool.saw("owut upgrade -q -V '25.12.7'") {
+			if got := firmware.LoadRecurrence(s.db.DB, rid).LastRunMs; got == 0 {
+				t.Fatalf("lastRun debe quedar marcado tras el disparo")
+			}
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("desfasado debe lanzar owut upgrade -V 25.12.7: %v", pool.cmds)
+}

--- a/server-go/internal/httpapi/firmware_owut_internal_test.go
+++ b/server-go/internal/httpapi/firmware_owut_internal_test.go
@@ -29,7 +29,7 @@ func (f *recFakeSSH) Run(host, cmd string, _ time.Duration) (string, error) {
 	defer f.mu.Unlock()
 	f.cmds = append(f.cmds, cmd)
 	if strings.Contains(cmd, "command -v owut") {
-		return "/usr/bin/owut\n", nil
+		return "__owut__\n", nil
 	}
 	if strings.Contains(cmd, "owut upgrade") {
 		return "There are no changes to upgrade\n__owut_exit__=0\n", nil

--- a/server-go/internal/httpapi/firmware_owut_test.go
+++ b/server-go/internal/httpapi/firmware_owut_test.go
@@ -289,3 +289,21 @@ func TestOwutEndpointsBlockedForVendorFirmware(t *testing.T) {
 		t.Fatalf("vendor no debe sondear versiones ASU: %v", ssh.cmdsSnapshot())
 	}
 }
+
+func TestTargetSaveWithoutURL(t *testing.T) {
+	// #761: con owut la imagen la construye ASU; el target se guarda sin URL.
+	ts, rid := makeOwutTestServer(t, nil)
+	_, cookie, _ := loginCookie(t, ts.URL, "admin", "test123456")
+	res := postJSON(t, ts.URL, "/api/firmware-upgrades/"+rid+"/target",
+		`{"model":"redmi_ax6","currentVersion":"25.12.5","targetVersion":"25.12.5"}`, cookie)
+	if res.StatusCode != 200 {
+		t.Fatalf("guardar sin targetUrl: %d %v", res.StatusCode, readJSON(t, res))
+	}
+	res = getJSONPath(t, ts.URL, "/api/firmware-upgrades", cookie)
+	for _, it := range readJSONArray(t, res) {
+		m, _ := it.(map[string]any)
+		if m["routerId"] == rid && m["targetVersion"] != "25.12.5" {
+			t.Fatalf("target no persistió: %v", m)
+		}
+	}
+}

--- a/server-go/internal/httpapi/firmware_owut_test.go
+++ b/server-go/internal/httpapi/firmware_owut_test.go
@@ -57,7 +57,7 @@ func deleteJSONPath(t *testing.T, base, path, cookie string) *http.Response {
 
 func TestOwutVersionsEndpoint(t *testing.T) {
 	ssh := &scriptedSSH{rules: []sshRule{
-		{contains: "command -v owut", out: "/usr/bin/owut\n"},
+		{contains: "command -v owut", out: "__owut__\n"},
 		{contains: "owut versions", out: owutVersionsSample},
 	}}
 	ts, rid := makeOwutTestServer(t, ssh)
@@ -255,5 +255,35 @@ func TestRecurrencePutGetDelete(t *testing.T) {
 	rc, _ = body["recurrence"].(map[string]any)
 	if rc["enabled"] != false {
 		t.Fatalf("tras DELETE debe quedar disabled: %v", body)
+	}
+}
+
+func TestOwutEndpointsBlockedForVendorFirmware(t *testing.T) {
+	// GL.iNet: la plataforma devuelve __gl__ -> install y upgrade 422, y el
+	// listado de versiones llega con vendorFirmware y sin sondear ASU.
+	ssh := &scriptedSSH{rules: []sshRule{
+		{contains: "fw.gl-inet.com", out: "__gl__\n"},
+	}}
+	ts, rid := makeOwutTestServer(t, ssh)
+	_, cookie, _ := loginCookie(t, ts.URL, "admin", "test123456")
+
+	res := postJSON(t, ts.URL, "/api/firmware-upgrades/"+rid+"/owut-install", "{}", cookie)
+	if res.StatusCode != 422 {
+		t.Fatalf("install status %d, esperaba 422 vendor_firmware", res.StatusCode)
+	}
+	res = postJSON(t, ts.URL, "/api/firmware-upgrades/"+rid+"/owut-upgrade", `{"targetVersion":"25.12.7"}`, cookie)
+	if res.StatusCode != 422 {
+		t.Fatalf("upgrade status %d, esperaba 422 vendor_firmware", res.StatusCode)
+	}
+	res = getJSONPath(t, ts.URL, "/api/firmware-upgrades/"+rid+"/owut-versions", cookie)
+	body := readJSON(t, res)
+	if body["vendorFirmware"] != "gl-inet" {
+		t.Fatalf("vendorFirmware: %v", body["vendorFirmware"])
+	}
+	if versions, _ := body["versions"].([]any); len(versions) != 0 {
+		t.Fatalf("vendor no debe listar versiones: %v", versions)
+	}
+	if ssh.saw("owut versions") {
+		t.Fatalf("vendor no debe sondear versiones ASU: %v", ssh.cmdsSnapshot())
 	}
 }

--- a/server-go/internal/httpapi/firmware_owut_test.go
+++ b/server-go/internal/httpapi/firmware_owut_test.go
@@ -157,6 +157,7 @@ func waitForUpgradeStatus(t *testing.T, ts *testServer, rid, want, cookie string
 
 func TestOwutUpgradeEndpointNoChanges(t *testing.T) {
 	ssh := &scriptedSSH{rules: []sshRule{
+		{contains: "command -v owut", out: "__owut__\n"},
 		{contains: "owut upgrade", out: "There are no changes to upgrade (see '--force')\n__owut_exit__=0\n"},
 	}}
 	ts, rid := makeOwutTestServer(t, ssh)
@@ -181,6 +182,7 @@ func TestOwutUpgradeEndpointNoChanges(t *testing.T) {
 
 func TestOwutUpgradeEndpointFailure(t *testing.T) {
 	ssh := &scriptedSSH{rules: []sshRule{
+		{contains: "command -v owut", out: "__owut__\n"},
 		{contains: "owut upgrade", out: "Update checks reveal errors, can't proceed\n__owut_exit__=1\n"},
 	}}
 	ts, rid := makeOwutTestServer(t, ssh)

--- a/server-go/internal/httpapi/firmware_owut_test.go
+++ b/server-go/internal/httpapi/firmware_owut_test.go
@@ -1,0 +1,259 @@
+// firmware_owut_test.go - contrato HTTP del ciclo owut completo (#761):
+// lista de versiones, instalación, upgrade desatendido y recurrencia.
+package httpapi_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// owutVersionsSample replica `owut versions` (salida real recortada).
+const owutVersionsSample = `Available 'version-to' values from https://sysupgrade.openwrt.org:
+  24.10 release branch
+    24.10.0
+    24.10.2 (latest)
+  25.12 release branch
+    25.12.5
+    25.12.7 (latest)
+`
+
+func reqJSON(t *testing.T, method, base, path, payload, cookie string) *http.Response {
+	t.Helper()
+	var body io.Reader
+	if payload != "" {
+		body = bytes.NewBufferString(payload)
+	}
+	req, err := http.NewRequest(method, base+path, body)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if cookie != "" {
+		req.Header.Set("Cookie", "session="+cookie)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	return res
+}
+
+func getJSONPath(t *testing.T, base, path, cookie string) *http.Response {
+	return reqJSON(t, http.MethodGet, base, path, "", cookie)
+}
+
+func putJSONPath(t *testing.T, base, path, payload, cookie string) *http.Response {
+	return reqJSON(t, http.MethodPut, base, path, payload, cookie)
+}
+
+func deleteJSONPath(t *testing.T, base, path, cookie string) *http.Response {
+	return reqJSON(t, http.MethodDelete, base, path, "", cookie)
+}
+
+func TestOwutVersionsEndpoint(t *testing.T) {
+	ssh := &scriptedSSH{rules: []sshRule{
+		{contains: "command -v owut", out: "/usr/bin/owut\n"},
+		{contains: "owut versions", out: owutVersionsSample},
+	}}
+	ts, rid := makeOwutTestServer(t, ssh)
+	_, cookie, _ := loginCookie(t, ts.URL, "admin", "test123456")
+
+	res := getJSONPath(t, ts.URL, "/api/firmware-upgrades/"+rid+"/owut-versions", cookie)
+	body := readJSON(t, res)
+	if res.StatusCode != 200 {
+		t.Fatalf("status %d: %v", res.StatusCode, body)
+	}
+	if body["owutAvailable"] != true {
+		t.Fatalf("owutAvailable: %v", body["owutAvailable"])
+	}
+	versions, _ := body["versions"].([]any)
+	if len(versions) != 4 {
+		t.Fatalf("esperaba 4 versiones, got %v", versions)
+	}
+}
+
+func TestOwutVersionsEndpointWithoutOwut(t *testing.T) {
+	ssh := &scriptedSSH{rules: []sshRule{
+		{contains: "command -v owut", out: "\n"}, // PATH sin owut
+	}}
+	ts, rid := makeOwutTestServer(t, ssh)
+	_, cookie, _ := loginCookie(t, ts.URL, "admin", "test123456")
+
+	res := getJSONPath(t, ts.URL, "/api/firmware-upgrades/"+rid+"/owut-versions", cookie)
+	body := readJSON(t, res)
+	if res.StatusCode != 200 {
+		t.Fatalf("status %d: %v", res.StatusCode, body)
+	}
+	if body["owutAvailable"] != false {
+		t.Fatalf("owutAvailable: %v", body["owutAvailable"])
+	}
+	if versions, _ := body["versions"].([]any); len(versions) != 0 {
+		t.Fatalf("sin owut no hay versiones: %v", versions)
+	}
+	if ssh.saw("owut versions") {
+		t.Fatalf("no debe lanzarse owut versions sin owut: %v", ssh.cmdsSnapshot())
+	}
+}
+
+func TestOwutInstallEndpoint(t *testing.T) {
+	ssh := &scriptedSSH{rules: []sshRule{
+		{contains: "apk add owut", out: "OK: 1 installed\n__owut_exit__=0\n"},
+	}}
+	ts, rid := makeOwutTestServer(t, ssh)
+	_, cookie, _ := loginCookie(t, ts.URL, "admin", "test123456")
+
+	res := postJSON(t, ts.URL, "/api/firmware-upgrades/"+rid+"/owut-install", "{}", cookie)
+	body := readJSON(t, res)
+	if res.StatusCode != 200 {
+		t.Fatalf("status %d: %v", res.StatusCode, body)
+	}
+	if body["ok"] != true {
+		t.Fatalf("ok: %v", body)
+	}
+	if !ssh.saw("apk add owut") {
+		t.Fatalf("no se lanzó la instalación: %v", ssh.cmdsSnapshot())
+	}
+}
+
+func TestOwutInstallEndpointNoPackageManager(t *testing.T) {
+	ssh := &scriptedSSH{rules: []sshRule{
+		{contains: "apk update", out: "__no_pm__\n__owut_exit__=0\n"},
+	}}
+	ts, rid := makeOwutTestServer(t, ssh)
+	_, cookie, _ := loginCookie(t, ts.URL, "admin", "test123456")
+
+	res := postJSON(t, ts.URL, "/api/firmware-upgrades/"+rid+"/owut-install", "{}", cookie)
+	if res.StatusCode != 500 {
+		t.Fatalf("status %d, esperaba 500", res.StatusCode)
+	}
+}
+
+// waitForUpgradeStatus polea la lista hasta que el upgrade llegue al estado
+// terminal (la goroutine del server corre en background).
+func waitForUpgradeStatus(t *testing.T, ts *testServer, rid, want, cookie string) map[string]any {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		res := getJSONPath(t, ts.URL, "/api/firmware-upgrades", cookie)
+		for _, it := range readJSONArray(t, res) {
+			m, _ := it.(map[string]any)
+			if m["routerId"] != rid {
+				continue
+			}
+			if up, ok := m["upgrade"].(map[string]any); ok && up["status"] == want {
+				return up
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("el upgrade no llegó a %s", want)
+	return nil
+}
+
+func TestOwutUpgradeEndpointNoChanges(t *testing.T) {
+	ssh := &scriptedSSH{rules: []sshRule{
+		{contains: "owut upgrade", out: "There are no changes to upgrade (see '--force')\n__owut_exit__=0\n"},
+	}}
+	ts, rid := makeOwutTestServer(t, ssh)
+	_, cookie, _ := loginCookie(t, ts.URL, "admin", "test123456")
+
+	res := postJSON(t, ts.URL, "/api/firmware-upgrades/"+rid+"/owut-upgrade", `{"targetVersion":"25.12.7"}`, cookie)
+	body := readJSON(t, res)
+	if res.StatusCode != 202 {
+		t.Fatalf("status %d: %v", res.StatusCode, body)
+	}
+	if body["engine"] != "owut" {
+		t.Fatalf("engine: %v", body["engine"])
+	}
+	up := waitForUpgradeStatus(t, ts, rid, "done", cookie)
+	if up["engine"] != "owut" {
+		t.Fatalf("engine del upgrade: %v", up["engine"])
+	}
+	if !ssh.saw("owut upgrade -q") {
+		t.Fatalf("comando lanzado: %v", ssh.cmdsSnapshot())
+	}
+}
+
+func TestOwutUpgradeEndpointFailure(t *testing.T) {
+	ssh := &scriptedSSH{rules: []sshRule{
+		{contains: "owut upgrade", out: "Update checks reveal errors, can't proceed\n__owut_exit__=1\n"},
+	}}
+	ts, rid := makeOwutTestServer(t, ssh)
+	_, cookie, _ := loginCookie(t, ts.URL, "admin", "test123456")
+
+	res := postJSON(t, ts.URL, "/api/firmware-upgrades/"+rid+"/owut-upgrade", `{"targetVersion":"25.12.7"}`, cookie)
+	if res.StatusCode != 202 {
+		t.Fatalf("status %d", res.StatusCode)
+	}
+	up := waitForUpgradeStatus(t, ts, rid, "failed", cookie)
+	if msg, _ := up["error"].(string); !strings.Contains(msg, "can't proceed") {
+		t.Fatalf("error del upgrade: %v", up["error"])
+	}
+}
+
+func TestOwutUpgradeRequiresTarget(t *testing.T) {
+	ts, rid := makeOwutTestServer(t, nil)
+	_, cookie, _ := loginCookie(t, ts.URL, "admin", "test123456")
+	res := postJSON(t, ts.URL, "/api/firmware-upgrades/"+rid+"/owut-upgrade", `{}`, cookie)
+	if res.StatusCode != 400 {
+		t.Fatalf("status %d, esperaba 400 sin targetVersion", res.StatusCode)
+	}
+}
+
+func TestRecurrencePutGetDelete(t *testing.T) {
+	ts, rid := makeOwutTestServer(t, nil)
+	_, cookie, _ := loginCookie(t, ts.URL, "admin", "test123456")
+
+	// weekly válido.
+	res := putJSONPath(t, ts.URL, "/api/firmware-upgrades/"+rid+"/recurrence",
+		`{"enabled":true,"kind":"weekly","dayOfWeek":5,"time":"04:00"}`, cookie)
+	if res.StatusCode != 200 {
+		t.Fatalf("PUT weekly: %d %v", res.StatusCode, readJSON(t, res))
+	}
+	res = getJSONPath(t, ts.URL, "/api/firmware-upgrades/"+rid+"/recurrence", cookie)
+	body := readJSON(t, res)
+	rc, _ := body["recurrence"].(map[string]any)
+	if rc["kind"] != "weekly" || rc["enabled"] != true {
+		t.Fatalf("GET recurrence: %v", body)
+	}
+	if _, ok := body["nextRunMs"]; !ok {
+		t.Fatalf("GET recurrence debe traer nextRunMs: %v", body)
+	}
+
+	// weekly sin time: 400.
+	res = putJSONPath(t, ts.URL, "/api/firmware-upgrades/"+rid+"/recurrence",
+		`{"enabled":true,"kind":"weekly","dayOfWeek":5}`, cookie)
+	if res.StatusCode != 400 {
+		t.Fatalf("PUT inválido: %d, esperaba 400", res.StatusCode)
+	}
+
+	// monthly y once válidos.
+	res = putJSONPath(t, ts.URL, "/api/firmware-upgrades/"+rid+"/recurrence",
+		`{"enabled":true,"kind":"monthly","dayOfMonth":1,"time":"05:30"}`, cookie)
+	if res.StatusCode != 200 {
+		t.Fatalf("PUT monthly: %d", res.StatusCode)
+	}
+	future := time.Now().Add(48 * time.Hour).UnixMilli()
+	res = putJSONPath(t, ts.URL, "/api/firmware-upgrades/"+rid+"/recurrence",
+		fmt.Sprintf(`{"enabled":true,"kind":"once","atMs":%d}`, future), cookie)
+	if res.StatusCode != 200 {
+		t.Fatalf("PUT once: %d", res.StatusCode)
+	}
+
+	// DELETE desactiva.
+	res = deleteJSONPath(t, ts.URL, "/api/firmware-upgrades/"+rid+"/recurrence", cookie)
+	if res.StatusCode != 200 {
+		t.Fatalf("DELETE: %d", res.StatusCode)
+	}
+	res = getJSONPath(t, ts.URL, "/api/firmware-upgrades/"+rid+"/recurrence", cookie)
+	body = readJSON(t, res)
+	rc, _ = body["recurrence"].(map[string]any)
+	if rc["enabled"] != false {
+		t.Fatalf("tras DELETE debe quedar disabled: %v", body)
+	}
+}

--- a/server-go/internal/httpapi/firmware_owut_test.go
+++ b/server-go/internal/httpapi/firmware_owut_test.go
@@ -178,6 +178,10 @@ func TestOwutUpgradeEndpointNoChanges(t *testing.T) {
 	if !ssh.saw("owut upgrade -q") {
 		t.Fatalf("comando lanzado: %v", ssh.cmdsSnapshot())
 	}
+	// #761: antes de flashear se preserva el stack en /etc/sysupgrade.conf.
+	if !ssh.saw("/etc/sysupgrade.conf") {
+		t.Fatalf("preserve-stack no se ejecutó: %v", ssh.cmdsSnapshot())
+	}
 }
 
 func TestOwutUpgradeEndpointFailure(t *testing.T) {

--- a/server-go/internal/httpapi/owut_test.go
+++ b/server-go/internal/httpapi/owut_test.go
@@ -80,7 +80,7 @@ func makeOwutTestServer(t *testing.T, ssh *scriptedSSH) (*testServer, string) {
 
 func TestOwutCheckUpgradeAvailable(t *testing.T) {
 	ssh := &scriptedSSH{rules: []sshRule{
-		{contains: "command -v owut", out: "/usr/bin/owut\n"},
+		{contains: "command -v owut", out: "__owut__\n"},
 		{contains: "owut check", out: owutCheckOKOut},
 	}}
 	ts, rid := makeOwutTestServer(t, ssh)

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/gnacho/netpulse/server-go/internal/adapters"
+	"github.com/gnacho/netpulse/server-go/internal/alerts"
 	"github.com/gnacho/netpulse/server-go/internal/apitoken"
 	"github.com/gnacho/netpulse/server-go/internal/auth"
 	"github.com/gnacho/netpulse/server-go/internal/baselines"
@@ -116,6 +117,11 @@ type Deps struct {
 	FirmwareImage *firmware.ImageResolver
 	// Speedtest: scheduler del test periódico WAN (#511). nil → 503.
 	Speedtest *speedtest.Scheduler
+	// AlertEmitter: motor de alertas para los resultados de firmware owut
+	// (#761). nil → sin alertas de resultado (p. ej. en tests).
+	AlertEmitter interface {
+		Emit(ev alerts.AlertEvent) bool
+	}
 }
 
 type server struct {
@@ -159,6 +165,17 @@ type server struct {
 	// Backups automáticos (#741): mutex single-flight entre el run manual
 	// (POST /api/backup/run) y el scheduler periódico.
 	backupMu sync.Mutex
+
+	// Firmware owut (#761): emisor de alertas de resultado (lo inyecta main
+	// tras construir el adapter), cache de detección de owut por router y
+	// single-flight de los disparos recurrentes.
+	alertEmitter alertEmitter
+	owutMu       sync.Mutex
+	owutCache    map[string]owutDetectCacheEntry
+	recMu        sync.Mutex
+	recInFlight  map[string]bool
+	// boardVersionFn: versión instalada según board info (hook de test).
+	boardVersionFn func(routerID string) string
 
 	// Avisos externos (announcements.json del repo): caché del último
 	// fetch; nil si el refresco no está activo.
@@ -232,9 +249,13 @@ func NewHandler(d Deps) http.Handler {
 		firmwareEngine:  firmware.NewEngine(d.Firmware, d.AgentHub),
 		imageResolver:   d.FirmwareImage,
 		speedtest:       d.Speedtest,
+		alertEmitter:    d.AlertEmitter,
 	}
 	if s.imageResolver == nil {
 		s.imageResolver = firmware.NewImageResolver()
+	}
+	if s.boardVersionFn == nil {
+		s.boardVersionFn = s.detectedFirmwareVersion
 	}
 	// Rearmer compartido entre el endpoint manual y el supervisor de
 	// auto-rearme (cmd/netpulse lo construye y lo pasa para que ambos
@@ -465,6 +486,9 @@ func NewHandler(d Deps) http.Handler {
 	// auto-updates no resetean el reloj. Solo en live (en demo no hay datos).
 	if s.cfg == nil || !s.cfg.DemoMode {
 		go s.backupLoop(context.Background(), backupTickEvery)
+		// Recurrencia de firmware (#761): mismo contrato reboot-safe; el
+		// disparo es idempotente (al día = no-op) y notifica el resultado.
+		go s.firmwareRecurrenceLoop(context.Background(), recTickEvery)
 	}
 
 	// --- Overrides manuales de topología (issue #142; solo admin) ---

--- a/server-go/internal/httpapi/server.go
+++ b/server-go/internal/httpapi/server.go
@@ -171,7 +171,7 @@ type server struct {
 	// single-flight de los disparos recurrentes.
 	alertEmitter alertEmitter
 	owutMu       sync.Mutex
-	owutCache    map[string]owutDetectCacheEntry
+	owutCache    map[string]platformCacheEntry
 	recMu        sync.Mutex
 	recInFlight  map[string]bool
 	// boardVersionFn: versión instalada según board info (hook de test).


### PR DESCRIPTION
Closes #761

## What

Reworks the Firmware upgrades page around attended sysupgrade (owut/ASU) as the primary engine, with the manual URL+checksum engine kept as the advanced path.

- Read-only detected model and current version (board info via agent or SSH fallback); free-text inputs are gone.
- Target version dropdown built from `owut versions` on the router (stable releases only, rc/snapshot/branch-SNAPSHOT filtered), current version preselected, major-jump warning inline.
- Image URL and checksum collapsed under Advanced; saving a target no longer requires a URL (ASU builds the image).
- owut installable from the UI (apk/opkg detected); "Check" renamed from "Check with owut" and moved into the same action row as Save / Upgrade now / Schedule.
- Upgrade now runs `owut upgrade` unattended (verified non-interactive in owut's ucode source): state machine running -> rebooting (SSH death at flash time is expected) -> done/failed, final confirmation by board info version, 15 min grace. Result alerts (urgent, info/warn) flow through the existing notifier chain: feed, push, webhook, Telegram.
- Check output parsed for packages missing from official feeds (`owut check -v`): banner names them, and the exclusion field pre-fills so the upgrade can proceed; own-stack packages (netgrip, agent) are preserved by ensuring their files are in /etc/sysupgrade.conf before flashing.
- Schedule dialog: once / weekly (Monday-first) / monthly, reboot-safe due times derived from persisted last-run, idempotent by contract (an up-to-date router is a silent no-op), auto-disables with an alert on invalid config.
- Vendor firmware guard: routers whose repositories point at fw.gl-inet.com (GL.iNet) are detected and blocked from the owut flow (422) with an informative panel; their upgrades belong to the vendor's own UI. The openwrt_release of GL builds is identical to vanilla, repositories are the reliable signal.
- In-progress view: while an upgrade runs the card becomes the process itself (large animated icon, phase, time-based progress bar with a 1s local ticker, console-style log lines). Completed upgrades show a celebration view and stale check banners are auto-cleared.
- targetVersion validated as a real OpenWrt version server-side (free text produced meaningless upgrades), dropdown filters invalid saved targets, failures always surface a message plus server log.

## Validation

- Full httpapi and firmware suites green; frontend tsc/build/lint clean (pre-existing warnings untouched).
- Validated end to end on a live 4-router fleet: three real owut upgrades completed (done in ~2-3 min each, routers rebooted and came back, agents survived via sysupgrade.conf preservation, Telegram result alerts received), vendor router blocked with 422, versions endpoint returns the real ASU catalog.