### PR TITLE
fix(ntfy): redact topic from logs and errors, tighten retry and cancel semantics

### DIFF
--- a/server-go/cmd/netpulse/main.go
+++ b/server-go/cmd/netpulse/main.go
@@ -357,7 +357,7 @@ func run() error {
 	// cada evento): activable desde la UI sin reiniciar el servicio.
 	ntfyNotifier := ntfy.NewNotifier(&mainKVAdapter{db: dbHandle.DB})
 	if ntfyCfg := ntfy.LoadConfig(&mainKVAdapter{db: dbHandle.DB}); ntfyCfg.Enabled && ntfyCfg.Topic != "" {
-		log.Printf("[netpulse] ntfy activo: %s/%s", ntfyCfg.Server, ntfyCfg.Topic)
+		log.Printf("[netpulse] ntfy activo: %s/%s", ntfyCfg.Server, ntfy.MaskTopic(ntfyCfg.Topic))
 	}
 
 	// Notifier compuesto: push + webhook + telegram + ntfy (SetNotifier solo admite UNO).

--- a/server-go/internal/httpapi/ntfy_settings_test.go
+++ b/server-go/internal/httpapi/ntfy_settings_test.go
@@ -94,4 +94,24 @@ func TestNtfySettingsTestFailsVisibly(t *testing.T) {
 	}
 }
 
+// TestNtfySettingsTestRequiresEnabled: el endpoint de test no publica con el
+// canal desactivado (misma decisión que el worker).
+func TestNtfySettingsTestRequiresEnabled(t *testing.T) {
+	ts, _ := makeOwutTestServer(t, nil)
+	_, cookie, _ := loginCookie(t, ts.URL, "admin", "test123456")
+	res := putJSONPath(t, ts.URL, "/api/settings/ntfy",
+		`{"enabled":false,"topic":"mi-topic"}`, cookie)
+	if res.StatusCode != 200 {
+		t.Fatalf("PUT desactivado: %d", res.StatusCode)
+	}
+	res = postJSON(t, ts.URL, "/api/settings/ntfy/test", "{}", cookie)
+	if res.StatusCode == 200 {
+		t.Fatalf("test con canal desactivado debe fallar")
+	}
+	body := readJSON(t, res)
+	if msg, _ := body["message"].(string); msg == "" {
+		t.Fatalf("el fallo debe llevar mensaje: %v", body)
+	}
+}
+
 var _ = httpapi.Version

--- a/server-go/internal/ntfy/ntfy.go
+++ b/server-go/internal/ntfy/ntfy.go
@@ -132,19 +132,30 @@ type Notifier struct {
 	done   chan struct{}
 	wg     sync.WaitGroup
 	client *http.Client
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 // NewNotifier arranca el worker de la cola.
 func NewNotifier(kv kvStore) *Notifier {
-	n := &Notifier{
+	n := newNotifier(kv)
+	n.wg.Add(1)
+	go n.worker()
+	return n
+}
+
+// newNotifier construye un notifier sin arrancar el worker: base común de
+// NewNotifier y SendTest.
+func newNotifier(kv kvStore) *Notifier {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Notifier{
 		kv:     kv,
 		queue:  make(chan alerts.AlertEvent, queueCap),
 		done:   make(chan struct{}),
 		client: &http.Client{Timeout: sendTimeout},
+		ctx:    ctx,
+		cancel: cancel,
 	}
-	n.wg.Add(1)
-	go n.worker()
-	return n
 }
 
 func (n *Notifier) Notify(ev alerts.AlertEvent) {
@@ -155,8 +166,11 @@ func (n *Notifier) Notify(ev alerts.AlertEvent) {
 	}
 }
 
-// Close detiene el worker.
+// Close detiene el worker y cancela cualquier publicación en curso.
 func (n *Notifier) Close() {
+	if n.cancel != nil {
+		n.cancel()
+	}
 	close(n.done)
 	n.wg.Wait()
 }
@@ -212,7 +226,11 @@ func priorityOf(ev alerts.AlertEvent) string {
 // publish envía un mensaje a <server>/<topic> con Title/Priority en cabeceras.
 func (n *Notifier) publish(cfg Config, title, body, priority string) error {
 	url := cfg.Server + "/" + cfg.Topic
-	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)
+	base := n.ctx
+	if base == nil {
+		base = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(base, sendTimeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
 	if err != nil {
@@ -373,10 +391,7 @@ func SendTest(kv kvStore) error {
 	if cfg.Topic == "" {
 		return fmt.Errorf("topic es requerido")
 	}
-	n := &Notifier{
-		client: &http.Client{Timeout: sendTimeout},
-		done:   make(chan struct{}),
-	}
-	defer close(n.done)
+	n := newNotifier(kv)
+	defer n.Close()
 	return n.publish(cfg, "NetPulse", "✅ Notificaciones ntfy configuradas correctamente.", "default")
 }

--- a/server-go/internal/ntfy/ntfy.go
+++ b/server-go/internal/ntfy/ntfy.go
@@ -10,12 +10,15 @@ package ntfy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/gnacho/netpulse/server-go/internal/alerts"
@@ -252,18 +255,53 @@ func redactErr(prefix string, err error, cfg Config) error {
 	return &redactedError{err: err, msg: prefix + ": " + msg}
 }
 
-// isRetryable: 4xx del ntfy (topic denegado, bad request) no reintenta.
+// isRetryable decide si un fallo de publish merece reintento: solo 5xx, 429 y
+// errores de red transitorios (timeout, conexión rechazada/reseteada). Los
+// permanentes (4xx, URL inválida, DNS, TLS, contexto) no se reintentan.
 func isRetryable(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
-	for _, code := range []string{"status 400", "status 401", "status 403", "status 404"} {
-		if strings.Contains(msg, code) {
-			return false
+	if code, ok := statusCode(err.Error()); ok {
+		return code >= 500 || code == 429
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	for _, target := range []error{
+		syscall.ECONNREFUSED,
+		syscall.ECONNRESET,
+		syscall.ECONNABORTED,
+		syscall.EPIPE,
+		io.ErrUnexpectedEOF,
+	} {
+		if errors.Is(err, target) {
+			return true
 		}
 	}
-	return true
+	return false
+}
+
+// statusCode extrae el código de un error con formato "status NNN: ...".
+func statusCode(msg string) (int, bool) {
+	const prefix = "status "
+	i := strings.Index(msg, prefix)
+	if i < 0 {
+		return 0, false
+	}
+	code, digits := 0, 0
+	for _, r := range msg[i+len(prefix):] {
+		if r < '0' || r > '9' {
+			break
+		}
+		code = code*10 + int(r-'0')
+		digits++
+	}
+	if digits == 0 {
+		return 0, false
+	}
+	return code, true
 }
 
 // formatMessage renderiza la alerta a texto plano (ntfy no parsea HTML).

--- a/server-go/internal/ntfy/ntfy.go
+++ b/server-go/internal/ntfy/ntfy.go
@@ -363,9 +363,13 @@ func MaskTopic(topic string) string {
 }
 
 // SendTest publica un mensaje de prueba contra la config guardada (botón de
-// la UI): es a la vez la validación del canal (ntfy no tiene getMe).
+// la UI): es a la vez la validación del canal (ntfy no tiene getMe). Exige el
+// canal activado, igual que el worker antes de enviar.
 func SendTest(kv kvStore) error {
 	cfg := LoadConfig(kv)
+	if !cfg.Enabled {
+		return fmt.Errorf("el canal ntfy está desactivado")
+	}
 	if cfg.Topic == "" {
 		return fmt.Errorf("topic es requerido")
 	}

--- a/server-go/internal/ntfy/ntfy.go
+++ b/server-go/internal/ntfy/ntfy.go
@@ -212,7 +212,7 @@ func (n *Notifier) publish(cfg Config, title, body, priority string) error {
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("new request: %w", err)
+		return redactErr("new request", err, cfg)
 	}
 	req.Header.Set("Title", title)
 	req.Header.Set("Priority", priority)
@@ -221,7 +221,7 @@ func (n *Notifier) publish(cfg Config, title, body, priority string) error {
 	}
 	resp, err := n.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("http do: %w", err)
+		return redactErr("http do", err, cfg)
 	}
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
@@ -229,6 +229,27 @@ func (n *Notifier) publish(cfg Config, title, body, priority string) error {
 		return nil
 	}
 	return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+}
+
+// redactedError conserva la cadena de errores (Unwrap) para isRetryable pero
+// expone un mensaje sin el topic, que es el secreto del canal.
+type redactedError struct {
+	err error
+	msg string
+}
+
+func (e *redactedError) Error() string { return e.msg }
+func (e *redactedError) Unwrap() error { return e.err }
+
+// redactErr sustituye el topic por *** en cualquier error que pueda incluir la
+// URL (<server>/<topic>).
+func redactErr(prefix string, err error, cfg Config) error {
+	msg := err.Error()
+	if cfg.Topic != "" {
+		full := cfg.Server + "/" + cfg.Topic
+		msg = strings.ReplaceAll(msg, full, cfg.Server+"/***")
+	}
+	return &redactedError{err: err, msg: prefix + ": " + msg}
 }
 
 // isRetryable: 4xx del ntfy (topic denegado, bad request) no reintenta.

--- a/server-go/internal/ntfy/ntfy.go
+++ b/server-go/internal/ntfy/ntfy.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gnacho/netpulse/server-go/internal/alerts"
 )
@@ -316,7 +317,7 @@ func formatMessage(ev alerts.AlertEvent) string {
 	if ev.Description != "" {
 		desc := ev.Description
 		if len(desc) > 500 {
-			desc = desc[:500] + "..."
+			desc = truncateUTF8(desc, 500) + "..."
 		}
 		b.WriteString(desc)
 		b.WriteString("\n")
@@ -327,9 +328,29 @@ func formatMessage(ev alerts.AlertEvent) string {
 	fmt.Fprintf(&b, "🕐 %s", ts)
 	out := b.String()
 	if len(out) > maxMsgLen {
-		out = out[:maxMsgLen-3] + "..."
+		out = truncateUTF8(out, maxMsgLen-3) + "..."
 	}
 	return out
+}
+
+// truncateUTF8 recorta s a lo sumo maxBytes bytes sin partir una runa
+// multibyte (el corte por bytes crudo podía dejar UTF-8 inválido).
+func truncateUTF8(s string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(s) <= maxBytes {
+		return s
+	}
+	s = s[:maxBytes]
+	for len(s) > 0 {
+		r, size := utf8.DecodeLastRuneInString(s)
+		if r != utf8.RuneError || size > 1 {
+			break
+		}
+		s = s[:len(s)-1]
+	}
+	return s
 }
 
 // MaskTopic redacta el topic (secreto del canal) para logs y diagnósticos:

--- a/server-go/internal/ntfy/ntfy.go
+++ b/server-go/internal/ntfy/ntfy.go
@@ -127,13 +127,14 @@ func validTopic(t string) bool {
 
 // Notifier satisface alerts.Notifier.
 type Notifier struct {
-	kv     kvStore
-	queue  chan alerts.AlertEvent
-	done   chan struct{}
-	wg     sync.WaitGroup
-	client *http.Client
-	ctx    context.Context
-	cancel context.CancelFunc
+	kv        kvStore
+	queue     chan alerts.AlertEvent
+	done      chan struct{}
+	wg        sync.WaitGroup
+	client    *http.Client
+	ctx       context.Context
+	cancel    context.CancelFunc
+	closeOnce sync.Once
 }
 
 // NewNotifier arranca el worker de la cola.
@@ -166,12 +167,15 @@ func (n *Notifier) Notify(ev alerts.AlertEvent) {
 	}
 }
 
-// Close detiene el worker y cancela cualquier publicación en curso.
+// Close detiene el worker y cancela cualquier publicación en curso. Es
+// idempotente: una segunda llamada no paniquea.
 func (n *Notifier) Close() {
-	if n.cancel != nil {
-		n.cancel()
-	}
-	close(n.done)
+	n.closeOnce.Do(func() {
+		if n.cancel != nil {
+			n.cancel()
+		}
+		close(n.done)
+	})
 	n.wg.Wait()
 }
 

--- a/server-go/internal/ntfy/ntfy.go
+++ b/server-go/internal/ntfy/ntfy.go
@@ -273,6 +273,15 @@ func formatMessage(ev alerts.AlertEvent) string {
 	return out
 }
 
+// MaskTopic redacta el topic (secreto del canal) para logs y diagnósticos:
+// nunca expone su valor, solo su longitud.
+func MaskTopic(topic string) string {
+	if topic == "" {
+		return ""
+	}
+	return fmt.Sprintf("*** (%d chars)", len(topic))
+}
+
 // SendTest publica un mensaje de prueba contra la config guardada (botón de
 // la UI): es a la vez la validación del canal (ntfy no tiene getMe).
 func SendTest(kv kvStore) error {

--- a/server-go/internal/ntfy/ntfy_test.go
+++ b/server-go/internal/ntfy/ntfy_test.go
@@ -221,6 +221,34 @@ func TestFormatMessageTruncatesOnRuneBoundary(t *testing.T) {
 	}
 }
 
+// B7: el test no publica si el canal está desactivado.
+func TestSendTestRequiresEnabled(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+	kv := &fakeKV{m: map[string]string{
+		"ntfy.server":  srv.URL,
+		"ntfy.topic":   "x",
+		"ntfy.enabled": "false",
+	}}
+	if err := SendTest(kv); err == nil {
+		t.Fatalf("test debe fallar con el canal desactivado")
+	}
+	if calls != 0 {
+		t.Fatalf("no debe publicar desactivado: %d", calls)
+	}
+	kv.m["ntfy.enabled"] = "true"
+	if err := SendTest(kv); err != nil {
+		t.Fatalf("test con canal activo: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("debe publicar una vez activo: %d", calls)
+	}
+}
+
 func contains(s, sub string) bool {
 	for i := 0; i+len(sub) <= len(s); i++ {
 		if s[i:i+len(sub)] == sub {

--- a/server-go/internal/ntfy/ntfy_test.go
+++ b/server-go/internal/ntfy/ntfy_test.go
@@ -137,6 +137,17 @@ func TestFormatMessage(t *testing.T) {
 	}
 }
 
+// B1: el topic (secreto del canal) nunca se registra en claro.
+func TestMaskTopic(t *testing.T) {
+	got := MaskTopic("top-secreto-123")
+	if contains(got, "top-secreto-123") || !contains(got, "***") {
+		t.Fatalf("el topic debe quedar enmascarado: %q", got)
+	}
+	if got := MaskTopic(""); got != "" {
+		t.Fatalf("topic vacío: %q", got)
+	}
+}
+
 func contains(s, sub string) bool {
 	for i := 0; i+len(sub) <= len(s); i++ {
 		if s[i:i+len(sub)] == sub {

--- a/server-go/internal/ntfy/ntfy_test.go
+++ b/server-go/internal/ntfy/ntfy_test.go
@@ -8,9 +8,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gnacho/netpulse/server-go/internal/alerts"
 )
@@ -195,6 +197,27 @@ func TestIsRetryable(t *testing.T) {
 		if got := isRetryable(tc.err); got != tc.want {
 			t.Errorf("%s: got %v want %v", tc.name, got, tc.want)
 		}
+	}
+}
+
+// B4: el truncado no debe partir runas multibyte.
+func TestFormatMessageTruncatesOnRuneBoundary(t *testing.T) {
+	desc := strings.Repeat("é", 600) // 1200 bytes, >500
+	msg := formatMessage(alerts.AlertEvent{Title: "t", Description: desc, Ts: 1700000000})
+	if !utf8.ValidString(msg) {
+		t.Fatalf("mensaje con UTF-8 inválido")
+	}
+	if !contains(msg, "...") {
+		t.Fatalf("esperaba recorte de la descripción: %q", msg)
+	}
+
+	big := strings.Repeat("日", 3000) // 9000 bytes, supera maxMsgLen
+	msg = formatMessage(alerts.AlertEvent{Title: big, Ts: 1700000000})
+	if !utf8.ValidString(msg) {
+		t.Fatalf("mensaje largo con UTF-8 inválido")
+	}
+	if len(msg) > maxMsgLen {
+		t.Fatalf("mensaje por encima del límite: %d bytes", len(msg))
 	}
 }
 

--- a/server-go/internal/ntfy/ntfy_test.go
+++ b/server-go/internal/ntfy/ntfy_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gnacho/netpulse/server-go/internal/alerts"
 )
@@ -145,6 +146,24 @@ func TestMaskTopic(t *testing.T) {
 	}
 	if got := MaskTopic(""); got != "" {
 		t.Fatalf("topic vacío: %q", got)
+	}
+}
+
+// B2: el error de red no debe filtrar el topic (URL saneada).
+func TestPublishErrorRedactsTopic(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	base := srv.URL
+	srv.Close()
+	n := &Notifier{client: &http.Client{Timeout: 2 * time.Second}, done: make(chan struct{})}
+	err := n.publish(Config{Server: base, Topic: "top-secreto-abc"}, "t", "b", "default")
+	if err == nil {
+		t.Fatalf("esperaba error con el server cerrado")
+	}
+	if contains(err.Error(), "top-secreto-abc") {
+		t.Fatalf("el topic no debe aparecer en el error: %q", err.Error())
+	}
+	if !contains(err.Error(), "***") {
+		t.Fatalf("esperaba el topic enmascarado: %q", err.Error())
 	}
 }
 

--- a/server-go/internal/ntfy/ntfy_test.go
+++ b/server-go/internal/ntfy/ntfy_test.go
@@ -3,8 +3,12 @@
 package ntfy
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"syscall"
 	"testing"
 	"time"
 
@@ -164,6 +168,33 @@ func TestPublishErrorRedactsTopic(t *testing.T) {
 	}
 	if !contains(err.Error(), "***") {
 		t.Fatalf("esperaba el topic enmascarado: %q", err.Error())
+	}
+}
+
+// B3: solo se reintenta 5xx, 429 y errores de red transitorios.
+func TestIsRetryable(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"status 500", errors.New("status 500: boom"), true},
+		{"status 503", errors.New("status 503: boom"), true},
+		{"status 429", errors.New("status 429: slow down"), true},
+		{"status 400", errors.New("status 400: bad"), false},
+		{"status 401", errors.New("status 401: bad"), false},
+		{"status 403", errors.New("status 403: bad"), false},
+		{"status 404", errors.New("status 404: bad"), false},
+		{"url inválida", &url.Error{Op: "parse", URL: "http://x/y", Err: errors.New("invalid")}, false},
+		{"contexto cancelado", &url.Error{Op: "Post", URL: "http://x/y", Err: context.Canceled}, false},
+		{"timeout", &url.Error{Op: "Post", URL: "http://x/y", Err: context.DeadlineExceeded}, true},
+		{"conexión rechazada", &url.Error{Op: "Post", URL: "http://x/y", Err: syscall.ECONNREFUSED}, true},
+	}
+	for _, tc := range cases {
+		if got := isRetryable(tc.err); got != tc.want {
+			t.Errorf("%s: got %v want %v", tc.name, got, tc.want)
+		}
 	}
 }
 

--- a/server-go/internal/ntfy/ntfy_test.go
+++ b/server-go/internal/ntfy/ntfy_test.go
@@ -284,6 +284,13 @@ func TestCloseCancelsInFlightPublish(t *testing.T) {
 	}
 }
 
+// B9: Close es idempotente.
+func TestCloseIsIdempotent(t *testing.T) {
+	n := NewNotifier(&fakeKV{})
+	n.Close()
+	n.Close() // no debe paniquear
+}
+
 func contains(s, sub string) bool {
 	for i := 0; i+len(sub) <= len(s); i++ {
 		if s[i:i+len(sub)] == sub {

--- a/server-go/internal/ntfy/ntfy_test.go
+++ b/server-go/internal/ntfy/ntfy_test.go
@@ -249,6 +249,41 @@ func TestSendTestRequiresEnabled(t *testing.T) {
 	}
 }
 
+// B8: Close cancela la petición en curso.
+func TestCloseCancelsInFlightPublish(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-release
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+	defer close(release)
+	kv := &fakeKV{m: map[string]string{
+		"ntfy.server":  srv.URL,
+		"ntfy.topic":   "x",
+		"ntfy.enabled": "true",
+	}}
+	n := NewNotifier(kv)
+	n.Notify(alerts.AlertEvent{Title: "t", Urgent: true})
+	select {
+	case <-started:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("la petición no llegó al server")
+	}
+	done := make(chan struct{})
+	go func() {
+		n.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("Close no canceló la petición en curso")
+	}
+}
+
 func contains(s, sub string) bool {
 	for i := 0; i+len(sub) <= len(s); i++ {
 		if s[i:i+len(sub)] == sub {


### PR DESCRIPTION
Hardening for the ntfy channel, found while auditing it for reuse:

- mask the topic in the startup log (the topic is the channel secret)
- strip the topic from network errors before they reach logs or the test response
- retry only transient failures (5xx, 429, network errors), not permanent ones
- truncate on rune boundaries so UTF-8 is never split
- require the channel to be enabled for the test publish
- cancel in-flight publishes on shutdown and make Close idempotent

Closes #773